### PR TITLE
Corrected argument orders for events

### DIFF
--- a/wadm/mix.exs
+++ b/wadm/mix.exs
@@ -4,7 +4,7 @@ defmodule Wadm.MixProject do
   def project do
     [
       app: :wadm,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: compiler_paths(Mix.env()),


### PR DESCRIPTION
This PR corrects a few event arguments that were ordered incorrectly, or in the `version` case sending the entire model instead of just the version.

Since #26 is now merged into main, this version may need to bump to `0.2.0`. Thoughts @autodidaddict ?