### PR TITLE
feat(*): Add better support for non-conditional spreadscaler

### DIFF
--- a/wadm/lib/wadm/reconciler/app_spec.ex
+++ b/wadm/lib/wadm/reconciler/app_spec.ex
@@ -12,7 +12,14 @@ defmodule Wadm.Reconciler.AppSpec do
     |> List.flatten()
   end
 
-  def matching_hosts(actual = %LatticeObserver.Observed.Lattice{}, requirements = %{}) do
+  # Matches all hosts when no requirements are specified (or empty requirements)
+  def matching_hosts(actual = %LatticeObserver.Observed.Lattice{}, requirements)
+      when requirements == %{} or requirements == nil do
+    actual.hosts
+    |> Enum.map(fn {host_id, _host} -> host_id end)
+  end
+
+  def matching_hosts(actual = %LatticeObserver.Observed.Lattice{}, requirements) do
     actual.hosts
     |> Enum.filter(fn {_host_id, host} -> subset?(requirements, host.labels) end)
     |> Enum.map(fn {host_id, _host} -> host_id end)

--- a/wadm/test/fixtures/mixed_spreads.yaml
+++ b/wadm/test/fixtures/mixed_spreads.yaml
@@ -1,0 +1,36 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-example-app
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: userinfo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/fake:1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 4
+            spread:
+              - name: allhosts
+                weight: 67
+              - name: westcoast
+                requirements:
+                  zone: us-west-1
+                weight: 33
+        - type: linkdef
+          properties:
+            target: webcap
+            values:
+              port: 8080
+
+    - name: webcap
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.13.1
+        link_name: default

--- a/wadm/test/fixtures/no_spreads.yaml
+++ b/wadm/test/fixtures/no_spreads.yaml
@@ -1,0 +1,29 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-example-app
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: userinfo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/fake:1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 4
+        - type: linkdef
+          properties:
+            target: webcap
+            values:
+              port: 8080
+
+    - name: webcap
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.13.1
+        link_name: default

--- a/wadm/test/model/validator_test.exs
+++ b/wadm/test/model/validator_test.exs
@@ -1,6 +1,8 @@
 defmodule WadmTest.Model.ValidatorTest do
   @simple_path "test/fixtures/simple1.yaml"
   @validfails_path "test/fixtures/valid_fails.yaml"
+  @nospread_path "test/fixtures/no_spreads.yaml"
+  @mixedspread_path "test/fixtures/mixed_spreads.yaml"
 
   use ExUnit.Case
   alias Wadm.Model.{AppSpec, Validator}
@@ -9,15 +11,27 @@ defmodule WadmTest.Model.ValidatorTest do
     setup do
       {:ok, pass_spec} = AppSpec.from_map(YamlElixir.read_from_file!(@simple_path))
       {:ok, fail_spec} = AppSpec.from_map(YamlElixir.read_from_file!(@validfails_path))
+      {:ok, nospreads_spec} = AppSpec.from_map(YamlElixir.read_from_file!(@nospread_path))
+      {:ok, mixedspreads_spec} = AppSpec.from_map(YamlElixir.read_from_file!(@mixedspread_path))
 
       [
         pass_spec: pass_spec,
-        fail_spec: fail_spec
+        fail_spec: fail_spec,
+        nospreads_spec: nospreads_spec,
+        mixedspreads_spec: mixedspreads_spec
       ]
     end
 
     test "Valid spec passes validation", fixture do
       assert Validator.validate_appspec(fixture.pass_spec) == :ok
+    end
+
+    test "No spread definition spec passes validation", fixture do
+      assert Validator.validate_appspec(fixture.nospreads_spec) == :ok
+    end
+
+    test "Mixed spread definition spec passes validation", fixture do
+      assert Validator.validate_appspec(fixture.mixedspreads_spec) == :ok
     end
 
     test "Invalid spec fails validation", fixture do


### PR DESCRIPTION
This PR also serves as a proposal. As things currently stand, a user
has to specify a full set of requirements and name in order to deploy
multiple replicas:

```yaml
- type: spreadscaler
  properties:
    replicas: 1
    spread:
      - name: customersclinicapp
        requirements:
          app: petclinic
```

However, if a user wanted to just run a certain number of replicas, without
setting up tagged hosts (e.g. when running `wash up`), they would get an
error about having an invalid trait if the `spread` key wasn't included. This
PR adds support for setting only the `replicas` field when you don't care
about requirements:

```yaml
- type: spreadscaler
  properties:
    replicas: 1
```

It also allows for `nil` or empty requirements fields for when you might want
to specify weight for all hosts and then run some on another host:

```yaml
- type: spreadscaler
  properties:
    replicas: 1
    spread:
      - name: allhosts
        weight: 66
      - name: customersclinicapp
        weight: 33
        requirements:
          app: petclinic
```