### PR TITLE
Setup c++ toolchains for snappyer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       ELIXIR_VERSION: 1.13.3
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Visual Studio C++ toolchain for Windows
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startswith(matrix.os, 'windows') }}
       # Install erlang/OTP and elixir
       - name: Install erlang and elixir
         if: ${{ startswith(matrix.os, 'ubuntu') || startswith(matrix.os, 'windows') }}

--- a/wadm/Dockerfile
+++ b/wadm/Dockerfile
@@ -2,7 +2,7 @@ FROM elixir:1.13.3-slim as builder
 
 # Install deps
 RUN apt update && \
-    apt install git -y
+    apt install git build-essential -y
 
 # Copy source code
 COPY ./ ./


### PR DESCRIPTION
Fixes issues causing the failure in https://github.com/wasmCloud/wadm/actions/runs/2876471664

It both requires adding a C++ toolchain into the build image and setting up the windows runner to know where the build toolchain is (we've done this same fix for wasmcloud-otp)