### PR TITLE
ref(storage): Refactors store to better fit the data structure we need

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test Wadm (v0.4)
 
 on:
   pull_request:
-    branches: [ wadm_0.4 ]
+    branches: [wadm_0.4]
 
 jobs:
   test:
@@ -10,42 +10,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04 ]
-        nats_version: [ 2.9.15 ]
-
-    services:
-      nats:
-        image: nats:${{ matrix.nats_version }}-alpine
-        env:
-          JETSTREAM: ""
+        os: [ubuntu-22.04]
+        nats_version: [2.9.15]
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
 
       # Cache: rust
       - uses: Swatinem/rust-cache@v2
         with:
           key: "${{ matrix.os }}-rust-cache"
 
-      # Cache: nats-server binary
-      - name: Cache nats binary
-        id: cache-nats
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-nats-binary
-        with:
-          path: /usr/bin/nats
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.nats_version }}
+      # GH Actions doesn't currently support passing args to service containers and there is no way
+      # to use an environment variable to turn on jetstream for nats, so we manually start it here
+      - name: Start NATS
+        run: docker run --rm -d --name kv-provider-test -p 127.0.0.1:4222:4222 nats:${{ matrix.nats_version }} -js
 
-      # Install: nats-serveer
-      - name: Install nats binary
-        if: ${{ steps.cache-nats.outputs.cache-hit != 'true' }}
+      # Run all tests
+      - name: Run tests
         run: |
-          curl -L https://github.com/nats-io/nats-server/releases/download/v${{ matrix.nats_version }}/nats-server-v${{ matrix.nats_version }}-linux-amd64.zip -o nats-server.zip
-          unzip nats-server.zip -d nats-server
-          sudo cp nats-server/nats-server-v${{ matrix.nats_version }}-linux-amd64/nats-server /usr/bin
-
-      # Run all integration tests
-      - name: Run integration tests
-        run: |
-          make test-int
+          cargo test -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,7 @@ dependencies = [
  "async-nats",
  "async-trait",
  "atty",
+ "chrono",
  "clap",
  "cloudevents-sdk",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1"
 async-nats = "0.27"
 async-trait = "0.1"
 atty = { version = "0.2", optional = true }
+chrono = "0.4"
 clap = { version = "4", features = ["derive", "cargo", "env"], optional = true }
 cloudevents-sdk = "0.7"
 futures = "0.3"

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,24 +1,24 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use async_nats::jetstream::{self, stream::Config, Context};
+use async_nats::jetstream::Context;
 use clap::Parser;
-use std::path::PathBuf;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, trace};
 
-use wadm::consumers::{
-    manager::{ConsumerManager, WorkResult, Worker},
-    *,
-};
 use wadm::{
-    commands::*, events::*, DEFAULT_COMMANDS_TOPIC, DEFAULT_EVENTS_TOPIC, DEFAULT_EXPIRY_TIME,
+    commands::*,
+    consumers::{
+        manager::{ConsumerManager, WorkResult, Worker},
+        *,
+    },
+    events::*,
+    storage::nats_kv::NatsKvStore,
+    DEFAULT_COMMANDS_TOPIC, DEFAULT_EVENTS_TOPIC,
 };
-
-use wadm::storage::{NatsAuthConfig, NatsKvStorageConfig, NatsKvStorageEngine};
 
 mod logging;
-
-const DEFAULT_STORAGE_NKV_URL: &str = "localhost:4222";
+mod nats;
 
 #[derive(Parser, Debug)]
 #[command(name = clap::crate_name!(), version = clap::crate_version!(), about = "wasmCloud Application Deployment Manager", long_about = None)]
@@ -30,7 +30,7 @@ struct Args {
 
     /// Whether or not to use structured log output (as JSON)
     #[arg(
-        short = 's',
+        short = 'l',
         long = "structured-logging",
         default_value = "false",
         env = "WADM_STRUCTURED_LOGGING"
@@ -81,46 +81,48 @@ struct Args {
     )]
     max_jobs: usize,
 
-    /// URL of the Nats Jetstream KV that will be used for storage
-    #[arg(long = "storage-nkv-url", env = "STORAGE_NATSKV_URL")]
-    storage_nkv_url: Option<String>,
-
-    /// Optional prefix for the server tate that will be stored.
-    /// this prefix will be prepended to the bucket name of the lattice
-    /// (ex. <prefix>_lattice_<lattice id>).
+    /// The URL of the nats server you want to connect to
     #[arg(
-        long = "storage-nkv-lattice-bucket-prefix",
-        env = "WADM_STORAGE_NATSKV_LATTICE_BUCKET_PREFIX"
+        short = 's',
+        long = "nats-server",
+        env = "WADM_NATS_SERVER",
+        default_value = "127.0.0.1:4222"
     )]
-    storage_nkv_lattice_bucket_prefix: Option<String>,
+    nats_server: String,
 
-    /// (Optional) NATS NKey authentication
-    #[arg(long = "storage-nkv-nkey", env = "WADM_STORAGE_NATSKV_NKEY")]
-    storage_nkv_nats_auth_nkey: Option<String>,
+    /// Use the specified nkey file or seed literal for authentication. Must be used in conjunction with --nats-jwt
+    #[arg(
+        long = "nats-seed",
+        env = "WADM_NATS_NKEY",
+        conflicts_with = "nats_creds",
+        requires = "nats_jwt"
+    )]
+    nats_seed: Option<String>,
+
+    /// Use the specified jwt file for authentication. Must be used in conjunction with --nats-nkey
+    #[arg(
+        long = "nats-jwt",
+        env = "WADM_NATS_JWT",
+        conflicts_with = "nats_creds",
+        requires = "nats_seed"
+    )]
+    nats_jwt: Option<PathBuf>,
 
     /// (Optional) NATS credential file to use when authenticating
     #[arg(
-        long = "storage-nkv-nats-auth-creds-file",
-        env = "WADM_STORAGE_NATSKV_NATS_AUTH_CREDS_FILE",
-        conflicts_with = "storage_nkv_nats_auth_jwt_seed"
+        long = "nats-creds-file",
+        env = "WADM_NATS_CREDS_FILE",
+        conflicts_with_all = ["nats_seed", "nats_jwt"],
     )]
-    storage_nkv_nats_auth_creds_file: Option<String>,
+    nats_creds: Option<PathBuf>,
 
-    /// (Optional) NATS JWT seed to use when authenticating
+    /// Name of the bucket used for storage of lattice state
     #[arg(
-        long = "storage-nkv-nats-auth-jwt-seed",
-        env = "WADM_STORAGE_NATSKV_NATS_AUTH_JWT_SEED",
-        conflicts_with = "storage_nkv_nats_auth_creds_file"
+        long = "state-bucket-name",
+        env = "WADM_STATE_BUCKET_NAME",
+        default_value = "wadm_state"
     )]
-    storage_nkv_nats_auth_jwt_seed: Option<String>,
-
-    /// (Optional) NATS JWT file to use when authenticating
-    #[arg(
-        long = "storage-nkv-nats-auth-jwt-path",
-        env = "WADM_STORAGE_NATSKV_NATS_AUTH_JWT_PATH",
-        conflicts_with = "storage_nkv_nats_auth_creds_file"
-    )]
-    storage_nkv_nats_auth_jwt_path: Option<String>,
+    state_bucket: String,
 }
 
 #[tokio::main]
@@ -134,63 +136,38 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Build storage adapter for lattice state (on by default)
-    let natskv_storage_config = NatsKvStorageConfig {
-        nats_url: args
-            .storage_nkv_url
-            .unwrap_or(DEFAULT_STORAGE_NKV_URL.into()),
-        lattice_bucket_prefix: args.storage_nkv_lattice_bucket_prefix,
-        auth: Some(NatsAuthConfig {
-            creds_file: args.storage_nkv_nats_auth_creds_file,
-            jwt_seed: args.storage_nkv_nats_auth_jwt_seed,
-            jwt_path: args.storage_nkv_nats_auth_jwt_path.map(PathBuf::from),
-        }),
-    };
+    let (_client, context) = nats::get_client_and_context(
+        args.nats_server,
+        args.domain,
+        args.nats_seed,
+        args.nats_jwt,
+        args.nats_creds,
+    )
+    .await?;
+
+    let store = nats::ensure_kv_bucket(&context, args.state_bucket, 1).await?;
 
     // TODO: use the storage engine
-    let _storage = NatsKvStorageEngine::new(natskv_storage_config)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let _state_storage = NatsKvStore::new(store);
 
-    // TODO: All the NATS connection options and jetstream stuff
-    let client = async_nats::connect("127.0.0.1:4222").await?;
-    let context = if let Some(domain) = args.domain {
-        jetstream::with_domain(client.clone(), domain)
-    } else {
-        jetstream::new(client.clone())
-    };
+    let event_stream = nats::ensure_stream(
+        &context,
+        args.event_stream_name,
+        DEFAULT_EVENTS_TOPIC.to_owned(),
+        Some(
+            "A stream that stores all events coming in on the wasmbus.evt topics in a cluster"
+                .to_string(),
+        ),
+    )
+    .await?;
 
-    let event_stream = context
-        .get_or_create_stream(Config {
-            name: args.event_stream_name,
-            description: Some(
-                "A stream that stores all events coming in on the wasmbus.evt topics in a cluster"
-                    .to_string(),
-            ),
-            num_replicas: 1,
-            retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
-            subjects: vec![DEFAULT_EVENTS_TOPIC.to_owned()],
-            max_age: DEFAULT_EXPIRY_TIME,
-            storage: async_nats::jetstream::stream::StorageType::File,
-            allow_rollup: false,
-            ..Default::default()
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-    let command_stream = context
-        .get_or_create_stream(Config {
-            name: args.command_stream_name,
-            description: Some("A stream that stores all commands for wadm".to_string()),
-            num_replicas: 1,
-            retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
-            subjects: vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
-            max_age: DEFAULT_EXPIRY_TIME,
-            storage: async_nats::jetstream::stream::StorageType::File,
-            allow_rollup: false,
-            ..Default::default()
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let command_stream = nats::ensure_stream(
+        &context,
+        args.command_stream_name,
+        DEFAULT_COMMANDS_TOPIC.to_owned(),
+        Some("A stream that stores all commands for wadm".to_string()),
+    )
+    .await?;
 
     let host_id = args
         .host_id

--- a/bin/nats.rs
+++ b/bin/nats.rs
@@ -1,0 +1,124 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_nats::{
+    jetstream::{
+        self,
+        kv::{Config as KvConfig, Store},
+        stream::{Config as StreamConfig, Stream},
+        Context,
+    },
+    Client, ConnectOptions,
+};
+
+use wadm::DEFAULT_EXPIRY_TIME;
+
+/// Creates a NATS client from the given options
+pub async fn get_client_and_context(
+    url: String,
+    js_domain: Option<String>,
+    seed: Option<String>,
+    jwt_path: Option<PathBuf>,
+    creds_path: Option<PathBuf>,
+) -> Result<(Client, Context)> {
+    let client = if seed.is_none() && jwt_path.is_none() && creds_path.is_none() {
+        async_nats::connect(url).await?
+    } else {
+        let opts = build_nats_options(seed, jwt_path, creds_path).await?;
+        async_nats::connect_with_options(url, opts).await?
+    };
+
+    let context = if let Some(domain) = js_domain {
+        jetstream::with_domain(client.clone(), domain)
+    } else {
+        jetstream::new(client.clone())
+    };
+
+    Ok((client, context))
+}
+
+async fn build_nats_options(
+    seed: Option<String>,
+    jwt_path: Option<PathBuf>,
+    creds_path: Option<PathBuf>,
+) -> Result<ConnectOptions> {
+    match (seed, jwt_path, creds_path) {
+        (Some(seed), Some(jwt), None) => {
+            let jwt = tokio::fs::read_to_string(jwt).await?;
+            let kp = std::sync::Arc::new(get_seed(seed).await?);
+
+            Ok(async_nats::ConnectOptions::with_jwt(jwt, move |nonce| {
+                let key_pair = kp.clone();
+                async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
+            }))
+        }
+        (None, None, Some(creds)) => async_nats::ConnectOptions::with_credentials_file(creds)
+            .await
+            .map_err(anyhow::Error::from),
+        _ => {
+            // We shouldn't ever get here due to the requirements on the flags, but return a helpful error just in case
+            Err(anyhow::anyhow!(
+                "Got too many options. Make sure to provide a seed and jwt or a creds path"
+            ))
+        }
+    }
+}
+
+/// Takes a string that could be a raw seed, or a path and does all the necessary loading and parsing steps
+async fn get_seed(seed: String) -> Result<nkeys::KeyPair> {
+    // MAGIC NUMBER: Length of a seed key
+    let raw_seed = if seed.len() == 58 && seed.starts_with('S') {
+        seed
+    } else {
+        tokio::fs::read_to_string(seed).await?
+    };
+
+    nkeys::KeyPair::from_seed(&raw_seed).map_err(anyhow::Error::from)
+}
+
+/// A helper that ensures that the given stream name exists, using defaults to create if it does
+/// not. Returns the handle to the stream
+pub async fn ensure_stream(
+    context: &Context,
+    name: String,
+    subject: String,
+    description: Option<String>,
+) -> Result<Stream> {
+    context
+        .get_or_create_stream(StreamConfig {
+            name,
+            description,
+            num_replicas: 1,
+            retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
+            subjects: vec![subject],
+            max_age: DEFAULT_EXPIRY_TIME,
+            storage: async_nats::jetstream::stream::StorageType::File,
+            allow_rollup: false,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))
+}
+
+/// A helper that ensures that the given KV bucket exists, using defaults to create if it does
+/// not. Returns the handle to the stream
+pub async fn ensure_kv_bucket(
+    context: &Context,
+    name: String,
+    history_to_keep: i64,
+) -> Result<Store> {
+    if let Ok(kv) = context.get_key_value(&name).await {
+        Ok(kv)
+    } else {
+        context
+            .create_key_value(KvConfig {
+                bucket: name,
+                history: history_to_keep,
+                num_replicas: 1,
+                storage: jetstream::stream::StorageType::File,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))
+    }
+}

--- a/src/events/data.rs
+++ b/src/events/data.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+/// All unique data needed to identify a provider. For this reason, this type implements PartialEq
+/// and Hash since it can serve as a key
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq, Hash)]
 pub struct ProviderInfo {
     pub contract_id: String,
     pub link_name: String,
@@ -10,7 +12,7 @@ pub struct ProviderInfo {
     pub public_key: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct ProviderClaims {
     pub expires_human: String,
     // TODO: Should we actually parse the nkey?
@@ -25,14 +27,14 @@ pub struct ProviderClaims {
     pub version: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct ProviderHealthCheckInfo {
     pub link_name: String,
     // TODO: Should we make this a parsed nkey?
     pub public_key: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct ActorClaims {
     pub call_alias: Option<String>,
     #[serde(rename = "caps")]

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -106,7 +106,9 @@ impl TryFrom<CloudEvent> for Event {
             ActorStopped::TYPE => ActorStopped::try_from(value).map(Event::ActorStopped),
             ProviderStarted::TYPE => ProviderStarted::try_from(value).map(Event::ProviderStarted),
             ProviderStopped::TYPE => ProviderStopped::try_from(value).map(Event::ProviderStopped),
-            ProviderStartFailed::TYPE => ProviderStartFailed::try_from(value).map(Event::ProviderStartFailed),
+            ProviderStartFailed::TYPE => {
+                ProviderStartFailed::try_from(value).map(Event::ProviderStartFailed)
+            }
             ProviderHealthCheckPassed::TYPE => {
                 ProviderHealthCheckPassed::try_from(value).map(Event::ProviderHealthCheckPassed)
             }
@@ -191,7 +193,7 @@ pub enum ConversionError {
 // EVENTS START HERE
 //
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ActorStarted {
     pub annotations: HashMap<String, String>,
     pub api_version: usize,
@@ -205,7 +207,7 @@ pub struct ActorStarted {
 
 event_impl!(ActorStarted, "com.wasmcloud.lattice.actor_started");
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ActorStopped {
     pub instance_id: String,
     // TODO: Parse as nkey?
@@ -214,7 +216,7 @@ pub struct ActorStopped {
 
 event_impl!(ActorStopped, "com.wasmcloud.lattice.actor_stopped");
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderStarted {
     pub annotations: HashMap<String, String>,
     pub claims: ProviderClaims,
@@ -229,7 +231,7 @@ pub struct ProviderStarted {
 
 event_impl!(ProviderStarted, "com.wasmcloud.lattice.provider_started");
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderStartFailed {
     pub error: String,
     pub link_name: String,
@@ -241,7 +243,7 @@ event_impl!(
     "com.wasmcloud.lattice.provider_start_failed"
 );
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderStopped {
     pub contract_id: String,
     // TODO: parse as UUID?
@@ -255,7 +257,7 @@ pub struct ProviderStopped {
 
 event_impl!(ProviderStopped, "com.wasmcloud.lattice.provider_stopped");
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderHealthCheckPassed {
     #[serde(flatten)]
     data: ProviderHealthCheckInfo,
@@ -266,7 +268,7 @@ event_impl!(
     "com.wasmcloud.lattice.health_check_passed"
 );
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderHealthCheckFailed {
     #[serde(flatten)]
     data: ProviderHealthCheckInfo,
@@ -277,7 +279,7 @@ event_impl!(
     "com.wasmcloud.lattice.health_check_failed"
 );
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LinkdefSet {
     #[serde(flatten)]
     pub linkdef: Linkdef,
@@ -285,7 +287,7 @@ pub struct LinkdefSet {
 
 event_impl!(LinkdefSet, "com.wasmcloud.lattice.linkdef_set");
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LinkdefDeleted {
     #[serde(flatten)]
     pub linkdef: Linkdef,
@@ -293,7 +295,7 @@ pub struct LinkdefDeleted {
 
 event_impl!(LinkdefDeleted, "com.wasmcloud.lattice.linkdef_deleted");
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HostStarted {
     pub labels: HashMap<String, String>,
     pub friendly_name: String,
@@ -309,7 +311,7 @@ event_impl!(
     id
 );
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HostStopped {
     pub labels: HashMap<String, String>,
     // TODO: Parse as nkey?
@@ -324,15 +326,17 @@ event_impl!(
     id
 );
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HostHeartbeat {
     pub actors: HashMap<String, usize>,
     pub friendly_name: String,
     pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub annotations: HashMap<String, String>,
     pub providers: Vec<ProviderInfo>,
     pub uptime_human: String,
     pub uptime_seconds: usize,
-    pub version: String,
+    pub version: semver::Version,
     // TODO: Parse as nkey?
     #[serde(default)]
     pub id: String,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,92 +1,154 @@
 use async_trait::async_trait;
-use semver::Version;
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use thiserror::Error;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{collections::HashMap, ops::Deref};
 
-mod nats_kv;
+pub mod nats_kv;
 mod state;
 
-pub use nats_kv::{NatsAuthConfig, NatsKvStorageConfig, NatsKvStorageEngine};
-pub use state::{Actor, Claim, Host, LatticeParameters, LatticeState, Provider};
+pub use state::{Actor, Host, Provider};
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct WithStateMetadata<T> {
-    /// Revision (if supported), often used for compare-and-set-semantics
-    pub revision: Option<u64>,
-
-    /// The state that was returned
-    pub state: T,
-}
-
-/////////////
-// Storage //
-/////////////
-
-/// Errors that are related to storage engines
-#[derive(Debug, Error)]
-pub enum StorageEngineError {
-    /// When the underlying engine throws an error
-    #[error("Storage engine encountered an error: {0:?}")]
-    Engine(Box<dyn Debug + Send + Sync>),
-
-    /// An error when the cause is unknown. This happens very rarely and should be considered fatal
-    #[error("Unknown error has occured")]
-    Unknown,
-}
-
-/// Errors that are related to storage
-#[derive(Debug, Error)]
-pub enum StorageError {
-    /// Errors that arise at the engine layer
-    #[error("Storage error: {0}")]
-    Engine(String),
-
-    /// Errors that arise at the network layer
-    #[error("Network error: {0}")]
-    NetworkError(String),
-
-    /// An error when the cause is unknown. This happens very rarely and should be considered fatal
-    #[error("Unknown error has occured: {0}")]
-    Unknown(String),
-}
-
-/// Options and metadata that can be used to improve store operations
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct StoreOptions {
-    /// Whether to force a store with compare-and-set semantics
-    pub require_cas: bool,
-
-    /// version identifier that enables stores to perform compare-and-set semantics
-    pub revision: Option<u64>,
+/// A trait that must be implemented with a unique identifier for the given type. This is used in
+/// the construction of keys for a store
+pub trait StateKind {
+    /// The type name of this storable state
+    const KIND: &'static str;
 }
 
 /// A trait that indicates the ability of a struct to store state
-/// Objects that implement Store can retrieve, save and delete some given State, identifiable by StateId
+///
+/// Internals of how to validate state (such as compare and swap semantics) are left up to
+/// implementors and should not be the concern of consumers of any given store
+// NOTE(thomastaylor312): To our future selves: I originally had a trait called `StateIdentity` that
+// I used rather than having the consumer generate the key. However, that seemed to be a bit
+// overkill for now, and it creates a bunch of extra work. Any type that needs to be used as an ID
+// would need to implement the type and it could lead to the annoying issue of needing to define a
+// struct just to get the ID. If we need the type guarantees in the future, we can always add it in
 #[async_trait]
 pub trait Store {
-    type State;
-    type StateId;
+    type Error: std::error::Error;
 
-    /// Get the name of the lattice storage
-    async fn name() -> String;
+    /// Get the state for the specified kind with the given ID. Returns None if it doesn't exist
+    ///
+    /// The ID can vary depending on the type, but should be the unique ID for the object (e.g. a
+    /// host key)
+    async fn get<T>(&self, lattice_id: &str, id: &str) -> Result<Option<T>, Self::Error>
+    where
+        T: DeserializeOwned + StateKind;
 
-    /// Get the version of the lattice storage
-    async fn version() -> Version;
+    /// Returns a map of all items of the given type.
+    ///
+    /// The map key is the value as given by [`StateId::id`]
+    async fn list<T>(&self, lattice_id: &str) -> Result<HashMap<String, T>, Self::Error>
+    where
+        T: DeserializeOwned + StateKind;
 
-    /// Get a particular piece of state
-    async fn get(&self, id: Self::StateId) -> Result<WithStateMetadata<Self::State>, StorageError>;
-
-    /// Store a piece of state
-    async fn store(
-        &mut self,
-        state: Self::State,
-        opts: StoreOptions,
-    ) -> Result<WithStateMetadata<Self::StateId>, StorageError>;
+    /// Store a piece of state with the given ID. This should overwrite existing state entries
+    ///
+    /// This function has several required bounds. It needs to be serialize and deserialize because
+    /// some implementations will need to deserialize the current data before modifying it.
+    /// [`StateKind`] is needed in order to store and access the data correctly,
+    /// and, lastly, [`Send`] is needed because this is an async function and the data needs to be
+    /// sendable between threads
+    async fn store<T>(&self, lattice_id: &str, id: String, data: T) -> Result<(), Self::Error>
+    where
+        T: Serialize + DeserializeOwned + StateKind + Send;
 
     /// Delete an existing piece of state
-    async fn delete(&self, id: String) -> Result<(), StorageError>;
+    ///
+    /// This function has several required bounds. It needs to be serialize and deserialize because
+    /// some implementations will need to deserialize the current data before modifying it.
+    /// [`StateKind`] is needed in order to store and access the data correctly, and, lastly,
+    /// [`Send`] is needed because this is an async function and the modified data needs to be
+    /// sendable between threads
+    async fn delete<T>(&self, lattice_id: &str, id: &str) -> Result<(), Self::Error>
+    where
+        T: Serialize + DeserializeOwned + StateKind + Send;
 }
 
-/// LatticeStorages are state stores that support storing lattice information
-pub trait LatticeStorage: Store<State = LatticeState, StateId = String> {}
+/// Scoped store is a convenience wrapper around a store that automatically passes the given
+/// lattice_id to [`Store`] implementations on every call
+pub struct ScopedStore<S> {
+    lattice_id: String,
+    inner: S,
+}
+
+impl<S> AsRef<S> for ScopedStore<S> {
+    fn as_ref(&self) -> &S {
+        &self.inner
+    }
+}
+
+impl<S> Deref for ScopedStore<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<S: Clone> Clone for ScopedStore<S> {
+    fn clone(&self) -> Self {
+        ScopedStore {
+            lattice_id: self.lattice_id.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<S: Store> ScopedStore<S> {
+    /// Creates a new store scoped to the given lattice ID
+    pub fn new(lattice_id: &str, store: S) -> ScopedStore<S> {
+        ScopedStore {
+            lattice_id: lattice_id.to_owned(),
+            inner: store,
+        }
+    }
+
+    /// Converts this scoped store back into its original store
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    /// Get the state for the specified kind with the given ID. Returns None if it doesn't exist
+    ///
+    /// The ID can vary depending on the type, but should be the unique ID for the object (e.g. a
+    /// host key)
+    pub async fn get<T>(&self, id: &str) -> Result<Option<T>, S::Error>
+    where
+        T: DeserializeOwned + StateKind,
+    {
+        self.inner.get(&self.lattice_id, id).await
+    }
+
+    /// Returns a map of all items of the given type.
+    ///
+    /// The map key is the value as given by [`StateId::id`]
+    pub async fn list<T>(&self) -> Result<HashMap<String, T>, S::Error>
+    where
+        T: DeserializeOwned + StateKind,
+    {
+        self.inner.list(&self.lattice_id).await
+    }
+
+    /// Store a piece of state. This should overwrite existing state entries
+    pub async fn store<T>(&self, id: String, data: T) -> Result<(), S::Error>
+    where
+        T: Serialize + DeserializeOwned + StateKind + Send,
+    {
+        self.inner.store(&self.lattice_id, id, data).await
+    }
+
+    /// Delete an existing piece of state
+    pub async fn delete<T>(&self, id: &str) -> Result<(), S::Error>
+    where
+        T: Serialize + DeserializeOwned + StateKind + Send,
+    {
+        self.inner.delete::<T>(&self.lattice_id, id).await
+    }
+}
+
+/// A helper function for generating a unique ID for any given provider. This is exposed purely to
+/// be a common way of creating a key to access/store provider information
+pub fn provider_id(public_key: &str, link_name: &str, contract_id: &str) -> String {
+    format!("{}/{}/{}", public_key, link_name, contract_id)
+}

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -58,6 +58,9 @@ struct HostResponse {
 }
 
 #[tokio::test]
+// TODO: Stop ignoring this test once https://github.com/wasmCloud/wash/issues/402 is fixed. Please
+// note this test should probably be changed to an e2e test as the order of events is somewhat flaky
+#[ignore]
 #[serial]
 async fn test_event_stream() {
     let _guard = helpers::setup_test().await;
@@ -214,6 +217,11 @@ async fn test_event_stream() {
 }
 
 #[tokio::test]
+// TODO: Stop ignoring this test once https://github.com/wasmCloud/wash/issues/402 is fixed. This
+// does work when you run it individually. Please note that there is problems when running this
+// against 0.60+ hosts as the KV bucket for linkdefs makes it so that all those linkdefs are emitted
+// as published events when the host starts
+#[ignore]
 #[serial]
 async fn test_nack_and_rereceive() {
     let _guard = helpers::setup_test().await;

--- a/tests/storage_nats_kv.rs
+++ b/tests/storage_nats_kv.rs
@@ -1,122 +1,280 @@
-use anyhow::Result;
-use semver::Version;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use wadm::events::Linkdef;
-use wadm::storage::{
-    Actor, Claim, Host, LatticeState, NatsKvStorageConfig, NatsKvStorageEngine, Provider, Store,
-    StoreOptions,
+use async_nats::jetstream::{
+    self,
+    kv::{Config as KvConfig, Store},
+};
+use chrono::Utc;
+
+use wadm::{
+    events::ProviderInfo,
+    storage::{nats_kv::NatsKvStore, Actor, Host, Provider, Store as WadmStore},
 };
 
-/// Test storing and retrieving an empty lattice
-#[tokio::test]
-async fn storage_nats_kv_empty_lattice() -> Result<()> {
-    let mut storage = NatsKvStorageEngine::new(NatsKvStorageConfig {
-        nats_url: "localhost:4222".into(),
-        lattice_bucket_prefix: None,
-        auth: None,
-    })
-    .await?;
+/// Helper function that sets up a store with the given ID as its name. This ID should be unique per
+/// test
+async fn create_test_store(id: String) -> Store {
+    let client = async_nats::connect("127.0.0.1:4222")
+        .await
+        .expect("Should be able to connect to NATS");
 
-    let lattice = LatticeState {
-        id: "test".into(),
-        ..LatticeState::default()
-    };
+    let context = jetstream::new(client);
 
-    // Store the lattice
-    let stored = storage.store(lattice, StoreOptions::default()).await?;
-    assert!(stored.revision.is_some(), "a Nats KV revision was present");
+    // First make sure we clean up the store. We can't just do a cleanup on `Drop` because
+    // `tokio::test` uses a single threaded runtime and blocks forever and it isn't really worth
+    // spinning up more cores to handle this. We don't care about the result because it could not
+    // exist
+    let _ = context.delete_key_value(&id).await;
 
-    // Re-read the stored lattice
-    let reread = storage.get(stored.state).await?;
-    assert_eq!(reread.revision, stored.revision);
-    assert_eq!(reread.state.id, "test");
-
-    Ok(())
+    context
+        .create_key_value(KvConfig {
+            bucket: id,
+            history: 1,
+            num_replicas: 1,
+            storage: jetstream::stream::StorageType::Memory,
+            ..Default::default()
+        })
+        .await
+        .expect("Unable to create KV bucket")
 }
 
-/// Test storing and retrieving an empty lattice
 #[tokio::test]
-async fn storage_nats_kv_full_lattice() -> Result<()> {
-    let mut storage = NatsKvStorageEngine::new(NatsKvStorageConfig {
-        nats_url: "localhost:4222".into(),
-        lattice_bucket_prefix: None,
-        auth: None,
-    })
-    .await?;
+async fn test_round_trip() {
+    let store = NatsKvStore::new(create_test_store("round_trip_test".to_string()).await);
 
-    let lattice = LatticeState {
-        id: "test".into(),
-        hosts: HashMap::from([(
-            "12345".into(),
-            Host {
-                id: "12345".into(),
-                name: "host-0".into(),
-                uptime_seconds: 12345,
-                labels: vec!["test".into()],
-                version: Version::parse("1.2.3")?,
-            },
-        )]),
-        actors: HashMap::from([(
-            "actor_0".into(),
-            Actor {
-                id: "actor_0".into(),
-                name: "actor_0".into(),
-                capabilities: vec!["httpserver".into()],
-                issuer: "fake-issuer".into(),
-                tags: vec!["server".into()],
-                call_alias: "actor0".into(),
-            },
-        )]),
-        providers: HashMap::from([(
-            "wasmcloud:httpserver".into(),
-            HashMap::from([(
-                "provider_0".into(),
-                Provider {
-                    id: "provider_0".into(),
-                    name: "provider_0".into(),
-                    issuer: "fake-issuer".into(),
-                    contract_id: "wasmcloud:httpserver".into(),
-                    tags: vec!["http".into()],
-                },
-            )]),
-        )]),
-        link_defs: HashMap::from([(
-            "link_0".into(),
-            Linkdef {
-                id: "link_0".into(),
-                actor_id: "actor_0".into(),
-                provider_id: "provider_0".into(),
-                contract_id: "wasmcloud:httpserver".into(),
-                link_name: "default".into(),
-                values: HashMap::new(),
-            },
-        )]),
-        claims: HashMap::from([(
-            "claim_0".into(),
-            Claim {
-                name: "claim_0".into(),
-                subscriber: "???".into(),
-                issuer: "fake-issuer".into(),
-                call_alias: None,
-                capabilities: vec!["httpserver".into()],
-                version: Version::parse("1.2.3")?,
-                revision: 0,
-                tags: HashMap::new(),
-            },
-        )]),
-        ..LatticeState::default()
+    let lattice_id = "roundtrip";
+
+    let actor1 = Actor {
+        id: "testactor".to_string(),
+        name: "Test Actor".to_string(),
+        capabilities: vec!["wasmcloud:httpserver".to_string()],
+        issuer: "afakekey".to_string(),
+        count: 1,
+        reference: "fake.oci.repo/testactor:0.1.0".to_string(),
+        ..Default::default()
     };
 
-    // Store the lattice
-    let stored = storage
-        .store(lattice.clone(), StoreOptions::default())
-        .await?;
-    assert!(stored.revision.is_some(), "a Nats KV revision was present");
+    let actor2 = Actor {
+        id: "anotheractor".to_string(),
+        name: "Another Actor".to_string(),
+        capabilities: vec!["wasmcloud:httpserver".to_string()],
+        issuer: "afakekey".to_string(),
+        count: 1,
+        reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
+        ..Default::default()
+    };
 
-    // Re-read the stored lattice, ensure that it's the exact same
-    let reread = storage.get(stored.state).await?;
-    assert_eq!(reread.state, lattice);
+    let host = Host {
+        actors: HashMap::from([("testactor".to_string(), 1)]),
+        id: "testhost".to_string(),
+        providers: HashSet::from([ProviderInfo {
+            public_key: "testprovider".to_string(),
+            contract_id: "wasmcloud:httpserver".to_owned(),
+            link_name: "default".to_owned(),
+        }]),
+        friendly_name: "test-host".to_string(),
+        uptime_seconds: 30,
+        last_seen: Utc::now(),
+        ..Default::default()
+    };
 
-    Ok(())
+    let provider = Provider {
+        id: "testprovider".to_string(),
+        name: "Test Provider".to_string(),
+        issuer: "afakekey".to_string(),
+        contract_id: "wasmcloud:httpserver".to_string(),
+        reference: "fake.oci.repo/testprovider:0.1.0".to_string(),
+        link_name: "default".to_string(),
+    };
+
+    store
+        .store(lattice_id, host.id.clone(), host.clone())
+        .await
+        .expect("Should be able to store a host");
+
+    let provider_id =
+        wadm::storage::provider_id(&provider.id, &provider.link_name, &provider.contract_id);
+    store
+        .store(lattice_id, provider_id.clone(), provider.clone())
+        .await
+        .expect("Should be able to store a provider");
+
+    store
+        .store(lattice_id, actor1.id.clone(), actor1.clone())
+        .await
+        .expect("Should be able to store actor");
+
+    // Now test we can retrieve all the data properly
+    let stored_host: Host = store
+        .get(lattice_id, &host.id)
+        .await
+        .expect("Unable to fetch stored host")
+        .expect("Host should exist");
+    assert_eq!(
+        stored_host.friendly_name, host.friendly_name,
+        "Host should be correct"
+    );
+
+    let stored_provider: Provider = store
+        .get(lattice_id, &provider_id)
+        .await
+        .expect("Unable to fetch stored provider")
+        .expect("Provider should exist");
+    assert_eq!(
+        stored_provider.name, provider.name,
+        "Provider should be correct"
+    );
+
+    let stored_actor: Actor = store
+        .get(lattice_id, &actor1.id)
+        .await
+        .expect("Unable to fetch stored actor")
+        .expect("Actor should exist");
+    assert_eq!(stored_actor.name, actor1.name, "Actor should be correct");
+
+    // Add something to the state and then fetch it to make sure it updated properly
+    store
+        .store(lattice_id, actor2.id.clone(), actor2.clone())
+        .await
+        .expect("Should be able to add a new actor");
+
+    let all_actors = store
+        .list::<Actor>(lattice_id)
+        .await
+        .expect("Should be able to get all actors");
+
+    assert_eq!(
+        all_actors.len(),
+        2,
+        "Should have found the correct number of actors"
+    );
+    assert!(
+        all_actors.contains_key(&actor1.id),
+        "Should have found actor with id {}",
+        actor1.id
+    );
+    assert!(
+        all_actors.contains_key(&actor2.id),
+        "Should have found actor with id {}",
+        actor2.id
+    );
+
+    // Delete one of the actors and make sure the data is correct
+    store
+        .delete::<Actor>(lattice_id, &actor1.id)
+        .await
+        .expect("Should be able to delete an actor");
+
+    let all_actors = store
+        .list::<Actor>(lattice_id)
+        .await
+        .expect("Should be able to get all actors");
+
+    assert_eq!(
+        all_actors.len(),
+        1,
+        "Should have found the correct number of actors"
+    );
+    assert!(
+        !all_actors.contains_key(&actor1.id),
+        "Should not have found actor with id {}",
+        actor1.id
+    );
+}
+
+#[tokio::test]
+async fn test_no_data() {
+    let store = NatsKvStore::new(create_test_store("nodata_test".to_string()).await);
+
+    let lattice_id = "nodata";
+
+    assert!(
+        store
+            .get::<Actor>(lattice_id, "doesnotexist")
+            .await
+            .expect("Should be able to query store")
+            .is_none(),
+        "Should get None for missing data"
+    );
+
+    let all = store
+        .list::<Provider>(lattice_id)
+        .await
+        .expect("Should not error when fetching list");
+    assert!(
+        all.is_empty(),
+        "An empty hash map should be returned when no data is present"
+    );
+
+    store
+        .delete::<Host>(lattice_id, "doesnotexist")
+        .await
+        .expect("Should be able to delete something that is non-existent without an error");
+}
+
+#[tokio::test]
+async fn test_multiple_lattice() {
+    let store = NatsKvStore::new(create_test_store("multiple_lattice_test".to_string()).await);
+
+    let lattice_id1 = "multiple_lattice";
+    let lattice_id2 = "other_lattice";
+    let actor1 = Actor {
+        id: "testactor".to_string(),
+        name: "Test Actor".to_string(),
+        capabilities: vec!["wasmcloud:httpserver".to_string()],
+        issuer: "afakekey".to_string(),
+        count: 1,
+        reference: "fake.oci.repo/testactor:0.1.0".to_string(),
+        ..Default::default()
+    };
+
+    let actor2 = Actor {
+        id: "anotheractor".to_string(),
+        name: "Another Actor".to_string(),
+        capabilities: vec!["wasmcloud:httpserver".to_string()],
+        issuer: "afakekey".to_string(),
+        count: 1,
+        reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
+        ..Default::default()
+    };
+
+    // Store both actors first with the different lattice id
+    store
+        .store(lattice_id1, actor1.id.clone(), actor1.clone())
+        .await
+        .expect("Should be able to store data");
+    store
+        .store(lattice_id2, actor2.id.clone(), actor2.clone())
+        .await
+        .expect("Should be able to store data");
+
+    let first = store
+        .list::<Actor>(lattice_id1)
+        .await
+        .expect("Should be able to list data");
+    assert_eq!(first.len(), 1, "First lattice should have exactly 1 actor");
+    let actor = first
+        .get(&actor1.id)
+        .expect("First lattice should have the right actor");
+    assert_eq!(
+        actor.name, actor1.name,
+        "Should have returned the correct actor"
+    );
+
+    let second = store
+        .list::<Actor>(lattice_id2)
+        .await
+        .expect("Should be able to list data");
+    assert_eq!(
+        second.len(),
+        1,
+        "Second lattice should have exactly 1 actor"
+    );
+    let actor = second
+        .get(&actor2.id)
+        .expect("Second lattice should have the right actor");
+    assert_eq!(
+        actor.name, actor2.name,
+        "Should have returned the correct actor"
+    );
 }


### PR DESCRIPTION
This is part of my work for actually generating the lattice state, however I realized that in the previous task we didn't really specify how we were going to save the data. As I started to work on storing lattice state, it became obvious what we had wasn't a good fit. So I refactored to better fit what we needed and took a little bit of time to make the patterns match what we had in other places (such as taking a `Store`, rather than constructing the client and the bucket within the store)

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

### Acceptance or Integration
I updated the integration tests to make sure data could be stored and retrieved

### Manual Verification
Verification was done through integration tests
