### PR TITLE
Cluster gossip configuration, renamed env vars

### DIFF
--- a/wadm/lib/config_plan.ex
+++ b/wadm/lib/config_plan.ex
@@ -4,12 +4,17 @@ defmodule Wadm.ConfigPlan do
 
   config :nats,
          env([
-           {:api_host, "API_NATS_HOST", default: '127.0.0.1'},
-           {:api_port, "API_NATS_PORT", default: 4222},
-           {:api_tls, "API_TLS", default: "false"},
-           {:api_jwt, "API_USER_JWT", default: ""},
-           {:api_seed, "API_USER_SEED", default: ""},
-           {:api_backoff_period, "NATS_BACKOFF_PERIOD", default: 4_000}
+           {:api_host, "WADM_NATS_HOST", default: '127.0.0.1'},
+           {:api_port, "WADM_NATS_PORT", default: 4222},
+           {:api_tls, "WADM_TLS", default: "false"},
+           {:api_jwt, "WADM_USER_JWT", default: ""},
+           {:api_seed, "WADM_USER_SEED", default: ""},
+           {:api_backoff_period, "WADM_NATS_BACKOFF_PERIOD", default: 4_000}
+         ])
+
+  config :cluster,
+         env([
+           {:gossip_port, "WADM_CLUSTER_GOSSIP_PORT", default: 45892}
          ])
 
   config :redis,

--- a/wadm/lib/supervisor.ex
+++ b/wadm/lib/supervisor.ex
@@ -12,7 +12,10 @@ defmodule Wadm.Supervisor do
 
     topologies = [
       wadmcluster: [
-        strategy: Cluster.Strategy.Gossip
+        strategy: Cluster.Strategy.Gossip,
+        config: [
+          port: config.cluster.gossip_port |> parse_gossip_port()
+        ]
       ]
     ]
 
@@ -52,4 +55,10 @@ defmodule Wadm.Supervisor do
       _ -> nil
     end
   end
+
+  # Helper function to parse a port number from a string or a number
+  defp parse_gossip_port(num) when is_binary(num), do: num |> String.to_integer()
+  defp parse_gossip_port(num) when is_integer(num), do: num
+  # Fallback to default
+  defp parse_gossip_port(_num), do: 45892
 end

--- a/wadm/lib/wadm/lattice_supervisor.ex
+++ b/wadm/lib/wadm/lattice_supervisor.ex
@@ -53,6 +53,7 @@ defmodule Wadm.LatticeSupervisor do
     Logger.info("Starting lattice supervisor for #{supervised_lattice_id}")
     lattice_id = String.to_atom(supervised_lattice_id)
 
+    config = Wadm.Supervisor.get_config()
     # TODO
     # get NATS configuration and credentials from secret store based on
     # the lattice ID
@@ -60,7 +61,7 @@ defmodule Wadm.LatticeSupervisor do
       name: lattice_id,
       backoff_period: 2000,
       connection_settings: [
-        %{host: "127.0.0.1", port: 4222}
+        %{host: config.nats.api_host, port: config.nats.api_port |> parse_nats_port()}
       ]
     }
 
@@ -98,4 +99,10 @@ defmodule Wadm.LatticeSupervisor do
       [] -> nil
     end
   end
+
+  # Helper function to parse a port number from a string or a number
+  defp parse_nats_port(num) when is_binary(num), do: num |> String.to_integer()
+  defp parse_nats_port(num) when is_integer(num), do: num
+  # Fallback to default
+  defp parse_nats_port(_num), do: 4222
 end


### PR DESCRIPTION
This PR renames env vars to have a standard `WADM_` prefix and introduces a port for cluster gossiping. The default is the default as specified in https://hexdocs.pm/libcluster/Cluster.Strategy.Gossip.html, but it can be configured. There are more cluster variables that can be configured but I've left them out until there's a need for them