### PR TITLE
Default to info level logs in prod

### DIFF
--- a/wadm/config/config.exs
+++ b/wadm/config/config.exs
@@ -1,5 +1,3 @@
 import Config
 
-config :logger, :console, format: "$time $metadata[$level] $message\n"
-
 import_config "#{config_env()}.exs"

--- a/wadm/config/dev.exs
+++ b/wadm/config/dev.exs
@@ -1,1 +1,3 @@
 # dev
+
+config :logger, :console, format: "$time $metadata[$level] $message\n", level: :debug

--- a/wadm/config/prod.exs
+++ b/wadm/config/prod.exs
@@ -1,1 +1,3 @@
 # prod
+
+config :logger, :console, format: "$time $metadata[$level] $message\n", level: :info

--- a/wadm/config/test.exs
+++ b/wadm/config/test.exs
@@ -1,1 +1,3 @@
 # Test
+
+config :logger, :console, format: "$time $metadata[$level] $message\n", level: :debug


### PR DESCRIPTION
This is largely due to the fact that the Gnat library logs connection information at the debug level (e.g. jwt + seed used for connecting)