### PR TITLE
Allow linkdefs to put during reconciliation loop

### DIFF
--- a/wadm/README.md
+++ b/wadm/README.md
@@ -2,16 +2,39 @@
 
 The core functional OTP application of the wasmCloud Application Deployment Manager. Any UI or additional tooling for this application should add this package as a dependency.
 
-## Installation
-At the moment this application isn't being bundled for release. It will shortly, but in the meantime you can check out the main branch and start the application via `iex -S mix` in the root directory. 
+## Running wadm
+Simply download the latest [release](https://github.com/wasmCloud/wadm/releases) of wadm based on your architecture and operating system, unpack, and run. We currently package `wadm` for x86_64 architectures on Linux, Mac, and Windows, and the following instructions are the same for all (simply replace the OS with your own):
 
-## Prerequisites
+### From Release:
+```
+wget https://github.com/wasmCloud/wadm/releases/download/v0.2.0/x86_64-linux.tar.gz
+mkdir -p wadm
+tar -xvf x86_64-linux.tar.gz -C wadm
+cd wadm
+./bin/wadm start
+```
+### With Docker Compose:
+You can see an example compose configuration in the [petclinic docker-compose](https://github.com/wasmCloud/examples/blob/main/petclinic/docker/docker-compose.yml#L111) file, and you can run it with:
+```
+wget https://raw.githubusercontent.com/wasmCloud/examples/main/petclinic/docker/docker-compose.yml
+docker compose up
+```
+
+## Installing from Source
 You will need the following on your machine in order to run wadm:
 
 * NATS (currently using anonymous local authentication, but real auth will come soon)
 * Elixir v1.13 and OTP 25
 
 You will also want a version of `wash` that is new enough to support the `app` subset of commands for interacting with the wadm API.
+
+Once you have the above, simply run the following to install dependencies, compile, and run `wadm`
+```
+cd wadm/wadm
+mix do deps.get, compile
+iex -S mix
+```
+
 
 ## To Release
 Ensure you have the Elixir/OTP prerequisite above, then run the following command to create a [mix release](https://hexdocs.pm/mix/1.13/Mix.Tasks.Release.html) of `wadm`:

--- a/wadm/lib/wadm/deployments/deployment_monitor.ex
+++ b/wadm/lib/wadm/deployments/deployment_monitor.ex
@@ -98,7 +98,7 @@ defmodule Wadm.Deployments.DeploymentMonitor do
          ""
        ) != :ok do
       Logger.warning(
-        "Failed to pings, first reconcilation pass may fail without proper host information"
+        "Failed to ping hosts, first reconcilation pass may fail without proper host information"
       )
     end
 
@@ -205,7 +205,7 @@ defmodule Wadm.Deployments.DeploymentMonitor do
       # without side effects.
       # Other events have no effect but will trigger a check after cooling off
       :reconciling ->
-        case reconcile_actions(state.spec, lattice) do
+        case actions_to_reconcile(state.spec, lattice) do
           {cmds, _skip, _err} ->
             case Enum.filter(cmds, fn %Wadm.Reconciler.Command{cmd: cmd} ->
                    cmd == :put_linkdef
@@ -243,7 +243,7 @@ defmodule Wadm.Deployments.DeploymentMonitor do
     end
   end
 
-  defp reconcile_actions(spec, lattice) do
+  defp actions_to_reconcile(spec, lattice) do
     {skips, cmds} =
       Wadm.Reconciler.AppSpec.reconcile(spec, lattice)
       |> Enum.split_with(fn command -> command.cmd == :no_action || command.cmd == :error end)
@@ -259,7 +259,7 @@ defmodule Wadm.Deployments.DeploymentMonitor do
   defp do_reconcile(spec, lattice, actions \\ nil) do
     {cmds, errors, skips} =
       if actions == nil do
-        reconcile_actions(spec, lattice)
+        actions_to_reconcile(spec, lattice)
       else
         actions
       end

--- a/wadm/lib/wadm/deployments/deployment_monitor.ex
+++ b/wadm/lib/wadm/deployments/deployment_monitor.ex
@@ -207,15 +207,12 @@ defmodule Wadm.Deployments.DeploymentMonitor do
       :reconciling ->
         case actions_to_reconcile(state.spec, lattice) do
           {cmds, _skip, _err} ->
-            case Enum.filter(cmds, fn %Wadm.Reconciler.Command{cmd: cmd} ->
-                   cmd == :put_linkdef
-                 end) do
-              [] ->
-                :ok
+            put_cmds =
+              Enum.filter(cmds, fn %Wadm.Reconciler.Command{cmd: cmd} ->
+                cmd == :put_linkdef
+              end)
 
-              put_cmds ->
-                do_reconcile(state.spec, lattice, {put_cmds, [], []})
-            end
+            do_reconcile(state.spec, lattice, {put_cmds, [], []})
         end
 
         # Regardless if we took action or not, we will check at the end of the

--- a/wadm/lib/wadm/model/store.ex
+++ b/wadm/lib/wadm/model/store.ex
@@ -161,7 +161,7 @@ defmodule Wadm.Model.Store do
       :ok
     else
       {:ok, [0, 0]} ->
-        Logger.warn("Attempt to remove a non-existent model version from the store")
+        Logger.warning("Attempt to remove a non-existent model version from the store")
         :ok
 
       e ->

--- a/wadm/lib/wadm/nats.ex
+++ b/wadm/lib/wadm/nats.ex
@@ -1,0 +1,28 @@
+defmodule Wadm.Nats do
+  @moduledoc false
+  require Logger
+
+  # Heavily inspired from the flawless https://github.com/wasmCloud/wasmcloud-otp/blob/main/host_core/lib/host_core/nats.ex
+  def safe_pub(process_name, topic, msg) do
+    if Process.whereis(process_name) != nil do
+      Gnat.pub(process_name, topic, msg)
+    else
+      Logger.warn("Publication on #{topic} aborted - connection #{process_name} is down",
+        nats_topic: topic
+      )
+    end
+  end
+
+  def safe_req(process_name, topic, body, opts \\ []) do
+    if Process.whereis(process_name) != nil do
+      Gnat.request(process_name, topic, body, opts)
+    else
+      Logger.error(
+        "NATS request for #{topic} aborted, connection #{process_name} is down. Returning 'fast timeout'",
+        nats_topic: topic
+      )
+
+      {:error, :timeout}
+    end
+  end
+end

--- a/wadm/lib/wadm/nats.ex
+++ b/wadm/lib/wadm/nats.ex
@@ -7,7 +7,7 @@ defmodule Wadm.Nats do
     if Process.whereis(process_name) != nil do
       Gnat.pub(process_name, topic, msg)
     else
-      Logger.warn("Publication on #{topic} aborted - connection #{process_name} is down",
+      Logger.warning("Publication on #{topic} aborted - connection #{process_name} is down",
         nats_topic: topic
       )
     end

--- a/wadm/lib/wadm/reconciler/traits.ex
+++ b/wadm/lib/wadm/reconciler/traits.ex
@@ -41,15 +41,19 @@ defmodule Wadm.Reconciler.Traits do
 
         :error ->
           [
-            Command.new(:put_linkdef, "", %{
-              ld: %Observed.LinkDefinition{
-                actor_id: actor_id,
-                provider_id: provider_id,
-                contract_id: cap.contract,
-                link_name: cap.link_name,
-                values: ld.values
+            Command.new(
+              :put_linkdef,
+              "Link definition has known source, target, and does not exist",
+              %{
+                ld: %Observed.LinkDefinition{
+                  actor_id: actor_id,
+                  provider_id: provider_id,
+                  contract_id: cap.contract,
+                  link_name: cap.link_name,
+                  values: ld.values
+                }
               }
-            })
+            )
           ]
       end
     else

--- a/wadm/mix.exs
+++ b/wadm/mix.exs
@@ -4,7 +4,7 @@ defmodule Wadm.MixProject do
   def project do
     [
       app: :wadm,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: compiler_paths(Mix.env()),

--- a/wadm/test/reconciler/linkdefs_test.exs
+++ b/wadm/test/reconciler/linkdefs_test.exs
@@ -111,7 +111,7 @@ defmodule WadmTest.Reconciler.LinkdefsTest do
                      values: %{"foo" => "bar"}
                    }
                  },
-                 reason: ""
+                 reason: "Link definition has known source, target, and does not exist"
                }
              ]
     end


### PR DESCRIPTION
This PR:
- Adds more instructions into the README for how to run wadm
- Wraps NATS calls in the safe wrapper like host_core to ensure no crashes when connection is lost
- Reduces the startup time by a few seconds, initiating the host ping quicker
- Refactors a few functions, notably allowing a reconcile to perform specific actions or calculate what to do
- Allows linkdefs to be put during the reconciliation loop

The last point is a big one, since it was a deliberate decision to only issue lattice control commands when wadm is not reconciling to avoid thrashing. I still think it's a good idea to prevent starting and stopping actors/providers because those are _not_ idempotent and change the state of the lattice in a way that can thrash. However, link definitions are idempotent and can be put multiple times without any side effects.

In the future, if wadm takes on the responsibility of deleting linkdefs on an undeploy or something similar, then we'll want to revisit this.