### PR TITLE
feat(*): State generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,10 +46,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "any_ascii"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
+name = "ascii_tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
+
+[[package]]
+name = "async-nats"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9323e13cccc5d28a249e3d0c22600129703c75283a73fc3ebb3dbd2d51bef1cb"
+dependencies = [
+ "base64 0.13.1",
+ "base64-url",
+ "bytes",
+ "futures",
+ "http",
+ "itertools",
+ "itoa",
+ "lazy_static",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "subslice",
+ "time 0.3.20",
+ "tokio",
+ "tokio-retry",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "async-nats"
@@ -94,6 +174,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "atelier_assembler"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feecf8364a7d1c80f2323ea0d1abee09d7256a91dc5d29a1d171a52c17be36a"
+dependencies = [
+ "atelier_core",
+ "atelier_json",
+ "atelier_smithy",
+ "atelier_test",
+ "log",
+]
+
+[[package]]
+name = "atelier_core"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c05c6353a26a3e1b7017058a0a99c8f61131cf9a0ecb604dd9b62069b1be75"
+dependencies = [
+ "error-chain",
+ "heck 0.3.3",
+ "lazy_static",
+ "log",
+ "paste",
+ "regex",
+]
+
+[[package]]
+name = "atelier_json"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86bad50f33038fa4dec1f5c4e83bc0a1174c17767defeff76b2eca0028ec4bf"
+dependencies = [
+ "atelier_core",
+ "serde_json",
+]
+
+[[package]]
+name = "atelier_smithy"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56140a8133b56c021ee62e64d35015d1f51b71e0b5cdf401edf78a2a77f2f7e3"
+dependencies = [
+ "atelier_core",
+ "log",
+ "pest",
+ "pest_ascii_tree",
+ "pest_derive",
+]
+
+[[package]]
+name = "atelier_test"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81fd306eb92079fce9b7089abaf178c306877b72ec6e679ad331253ea9bfb00"
+dependencies = [
+ "atelier_core",
+ "pretty_assertions",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +249,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -252,6 +407,25 @@ dependencies = [
 
 [[package]]
 name = "cloudevents-sdk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdcf727db26626ad9117c83e986ba6afba0c3c0e38eae5f5035adda3ab0c0e6"
+dependencies = [
+ "base64 0.12.3",
+ "bitflags",
+ "chrono",
+ "delegate-attr",
+ "hostname",
+ "serde",
+ "serde_json",
+ "snafu",
+ "url",
+ "uuid",
+ "web-sys",
+]
+
+[[package]]
+name = "cloudevents-sdk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801713078518ab05d7c78508c14cf55173a14a1a6659421d3352c2576a6167bf"
@@ -337,6 +511,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -436,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,10 +645,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "futures",
+ "rand",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "ed25519"
@@ -497,6 +720,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +752,22 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "backtrace",
+ "version_check",
+]
+
+[[package]]
+name = "escape_string"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
 
 [[package]]
 name = "fastrand"
@@ -658,6 +910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "h2"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +932,20 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.7",
  "tracing",
+]
+
+[[package]]
+name = "handlebars"
+version = "4.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -767,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +1066,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -914,6 +1205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-sort"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09e4591611e231daf4d4c685a66cb0410cc1e502027a20ae55f2bb9e997207a"
+dependencies = [
+ "any_ascii",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1279,37 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minicbor"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
+
+[[package]]
+name = "minicbor"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e575910763b21a0db7df5e142907fe944bff84d1dfc78e2ba92e7f3bdfd36b"
+
+[[package]]
+name = "minicbor-ser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327f21c0fdeca4f4e5d0552ac36af7bf76e1e1fe4fc165ae00355b4f1995d493"
+dependencies = [
+ "minicbor 0.11.5",
+ "serde",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1063,6 +1394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,10 +1482,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking_lot"
@@ -1171,6 +1526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1545,62 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_ascii_tree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152b393638a9816cd3dedb5aea2fb60ab0b641315aa133cea219c8797e768fc"
+dependencies = [
+ "ascii_tree",
+ "escape_string",
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.6",
+]
 
 [[package]]
 name = "petgraph"
@@ -1244,6 +1661,18 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1407,6 +1836,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1887,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -1454,15 +1895,19 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1480,6 +1925,40 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1607,6 +2086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +2134,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2058,6 +2555,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -2327,12 +2874,13 @@ name = "wadm"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.23.0",
+ "async-nats 0.27.1",
  "async-trait",
  "atty",
  "chrono",
  "clap",
- "cloudevents-sdk",
+ "cloudevents-sdk 0.7.0",
  "futures",
  "nkeys",
  "opentelemetry",
@@ -2350,6 +2898,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "wasmcloud-control-interface",
 ]
 
 [[package]]
@@ -2360,6 +2909,27 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "wascap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d1cfad67501627ac9344cbd89be80d2d5ebc98ef3b86862041cb26a280081f"
+dependencies = [
+ "base64 0.13.1",
+ "data-encoding",
+ "env_logger",
+ "humantime",
+ "lazy_static",
+ "log",
+ "nkeys",
+ "nuid",
+ "parity-wasm",
+ "ring",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -2441,6 +3011,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "wasmbus-macros"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29134584a9233fe941de00a84ef60006954c48f0b80fca29db54fbb799ac817"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmbus-rpc"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61f6be0a90660de63951fb782dbb37979d03203c60176b6041ec36f6d367136"
+dependencies = [
+ "async-nats 0.27.1",
+ "async-trait",
+ "atty",
+ "base64 0.13.1",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures",
+ "lazy_static",
+ "minicbor 0.17.1",
+ "minicbor-ser",
+ "nkeys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2 0.10.6",
+ "thiserror",
+ "time 0.3.20",
+ "tokio",
+ "toml 0.5.11",
+ "tracing",
+ "tracing-futures",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "uuid",
+ "wascap",
+ "wasmbus-macros",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmcloud-control-interface"
+version = "0.24.0"
+source = "git+https://github.com/thomastaylor312/control-interface-client.git?branch=chore/update_rpc_version#f52f9098233257a140eb2321a161b8388f10992a"
+dependencies = [
+ "async-nats 0.27.1",
+ "cloudevents-sdk 0.6.0",
+ "data-encoding",
+ "futures",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "wasmbus-rpc",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +3099,45 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "weld-codegen"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66385fd8affabb09b678d2f826c78d995789cdb2fbb2dd02e6010dffe298797e"
+dependencies = [
+ "Inflector",
+ "anyhow",
+ "atelier_assembler",
+ "atelier_core",
+ "atelier_json",
+ "atelier_smithy",
+ "bytes",
+ "cfg-if",
+ "clap",
+ "directories",
+ "downloader",
+ "handlebars",
+ "lazy_static",
+ "lexical-sort",
+ "reqwest",
+ "rustc-hash",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "toml 0.7.3",
 ]
 
 [[package]]
@@ -2582,6 +3262,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ default = []
 cli = ["clap", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry", "opentelemetry-otlp", "atty", "uuid"]
 
 [dependencies]
+# workaround for exported NATS deps
+alt_nats = {package = "async-nats", version = "0.23"}
 anyhow = "1"
 async-nats = "0.27"
 async-trait = "0.1"
@@ -16,12 +18,14 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive", "cargo", "env"], optional = true }
 cloudevents-sdk = "0.7"
 futures = "0.3"
+nkeys = "0.2.0"
 # One version back to avoid clashes with 0.10 of otlp
 opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
 # 0.10 to avoid protoc dep
 opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-client"], optional = true }
 # TODO: Actually leverage prometheus
 prometheus = { version = "0.13", optional = true }
+semver = { version = "1.0.16", features = [ "serde" ] }
 serde = "1"
 serde_json = "1"
 sha2 = "0.10.2"
@@ -32,8 +36,7 @@ tracing-futures = "0.2"
 tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"], optional = true }
 uuid = { version = "1", optional = true }
-semver = { version = "1.0.16", features = [ "serde" ] }
-nkeys = "0.2.0"
+wasmcloud-control-interface = "0.24"
 
 [dev-dependencies]
 serial_test = "1"
@@ -42,3 +45,6 @@ serial_test = "1"
 name = "wadm"
 path = "bin/main.rs"
 required-features = ["cli"]
+
+[patch.crates-io]
+wasmcloud-control-interface = { git = "https://github.com/thomastaylor312/control-interface-client.git", branch = "chore/update_rpc_version" }

--- a/bin/nats.rs
+++ b/bin/nats.rs
@@ -37,6 +37,22 @@ pub async fn get_client_and_context(
     Ok((client, context))
 }
 
+pub async fn get_alt_client(
+    url: String,
+    seed: Option<String>,
+    jwt_path: Option<PathBuf>,
+    creds_path: Option<PathBuf>,
+) -> Result<alt_nats::Client> {
+    let client = if seed.is_none() && jwt_path.is_none() && creds_path.is_none() {
+        alt_nats::connect(url).await?
+    } else {
+        let opts = build_alt_nats_options(seed, jwt_path, creds_path).await?;
+        alt_nats::connect_with_options(url, opts).await?
+    };
+
+    Ok(client)
+}
+
 async fn build_nats_options(
     seed: Option<String>,
     jwt_path: Option<PathBuf>,
@@ -53,6 +69,33 @@ async fn build_nats_options(
             }))
         }
         (None, None, Some(creds)) => async_nats::ConnectOptions::with_credentials_file(creds)
+            .await
+            .map_err(anyhow::Error::from),
+        _ => {
+            // We shouldn't ever get here due to the requirements on the flags, but return a helpful error just in case
+            Err(anyhow::anyhow!(
+                "Got too many options. Make sure to provide a seed and jwt or a creds path"
+            ))
+        }
+    }
+}
+
+async fn build_alt_nats_options(
+    seed: Option<String>,
+    jwt_path: Option<PathBuf>,
+    creds_path: Option<PathBuf>,
+) -> Result<alt_nats::ConnectOptions> {
+    match (seed, jwt_path, creds_path) {
+        (Some(seed), Some(jwt), None) => {
+            let jwt = tokio::fs::read_to_string(jwt).await?;
+            let kp = std::sync::Arc::new(get_seed(seed).await?);
+
+            Ok(alt_nats::ConnectOptions::with_jwt(jwt, move |nonce| {
+                let key_pair = kp.clone();
+                async move { key_pair.sign(&nonce).map_err(alt_nats::AuthError::new) }
+            }))
+        }
+        (None, None, Some(creds)) => alt_nats::ConnectOptions::with_credentials_file(creds)
             .await
             .map_err(anyhow::Error::from),
         _ => {

--- a/src/consumers/events.rs
+++ b/src/consumers/events.rs
@@ -13,7 +13,7 @@ use async_nats::{
     Error as NatsError,
 };
 use futures::{Stream, TryStreamExt};
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use super::{CreateConsumer, ScopedMessage};
 use crate::events::*;
@@ -113,7 +113,7 @@ impl Stream for EventConsumer {
                 let evt = match Event::try_from(raw_evt) {
                     Ok(evt) => evt,
                     Err(e) => {
-                        warn!(error = ?e, "Unable to decode as event. Skipping message");
+                        debug!(error = ?e, "Unable to decode as event. Skipping message");
                         let waker = cx.waker().clone();
                         tokio::spawn(async move {
                             if let Err(e) = msg.ack().await {

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -203,18 +203,32 @@ pub struct ActorStarted {
     pub instance_id: String,
     // TODO: Parse as nkey?
     pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
 }
 
-event_impl!(ActorStarted, "com.wasmcloud.lattice.actor_started");
+event_impl!(
+    ActorStarted,
+    "com.wasmcloud.lattice.actor_started",
+    source,
+    host_id
+);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ActorStopped {
     pub instance_id: String,
     // TODO: Parse as nkey?
     pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
 }
 
-event_impl!(ActorStopped, "com.wasmcloud.lattice.actor_stopped");
+event_impl!(
+    ActorStopped,
+    "com.wasmcloud.lattice.actor_stopped",
+    source,
+    host_id
+);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderStarted {
@@ -227,20 +241,31 @@ pub struct ProviderStarted {
     pub link_name: String,
     // TODO: parse as nkey?
     pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
 }
 
-event_impl!(ProviderStarted, "com.wasmcloud.lattice.provider_started");
+event_impl!(
+    ProviderStarted,
+    "com.wasmcloud.lattice.provider_started",
+    source,
+    host_id
+);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderStartFailed {
     pub error: String,
     pub link_name: String,
     pub provider_ref: String,
+    #[serde(default)]
+    pub host_id: String,
 }
 
 event_impl!(
     ProviderStartFailed,
-    "com.wasmcloud.lattice.provider_start_failed"
+    "com.wasmcloud.lattice.provider_start_failed",
+    source,
+    host_id
 );
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -253,30 +278,45 @@ pub struct ProviderStopped {
     pub public_key: String,
     // We should probably do an actual enum here, but elixir definitely isn't doing it
     pub reason: String,
+    #[serde(default)]
+    pub host_id: String,
 }
 
-event_impl!(ProviderStopped, "com.wasmcloud.lattice.provider_stopped");
+event_impl!(
+    ProviderStopped,
+    "com.wasmcloud.lattice.provider_stopped",
+    source,
+    host_id
+);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderHealthCheckPassed {
     #[serde(flatten)]
-    data: ProviderHealthCheckInfo,
+    pub data: ProviderHealthCheckInfo,
+    #[serde(default)]
+    pub host_id: String,
 }
 
 event_impl!(
     ProviderHealthCheckPassed,
-    "com.wasmcloud.lattice.health_check_passed"
+    "com.wasmcloud.lattice.health_check_passed",
+    source,
+    host_id
 );
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProviderHealthCheckFailed {
     #[serde(flatten)]
-    data: ProviderHealthCheckInfo,
+    pub data: ProviderHealthCheckInfo,
+    #[serde(default)]
+    pub host_id: String,
 }
 
 event_impl!(
     ProviderHealthCheckFailed,
-    "com.wasmcloud.lattice.health_check_failed"
+    "com.wasmcloud.lattice.health_check_failed",
+    source,
+    host_id
 );
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod consumers;
 pub mod events;
 pub mod nats_utils;
 pub mod storage;
+pub mod workers;
 
 /// Default amount of time events should stay in the stream. This is the 2x heartbeat interval, plus
 /// some wiggle room. Exported to make setting defaults easy

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,9 +3,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::HashMap, ops::Deref};
 
 pub mod nats_kv;
+pub mod reaper;
 mod state;
 
-pub use state::{Actor, Host, Provider};
+pub use state::{Actor, Host, Provider, ProviderStatus};
 
 /// A trait that must be implemented with a unique identifier for the given type. This is used in
 /// the construction of keys for a store
@@ -25,7 +26,7 @@ pub trait StateKind {
 // struct just to get the ID. If we need the type guarantees in the future, we can always add it in
 #[async_trait]
 pub trait Store {
-    type Error: std::error::Error;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Get the state for the specified kind with the given ID. Returns None if it doesn't exist
     ///
@@ -44,14 +45,30 @@ pub trait Store {
 
     /// Store a piece of state with the given ID. This should overwrite existing state entries
     ///
+    /// By default this will just call [`Store::store_many`] with a single item in the list of data
+    async fn store<T>(&self, lattice_id: &str, id: String, data: T) -> Result<(), Self::Error>
+    where
+        T: Serialize + DeserializeOwned + StateKind + Send,
+    {
+        self.store_many(lattice_id, [(id, data)]).await
+    }
+
+    /// Store multiple items of the same type. This should overwrite existing state entries. This
+    /// allows for stores to perform multiple writes simultaneously or to leverage transactions
+    ///
+    /// The given data can be anything that can be turned into an iterator of (key, value). This
+    /// means you can pass a [`HashMap`](std::collections::HashMap) or something like
+    /// `["key".to_string(), Actor{...}]`
+    ///
     /// This function has several required bounds. It needs to be serialize and deserialize because
     /// some implementations will need to deserialize the current data before modifying it.
     /// [`StateKind`] is needed in order to store and access the data correctly,
     /// and, lastly, [`Send`] is needed because this is an async function and the data needs to be
     /// sendable between threads
-    async fn store<T>(&self, lattice_id: &str, id: String, data: T) -> Result<(), Self::Error>
+    async fn store_many<T, D>(&self, lattice_id: &str, data: D) -> Result<(), Self::Error>
     where
-        T: Serialize + DeserializeOwned + StateKind + Send;
+        T: Serialize + DeserializeOwned + StateKind + Send,
+        D: IntoIterator<Item = (String, T)> + Send;
 
     /// Delete an existing piece of state
     ///
@@ -95,7 +112,7 @@ impl<S: Clone> Clone for ScopedStore<S> {
     }
 }
 
-impl<S: Store> ScopedStore<S> {
+impl<S: Store + Sync> ScopedStore<S> {
     /// Creates a new store scoped to the given lattice ID
     pub fn new(lattice_id: &str, store: S) -> ScopedStore<S> {
         ScopedStore {
@@ -138,6 +155,16 @@ impl<S: Store> ScopedStore<S> {
         self.inner.store(&self.lattice_id, id, data).await
     }
 
+    /// Store multiple items of the same type. This should overwrite existing state entries. This
+    /// allows for stores to perform multiple writes simultaneously or to leverage transactions
+    pub async fn store_many<T, D>(&self, data: D) -> Result<(), S::Error>
+    where
+        T: Serialize + DeserializeOwned + StateKind + Send,
+        D: IntoIterator<Item = (String, T)> + Send,
+    {
+        self.inner.store_many(&self.lattice_id, data).await
+    }
+
     /// Delete an existing piece of state
     pub async fn delete<T>(&self, id: &str) -> Result<(), S::Error>
     where
@@ -149,6 +176,7 @@ impl<S: Store> ScopedStore<S> {
 
 /// A helper function for generating a unique ID for any given provider. This is exposed purely to
 /// be a common way of creating a key to access/store provider information
-pub fn provider_id(public_key: &str, link_name: &str, contract_id: &str) -> String {
-    format!("{}/{}/{}", public_key, link_name, contract_id)
+pub fn provider_id(public_key: &str, link_name: &str) -> String {
+    // TODO: Update this to also use contract ID when 0.62 comes out
+    format!("{}/{}", public_key, link_name)
 }

--- a/src/storage/reaper.rs
+++ b/src/storage/reaper.rs
@@ -1,0 +1,109 @@
+//! Contains helpers for reaping Hosts that haven't received a heartbeat within a configured amount
+//! of time
+
+use std::collections::HashMap;
+
+use chrono::{Duration, Utc};
+use tokio::{task::JoinHandle, time};
+use tracing::{debug, error, info, instrument, trace};
+
+use super::{Host, Store};
+
+/// A struct that can reap various pieces of data from the given store
+pub struct Reaper<S> {
+    store: S,
+    interval: Duration,
+    handles: HashMap<String, JoinHandle<()>>,
+}
+
+impl<S: Store + Clone + Send + Sync + 'static> Reaper<S> {
+    /// Creates a new reaper using the given store configured to check for reaping every
+    /// `check_interval` for all passed lattice IDs. This reaper will immediately begin executing
+    /// spawned tasks. When the reaper is dropped, it will stop polling all tasks. This function
+    /// will panic if you pass it a duration that is larger than the maximum value accepted by the
+    /// `chrono` library. As this is a rare case, we don't actually return an error an panic instead
+    ///
+    /// The reaper will wait for 2 * `check_interval` before removing anything. For example, if
+    /// `check_interval` is set to 30s, then after 30s, the item is considered to be in a "warning"
+    /// state. This isn't actually reflected in state right now, but it will be logged. When the
+    /// next tick fires (around 60s total), then the item will be removed from the store
+    pub fn new(
+        store: S,
+        check_interval: std::time::Duration,
+        lattices_to_observe: impl IntoIterator<Item = String>,
+    ) -> Reaper<S> {
+        let interval = Duration::from_std(check_interval)
+            .expect("The given duration is out of bounds for a max duration value");
+        let cloned_store = store.clone();
+        let handles = lattices_to_observe.into_iter().map(move |id| {
+            (
+                id.clone(),
+                tokio::spawn(reaper_fn(cloned_store.clone(), id, interval)),
+            )
+        });
+        Reaper {
+            store,
+            interval,
+            handles: handles.collect(),
+        }
+    }
+
+    /// Adds a new lattice to be reaped
+    pub fn observe(&mut self, lattice_id: String) {
+        self.handles.insert(
+            lattice_id.clone(),
+            tokio::spawn(reaper_fn(self.store.clone(), lattice_id, self.interval)),
+        );
+    }
+
+    /// Stops observing the given lattice
+    pub fn remove(&mut self, lattice_id: &str) {
+        if let Some(handle) = self.handles.remove(lattice_id) {
+            handle.abort();
+        }
+    }
+}
+
+#[instrument(level = "debug", skip(store))]
+async fn reaper_fn<S: Store>(store: S, lattice_id: String, check_interval: Duration) {
+    debug!("Starting reaper");
+    // SAFETY: We created this Duration from a std Duration, so it should unwrap back just fine
+    let mut ticker = time::interval(check_interval.to_std().unwrap());
+    ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        trace!("Tick fired, fetching host list");
+        let nodes = match store.list::<Host>(&lattice_id).await {
+            Ok(n) => n,
+            Err(e) => {
+                error!(error = %e, "Error when fetching hosts from store. Will retry on next tick");
+                continue;
+            }
+        };
+
+        let hosts_to_remove = nodes.into_iter().filter_map(|(id, host)| {
+            let elapsed = Utc::now() - host.last_seen;
+            if elapsed > (check_interval * 2) {
+                info!(%id, friendly_name = %host.friendly_name, "Host has not been seen for 2 intervals. Will reap node");
+                Some(id)
+            } else if elapsed > check_interval {
+                info!(%id, friendly_name = %host.friendly_name, "Host has not been seen for 1 interval. Next check will reap node from store");
+                None
+            } else {
+                None
+            }
+        });
+
+        // NOTE(thomastaylor): We probably will never be deleting more than a few at a time anyway,
+        // so doing this serially is fine. If it does become a problem, we can add a `delete_many`
+        // function to `Store`
+        for id in hosts_to_remove {
+            if let Err(e) = store.delete::<Host>(&lattice_id, &id).await {
+                error!(error = %e, host_id = %id, "Error when deleting host from store. Will retry on next tick")
+            }
+            info!(host_id = %id, "Removed host from store");
+        }
+        trace!("Completed reap check");
+    }
+}

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -30,6 +30,37 @@ pub struct Provider {
 
     /// The linkname the provider was started with
     pub link_name: String,
+
+    /// The hosts this provider is running on
+    pub hosts: HashMap<String, ProviderStatus>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum ProviderStatus {
+    /// The provider is starting and hasn't returned a heartbeat yet
+    Pending,
+    /// The provider is running
+    Running,
+    /// The provider failed to start
+    // TODO(thomastaylor312): In the future, we'll probably want to decay out a provider from state
+    // if it hasn't had a heartbeat
+    Failed,
+}
+
+impl Default for ProviderStatus {
+    fn default() -> Self {
+        Self::Pending
+    }
+}
+
+impl ToString for ProviderStatus {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Pending => "pending".to_string(),
+            Self::Running => "running".to_string(),
+            Self::Failed => "failed".to_string(),
+        }
+    }
 }
 
 impl StateKind for Provider {
@@ -45,6 +76,7 @@ impl From<ProviderStarted> for Provider {
             contract_id: value.contract_id,
             reference: value.image_ref,
             link_name: value.link_name,
+            hosts: HashMap::from([(value.host_id, ProviderStatus::default())]),
         }
     }
 }
@@ -58,6 +90,7 @@ impl From<&ProviderStarted> for Provider {
             contract_id: value.contract_id.clone(),
             reference: value.image_ref.clone(),
             link_name: value.link_name.clone(),
+            hosts: HashMap::from([(value.host_id.clone(), ProviderStatus::default())]),
         }
     }
 }
@@ -83,11 +116,19 @@ pub struct Actor {
     /// Call alias to use for the actor
     pub call_alias: Option<String>,
 
-    /// The count of actors running in the lattice
-    pub count: usize,
+    /// The count of actors running in the lattice, broken down by host
+    pub count: HashMap<String, usize>,
 
     /// The reference used to start the actor. Can be empty if it was started from a file
     pub reference: String,
+}
+
+impl Actor {
+    /// A helper method that returns the total count of running copies of this actor, regardless of
+    /// which host they are running on
+    pub fn count(&self) -> usize {
+        self.count.values().sum()
+    }
 }
 
 impl StateKind for Actor {
@@ -102,7 +143,7 @@ impl From<ActorStarted> for Actor {
             capabilities: value.claims.capabilites,
             issuer: value.claims.issuer,
             call_alias: value.claims.call_alias,
-            count: 1,
+            count: HashMap::from([(value.host_id, 1)]),
             reference: value.image_ref,
         }
     }
@@ -116,7 +157,7 @@ impl From<&ActorStarted> for Actor {
             capabilities: value.claims.capabilites.clone(),
             issuer: value.claims.issuer.clone(),
             call_alias: value.claims.call_alias.clone(),
-            count: 1,
+            count: HashMap::from([(value.host_id.clone(), 1)]),
             reference: value.image_ref.clone(),
         }
     }

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -1,0 +1,545 @@
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+
+use tracing::{debug, instrument, trace};
+use wasmcloud_control_interface::Client;
+
+use crate::consumers::{
+    manager::{WorkError, WorkResult, Worker},
+    ScopedMessage,
+};
+use crate::events::*;
+use crate::storage::{Actor, Host, Provider, ProviderStatus, Store};
+
+pub struct EventWorker<S> {
+    store: S,
+    ctl_client: Client,
+}
+
+impl<S: Clone> Clone for EventWorker<S> {
+    fn clone(&self) -> Self {
+        EventWorker {
+            store: self.store.clone(),
+            ctl_client: self.ctl_client.clone(),
+        }
+    }
+}
+
+impl<S: Store + Send + Sync> EventWorker<S> {
+    /// Creates a new event worker configured to use the given store and control interface client for fetching state
+    pub fn new(store: S, ctl_client: Client) -> EventWorker<S> {
+        EventWorker { store, ctl_client }
+    }
+
+    // BEGIN HANDLERS
+    // NOTE(thomastaylor312): These use anyhow errors because in the _single_ case where we have to
+    // call the lattice controller, we no longer just have error types from the store. To handle the
+    // multiple error cases, it was just easier to catch it into an anyhow Error and then convert at
+    // the end
+
+    // TODO(thomastaylor312): Initially I thought we'd have to update the host state as well with
+    // the new provider/actor. However, do we actually need to update the host info or just let the
+    // heartbeat take care of it? I think we might be ok because the actor/provider data should have
+    // all the info needed to make a decision for scaling in conjunction with the basic host info
+    // (like labels). We might have to revisit this when a) we implement the `Scaler` trait or b) if
+    // we start serving up lattice state to consumers of wadm (in which case we'd want state changes
+    // reflected immediately)
+
+    #[instrument(level = "debug", skip(self, actor), fields(actor_id = %actor.public_key, host_id = %actor.host_id))]
+    async fn handle_actor_started(
+        &self,
+        lattice_id: &str,
+        actor: &ActorStarted,
+    ) -> anyhow::Result<()> {
+        trace!("Adding newly started actor to store");
+        debug!("Fetching current data for actor");
+        // Because we could have created an actor from the host heartbeat, we just overwrite
+        // everything except counts here
+        let mut actor_data = Actor::from(actor);
+        if let Some(current) = self
+            .store
+            .get::<Actor>(lattice_id, &actor.public_key)
+            .await?
+        {
+            trace!(actor = ?current, "Found existing actor data");
+            // Merge in current counts
+            actor_data.count = current.count;
+        }
+
+        // Update count of the data
+        actor_data
+            .count
+            .entry(actor.host_id.clone())
+            .and_modify(|val| *val += 1)
+            .or_insert(1);
+
+        self.store
+            .store(lattice_id, actor.public_key.clone(), actor_data)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    #[instrument(level = "debug", skip(self, actor), fields(actor_id = %actor.public_key, host_id = %actor.host_id))]
+    async fn handle_actor_stopped(
+        &self,
+        lattice_id: &str,
+        actor: &ActorStopped,
+    ) -> anyhow::Result<()> {
+        trace!("Removing stopped actor from store");
+        debug!("Fetching current data for actor");
+        if let Some(mut current) = self
+            .store
+            .get::<Actor>(lattice_id, &actor.public_key)
+            .await?
+        {
+            trace!(actor = ?current, "Found existing actor data");
+            if let Some(current_count) = current.count.get(&actor.host_id) {
+                let new_count = current_count - 1;
+                if new_count == 0 {
+                    trace!(host_id = %actor.host_id, "Stopped last actor on host, removing host entry from actor");
+                    current.count.remove(&actor.host_id);
+                } else {
+                    trace!(count = %new_count, host_id = %actor.host_id, "Setting current actor");
+                    current.count.insert(actor.host_id.clone(), new_count);
+                }
+            }
+
+            if current.count.is_empty() {
+                debug!("Last actor instance was removed, removing actor from storage");
+                self.store
+                    .delete::<Actor>(lattice_id, &actor.public_key)
+                    .await
+            } else {
+                self.store
+                    .store(lattice_id, actor.public_key.clone(), current)
+                    .await
+            }?;
+        }
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self, host), fields(host_id = %host.id))]
+    async fn handle_host_heartbeat(
+        &self,
+        lattice_id: &str,
+        host: &HostHeartbeat,
+    ) -> anyhow::Result<()> {
+        debug!("Updating store with current host heartbeat information");
+        // Host updates just overwrite current information, so no need to fetch
+        let host_data = Host::from(host);
+        self.store
+            .store(lattice_id, host.id.clone(), host_data)
+            .await?;
+
+        // NOTE: We can return an error here and then nack because we'll just reupdate the host data
+        // with the exact same host heartbeat entry. There is no possibility of a duplicate
+        self.heartbeat_provider_update(lattice_id, host).await?;
+
+        // NOTE: We can return an error here and then nack because we'll just reupdate the host data
+        // with the exact same host heartbeat entry. There is no possibility of a duplicate
+        self.heartbeat_actor_update(lattice_id, host).await?;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self, host), fields(host_id = %host.id))]
+    async fn handle_host_started(
+        &self,
+        lattice_id: &str,
+        host: &HostStarted,
+    ) -> anyhow::Result<()> {
+        debug!("Updating store with new host");
+        // New hosts have nothing running on them yet, so just drop it in the store
+        self.store
+            .store(lattice_id, host.id.clone(), Host::from(host))
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    #[instrument(level = "debug", skip(self, host), fields(host_id = %host.id))]
+    async fn handle_host_stopped(
+        &self,
+        lattice_id: &str,
+        host: &HostStopped,
+    ) -> anyhow::Result<()> {
+        debug!("Handling host stopped event");
+        // NOTE(thomastaylor312): Generally to get a host stopped event, the host should have
+        // already sent a bunch of stop actor/provider events, but for correctness sake, we fetch
+        // the current host and make sure all the actors and providers are removed
+        trace!("Fetching current host data");
+        let current: Host = match self.store.get(lattice_id, &host.id).await? {
+            Some(h) => h,
+            None => {
+                debug!("Got host stopped event for a host we didn't have in the store");
+                return Ok(());
+            }
+        };
+
+        trace!("Fetching actors from store to remove stopped instances");
+        let all_actors = self.store.list::<Actor>(lattice_id).await?;
+
+        let actors_to_update = all_actors.into_iter().filter_map(|(id, mut actor)| {
+            if current.actors.contains_key(&id) {
+                actor.count.remove(&current.id);
+                Some((id, actor))
+            } else {
+                None
+            }
+        });
+        trace!("Storing updated actors in store");
+        self.store.store_many(lattice_id, actors_to_update).await?;
+
+        trace!("Fetching providers from store to remove stopped instances");
+        let mut all_providers = self.store.list::<Provider>(lattice_id).await?;
+
+        let providers_to_update = current.providers.into_iter().filter_map(|info| {
+            let key = crate::storage::provider_id(&info.public_key, &info.link_name);
+            let mut prov = all_providers.remove(&key)?;
+            prov.hosts.remove(&host.id).map(|_| (key, prov))
+        });
+        trace!("Storing updated providers in store");
+        self.store
+            .store_many(lattice_id, providers_to_update)
+            .await?;
+
+        // Order matters here: Now that we've cleaned stuff up, remove the host. We do this last
+        // because if any of the above fails after we remove the host, we won't be able to fetch the
+        // data to remove the actors and providers on a retry.
+        debug!("Deleting host from store");
+        self.store
+            .delete::<Host>(lattice_id, &host.id)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    #[instrument(
+        level = "debug",
+        skip(self, provider),
+        fields(
+            public_key = %provider.public_key,
+            link_name = %provider.link_name,
+            contract_id = %provider.contract_id
+        )
+    )]
+    async fn handle_provider_started(
+        &self,
+        lattice_id: &str,
+        provider: &ProviderStarted,
+    ) -> anyhow::Result<()> {
+        debug!("Handling provider started event");
+        let id = crate::storage::provider_id(&provider.public_key, &provider.link_name);
+        trace!("Fetching current data from store");
+        let provider_data = if let Some(mut current) =
+            self.store.get::<Provider>(lattice_id, &id).await?
+        {
+            // Using the entry api is a bit more efficient because we do a single key lookup
+            match current.hosts.entry(provider.host_id.clone()) {
+                Entry::Occupied(_) => {
+                    trace!("Found host entry for the provider already in store. Returning early");
+                    return Ok(());
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(ProviderStatus::default());
+                    current
+                }
+            }
+        } else {
+            trace!("No current provider found in store");
+            Provider::from(provider)
+        };
+        debug!("Storing updated provider in store");
+        self.store
+            .store(lattice_id, id, provider_data)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    #[instrument(
+        level = "debug",
+        skip(self, provider),
+        fields(
+            public_key = %provider.public_key,
+            link_name = %provider.link_name,
+            contract_id = %provider.contract_id
+        )
+    )]
+    async fn handle_provider_stopped(
+        &self,
+        lattice_id: &str,
+        provider: &ProviderStopped,
+    ) -> anyhow::Result<()> {
+        debug!("Handling provider stopped event");
+        let id = crate::storage::provider_id(&provider.public_key, &provider.link_name);
+        trace!("Fetching current data from store");
+        if let Some(mut current) = self.store.get::<Provider>(lattice_id, &id).await? {
+            if current.hosts.remove(&provider.host_id).is_none() {
+                trace!(host_id = %provider.host_id, "Did not find host entry in provider");
+                return Ok(());
+            }
+            if current.hosts.is_empty() {
+                debug!("Provider is no longer running on any hosts. Removing from store");
+                self.store
+                    .delete::<Provider>(lattice_id, &id)
+                    .await
+                    .map_err(anyhow::Error::from)
+            } else {
+                debug!("Storing updated provider");
+                self.store
+                    .store(lattice_id, id, current)
+                    .await
+                    .map_err(anyhow::Error::from)
+            }
+        } else {
+            trace!("No current provider found in store");
+            Ok(())
+        }
+    }
+
+    #[instrument(
+        level = "debug",
+        skip(self, provider),
+        fields(
+            public_key = %provider.public_key,
+            link_name = %provider.link_name,
+        )
+    )]
+    async fn handle_provider_health_check(
+        &self,
+        lattice_id: &str,
+        host_id: &str,
+        provider: &ProviderHealthCheckInfo,
+        failed: bool,
+    ) -> anyhow::Result<()> {
+        debug!("Handling provider health check event");
+        trace!("Getting current provider");
+        let id = crate::storage::provider_id(&provider.public_key, &provider.link_name);
+        let mut current: Provider = match self.store.get(lattice_id, &id).await? {
+            Some(p) => p,
+            None => {
+                trace!("Didn't find provider in store. Creating");
+                Provider {
+                    id: provider.public_key.clone(),
+                    link_name: provider.link_name.clone(),
+                    ..Default::default()
+                }
+            }
+        };
+        debug!("Updating store with current status");
+        let status = if failed {
+            ProviderStatus::Failed
+        } else {
+            ProviderStatus::Running
+        };
+        current.hosts.insert(host_id.to_owned(), status);
+        self.store
+            .store(lattice_id, id, current)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    // END HANDLER FUNCTIONS
+    async fn populate_actor_info(
+        &self,
+        mut actor_ids: HashSet<String>,
+        host_id: &str,
+        count_map: &HashMap<String, usize>,
+    ) -> anyhow::Result<Vec<(String, Actor)>> {
+        let resp = self
+            .ctl_client
+            .get_claims()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        Ok(resp
+            .claims
+            .into_iter()
+            .filter_map(|mut claim| {
+                let sub = claim.get("sub").map(|s| s.as_str()).unwrap_or_default();
+
+                actor_ids.take(sub).map(|id| {
+                    (
+                        id.clone(),
+                        Actor {
+                            id: id.clone(),
+                            name: claim.remove("name").unwrap_or_default(),
+                            capabilities: claim
+                                .remove("caps")
+                                .map(|raw| raw.split(',').map(|s| s.to_owned()).collect())
+                                .unwrap_or_default(),
+                            issuer: claim.remove("iss").unwrap_or_default(),
+                            count: [(
+                                host_id.to_owned(),
+                                count_map.get(&id).copied().unwrap_or_default(),
+                            )]
+                            .into(),
+                            ..Default::default()
+                        },
+                    )
+                })
+            })
+            .collect())
+    }
+
+    #[instrument(level = "debug", skip(self, host), fields(host_id = %host.id))]
+    async fn heartbeat_actor_update(
+        &self,
+        lattice_id: &str,
+        host: &HostHeartbeat,
+    ) -> anyhow::Result<()> {
+        debug!("Fetching current actor state");
+        let mut actors = self.store.list::<Actor>(lattice_id).await?;
+
+        let missing_actors: HashSet<String> = host
+            .actors
+            .iter()
+            .filter_map(|(id, _)| (!actors.contains_key(id)).then_some(id))
+            .cloned()
+            .collect();
+
+        // TODO: FIXME
+
+        let actors_to_update = host.actors.iter().filter_map(|(id, count)| {
+            match actors.remove(id) {
+                Some(mut current) => {
+                    // An actor count should never be 0, so defaulting is fine. If we didn't modify the count, skip
+                    if current
+                        .count
+                        .insert(host.id.clone(), *count)
+                        .unwrap_or_default()
+                        == *count
+                    {
+                        None
+                    } else {
+                        Some((id.to_owned(), current))
+                    }
+                }
+                None => None,
+            }
+        });
+
+        let actors_to_update: Vec<(String, Actor)> = if !missing_actors.is_empty() {
+            trace!(num_actors = %missing_actors.len(), "Fetching claims for missing actors");
+            actors_to_update
+                .chain(
+                    self.populate_actor_info(missing_actors, &host.id, &host.actors)
+                        .await?,
+                )
+                .collect()
+        } else {
+            actors_to_update.collect()
+        };
+
+        trace!("Updating actors with new status from host");
+
+        self.store.store_many(lattice_id, actors_to_update).await?;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self, host), fields(host_id = %host.id))]
+    async fn heartbeat_provider_update(
+        &self,
+        lattice_id: &str,
+        host: &HostHeartbeat,
+    ) -> anyhow::Result<()> {
+        debug!("Fetching current provider state");
+        let mut providers = self.store.list::<Provider>(lattice_id).await?;
+        let providers_to_update = host.providers.iter().filter_map(|info| {
+            let provider_id = crate::storage::provider_id(&info.public_key, &info.link_name);
+            match providers.remove(&provider_id) {
+                Some(mut prov) => {
+                    let mut has_changes = false;
+                    // A health check from a provider we hadn't registered doesn't have a link name,
+                    // so check if that needs to be set
+                    if prov.link_name.is_empty() {
+                        prov.link_name = info.link_name.clone();
+                        has_changes = true;
+                    }
+                    if let Entry::Vacant(entry) = prov.hosts.entry(host.id.clone()) {
+                        entry.insert(ProviderStatus::default());
+                        has_changes = true;
+                    }
+                    if has_changes {
+                        Some((provider_id, prov))
+                    } else {
+                        None
+                    }
+                }
+                None => {
+                    // If we don't already have the provider, create a basic one so we know it
+                    // exists at least. The next provider heartbeat will fix it for us
+                    Some((
+                        provider_id,
+                        Provider {
+                            id: info.public_key.clone(),
+                            contract_id: info.contract_id.clone(),
+                            link_name: info.link_name.clone(),
+                            hosts: [(host.id.clone(), ProviderStatus::default())].into(),
+                            ..Default::default()
+                        },
+                    ))
+                }
+            }
+        });
+
+        trace!("Updating providers with new status from host");
+        self.store
+            .store_many(lattice_id, providers_to_update)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: Store + Send + Sync> Worker for EventWorker<S> {
+    type Message = Event;
+
+    #[instrument(level = "debug", skip(self))]
+    async fn do_work(&self, mut message: ScopedMessage<Self::Message>) -> WorkResult<()> {
+        let res = match message.as_ref() {
+            Event::ActorStarted(actor) => {
+                self.handle_actor_started(&message.lattice_id, actor).await
+            }
+            Event::ActorStopped(actor) => {
+                self.handle_actor_stopped(&message.lattice_id, actor).await
+            }
+            Event::HostHeartbeat(host) => {
+                self.handle_host_heartbeat(&message.lattice_id, host).await
+            }
+            Event::HostStarted(host) => self.handle_host_started(&message.lattice_id, host).await,
+            Event::HostStopped(host) => self.handle_host_stopped(&message.lattice_id, host).await,
+            Event::LinkdefDeleted(_ld) => {
+                // TODO: This will need to be handled when we start managing applications
+                Ok(())
+            }
+            Event::ProviderStarted(provider) => {
+                self.handle_provider_started(&message.lattice_id, provider)
+                    .await
+            }
+            Event::ProviderStopped(provider) => {
+                self.handle_provider_stopped(&message.lattice_id, provider)
+                    .await
+            }
+            Event::ProviderHealthCheckPassed(ProviderHealthCheckPassed { data, host_id }) => {
+                self.handle_provider_health_check(&message.lattice_id, host_id, data, false)
+                    .await
+            }
+            Event::ProviderHealthCheckFailed(ProviderHealthCheckFailed { data, host_id }) => {
+                self.handle_provider_health_check(&message.lattice_id, host_id, data, true)
+                    .await
+            }
+            // All other events we don't care about for state.
+            _ => {
+                trace!("Got event we don't care about. Skipping");
+                Ok(())
+            }
+        }
+        .map_err(Box::<dyn std::error::Error + Send + 'static>::from);
+
+        // NOTE: This is where the call to scaler types will go
+        if let Err(e) = res {
+            message.nack().await;
+            return Err(WorkError::Other(e));
+        }
+        message.ack().await.map_err(WorkError::from)
+    }
+}

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1,0 +1,7 @@
+//! Various [`Worker`](crate::consumers::manager::Worker) implementations for reconciling and
+//! handling events and commands. These are essentially the default things that drive work forward
+//! in wadm
+
+mod event;
+
+pub use event::EventWorker;

--- a/tests/storage_nats_kv.rs
+++ b/tests/storage_nats_kv.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 
 use wadm::{
     events::ProviderInfo,
-    storage::{nats_kv::NatsKvStore, Actor, Host, Provider, Store as WadmStore},
+    storage::{nats_kv::NatsKvStore, Actor, Host, Provider, ProviderStatus, Store as WadmStore},
 };
 
 /// Helper function that sets up a store with the given ID as its name. This ID should be unique per
@@ -49,7 +49,7 @@ async fn test_round_trip() {
         name: "Test Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: 1,
+        count: HashMap::from([("testhost".to_string(), 1)]),
         reference: "fake.oci.repo/testactor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -59,7 +59,7 @@ async fn test_round_trip() {
         name: "Another Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: 1,
+        count: HashMap::from([("testhost".to_string(), 1)]),
         reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -85,6 +85,7 @@ async fn test_round_trip() {
         contract_id: "wasmcloud:httpserver".to_string(),
         reference: "fake.oci.repo/testprovider:0.1.0".to_string(),
         link_name: "default".to_string(),
+        hosts: [("testhost".to_string(), ProviderStatus::default())].into(),
     };
 
     store
@@ -92,8 +93,7 @@ async fn test_round_trip() {
         .await
         .expect("Should be able to store a host");
 
-    let provider_id =
-        wadm::storage::provider_id(&provider.id, &provider.link_name, &provider.contract_id);
+    let provider_id = wadm::storage::provider_id(&provider.id, &provider.link_name);
     store
         .store(lattice_id, provider_id.clone(), provider.clone())
         .await
@@ -223,7 +223,7 @@ async fn test_multiple_lattice() {
         name: "Test Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: 1,
+        count: HashMap::from([("testhost".to_string(), 1)]),
         reference: "fake.oci.repo/testactor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -233,7 +233,7 @@ async fn test_multiple_lattice() {
         name: "Another Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: 1,
+        count: HashMap::from([("testhost".to_string(), 1)]),
         reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -276,5 +276,64 @@ async fn test_multiple_lattice() {
     assert_eq!(
         actor.name, actor2.name,
         "Should have returned the correct actor"
+    );
+}
+
+#[tokio::test]
+async fn test_store_many() {
+    let store = NatsKvStore::new(create_test_store("store_many_test".to_string()).await);
+
+    let lattice_id = "storemany";
+
+    let actor1 = Actor {
+        id: "testactor".to_string(),
+        name: "Test Actor".to_string(),
+        capabilities: vec!["wasmcloud:httpserver".to_string()],
+        issuer: "afakekey".to_string(),
+        count: HashMap::from([("testhost".to_string(), 1)]),
+        reference: "fake.oci.repo/testactor:0.1.0".to_string(),
+        ..Default::default()
+    };
+
+    let actor2 = Actor {
+        id: "anotheractor".to_string(),
+        name: "Another Actor".to_string(),
+        capabilities: vec!["wasmcloud:httpserver".to_string()],
+        issuer: "afakekey".to_string(),
+        count: HashMap::from([("testhost".to_string(), 1)]),
+        reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
+        ..Default::default()
+    };
+
+    store
+        .store_many(
+            lattice_id,
+            [
+                (actor1.id.clone(), actor1.clone()),
+                (actor2.id.clone(), actor2.clone()),
+            ],
+        )
+        .await
+        .expect("Should be able to store multiple actors");
+
+    let all_actors = store
+        .list::<Actor>(lattice_id)
+        .await
+        .expect("Should be able to get all actors");
+
+    assert_eq!(
+        all_actors.len(),
+        2,
+        "Should have found the correct number of actors"
+    );
+    assert!(
+        all_actors.contains_key(&actor1.id),
+        "Should have found actor with id {}",
+        actor1.id
+    );
+    assert!(
+        all_actors.contains_key(&actor2.id),
+        "Should have found actor with id {}",
+        actor2.id
     );
 }


### PR DESCRIPTION
This PR adds state generation based off of incoming events. Honestly, I would love for this code to be cleaner, but for now I think this works fine. I've tried to document the code well so people can follow along.

Integration tests will be added in a follow up, but I did test this locally with two wasmcloud hosts and two wadm processes running, while checking the state with `nats kv get`.