### PR TITLE
Added parser to serialize and deserialize OAM manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1667,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "serial_test"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2359,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sha2 0.10.6",
  "thiserror",
@@ -2590,6 +2609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-clie
 prometheus = { version = "0.13", optional = true }
 serde = "1"
 serde_json = "1"
+serde_yaml = "0.8.7"
 sha2 = "0.10.2"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/oam/simple1.json
+++ b/oam/simple1.json
@@ -1,0 +1,88 @@
+{
+    "apiVersion": "core.oam.dev/v1beta1",
+    "kind": "Application",
+    "metadata": {
+        "name": "my-example-app",
+        "annotations": {
+            "version": "v0.0.1",
+            "description": "This is my app"
+        }
+    },
+    "spec": {
+        "components": [
+            {
+                "name": "userinfo",
+                "type": "actor",
+                "properties": {
+                    "image": "wasmcloud.azurecr.io/fake:1"
+                },
+                "traits": [
+                    {
+                        "type": "spreadscaler",
+                        "properties": {
+                            "replicas": 4,
+                            "spread": [
+                                {
+                                    "name": "eastcoast",
+                                    "requirements": {
+                                        "zone": "us-east-1"
+                                    },
+                                    "weight": 80
+                                },
+                                {
+                                    "name": "westcoast",
+                                    "requirements": {
+                                        "zone": "us-west-1"
+                                    },
+                                    "weight": 20
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "linkdef",
+                        "properties": {
+                            "target": "webcap",
+                            "values": {
+                                "port": 8080
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "webcap",
+                "type": "capability",
+                "properties": {
+                    "contract": "wasmcloud:httpserver",
+                    "image": "wasmcloud.azurecr.io/httpserver:0.13.1",
+                    "link_name": "default"
+                }
+            },
+            {
+                "name": "ledblinky",
+                "type": "capability",
+                "properties": {
+                    "image": "wasmcloud.azurecr.io/ledblinky:0.0.1",
+                    "contract": "wasmcloud:blinkenlights"
+                },
+                "traits": [
+                    {
+                        "type": "spreadscaler",
+                        "properties": {
+                            "replicas": 1,
+                            "spread": [
+                                {
+                                    "name": "haslights",
+                                    "requirements": {
+                                        "ledenabled": true
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,5 +1,6 @@
 mod data;
 mod deser;
+mod parser;
 mod ser;
 mod types;
 

--- a/src/events/parser.rs
+++ b/src/events/parser.rs
@@ -1,28 +1,27 @@
-use anyhow::Result;
-use serde_json;
-use serde_yaml;
 use std::collections::BTreeMap;
-use std::io::BufReader;
-use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+pub const DEFAULT_WEIGHT: i32 = 100;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ComponentType {
-    actor,
-    capability,
+    #[serde(rename = "actor")]
+    Actor,
+    #[serde(rename = "capability")]
+    Capability,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Annotations {
-    version: String,
-    description: String,
+    pub version: String,
+    pub description: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Metadata {
-    name: String,
-    annotations: Annotations,
+    pub name: String,
+    pub annotations: Annotations,
 }
 
 fn default_link_name() -> Option<String> {
@@ -31,118 +30,128 @@ fn default_link_name() -> Option<String> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Properties {
-    image: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    contract: Option<String>,
+    pub image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract: Option<String>,
     #[serde(default = "default_link_name", skip_serializing_if = "Option::is_none")]
-    link_name: Option<String>,
+    pub link_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum TraitType {
-    spreadscaler,
-    linkdef,
-}
-#[derive(Debug, Serialize, Deserialize)]
-pub enum SpreadRequirements {
-    app(String),
-    zone(String),
-    ledenabled(bool),
+    #[serde(rename = "spreadscaler")]
+    Spreadscaler,
+    #[serde(rename = "linkdef")]
+    Linkdef,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum LinkdefValueItems {
-    uri(String),
-    address(String),
-    port(i32),
+pub struct LinkdefValueItems {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<i32>,
 }
 
 fn default_weight() -> Option<i32> {
-    Some(100)
+    Some(DEFAULT_WEIGHT)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SpreadRequirementValues {
     String(String),
-    bool(bool),
-    i32(i32),
-    char(char),
+    Bool(bool),
+    I32(i32),
+    Char(char),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Spread {
-    name: String,
-    requirements: BTreeMap<String, SpreadRequirementValues>,
+    pub name: String,
+    pub requirements: BTreeMap<String, SpreadRequirementValues>,
     #[serde(default = "default_weight", skip_serializing_if = "Option::is_none")]
-    weight: Option<i32>,
+    pub weight: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinkdefProperty {
+    pub target: String,
+    pub values: LinkdefValueItems,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SpreadScalerProperty {
+    pub replicas: i32,
+    pub spread: Vec<Spread>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TraitPropertyItem {
-    LinkdefProperty {
-        target: String,
-        values: LinkdefValueItems,
-    },
-    SpreadScalerProperty {
-        replicas: i32,
-        spread: Vec<Spread>,
-    },
+    LinkdefProperty(LinkdefProperty),
+    SpreadScalerProperty(SpreadScalerProperty),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Traits {
     #[serde(rename = "type")]
-    trait_type: TraitType,
-    properties: TraitPropertyItem,
+    pub trait_type: TraitType,
+    pub properties: TraitPropertyItem,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ComponentItem {
-    name: String,
+    pub name: String,
     #[serde(rename = "type")]
-    component_type: ComponentType,
-    properties: Properties,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    traits: Option<Vec<Traits>>,
+    pub component_type: ComponentType,
+    pub properties: Properties,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traits: Option<Vec<Traits>>,
 }
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Components {
-    components: Vec<ComponentItem>,
+    pub components: Vec<ComponentItem>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Manifest {
-    apiVersion: String,
-    kind: String,
-    metadata: Metadata,
-    spec: Components,
-}
-
-pub(crate) fn deserialize_yaml(filepath: PathBuf) -> Result<Manifest> {
-    let file = std::fs::File::open(filepath)?;
-    let reader = BufReader::new(file);
-    let yaml_string: Manifest = serde_yaml::from_reader(reader)?;
-    println!("Read YAML string: {:?}", yaml_string);
-    Ok(yaml_string)
-}
-
-pub(crate) fn deserialize_json(filepath: PathBuf) -> Result<Manifest> {
-    let file = std::fs::File::open(filepath)?;
-    let reader = BufReader::new(file);
-    let json_string: Manifest = serde_json::from_reader(reader)?;
-    println!("Read JSON string: {:?}", json_string);
-    Ok(json_string)
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: Metadata,
+    pub spec: Components,
 }
 
 #[cfg(test)]
 mod test {
 
     use super::*;
+    use anyhow::Result;
+    use serde_json;
+    use serde_yaml;
+    use std::io::BufReader;
+    use std::path::PathBuf;
+    pub(crate) fn deserialize_yaml(filepath: PathBuf) -> Result<Manifest> {
+        let file = std::fs::File::open(filepath)?;
+        let reader = BufReader::new(file);
+        let yaml_string: Manifest = serde_yaml::from_reader(reader)?;
+        println!("Read YAML string: {:?}", yaml_string);
+        Ok(yaml_string)
+    }
+
+    pub(crate) fn deserialize_json(filepath: PathBuf) -> Result<Manifest> {
+        let file = std::fs::File::open(filepath)?;
+        let reader = BufReader::new(file);
+        let json_string: Manifest = serde_json::from_reader(reader)?;
+        println!("Read JSON string: {:?}", json_string);
+        Ok(json_string)
+    }
 
     #[test]
-    fn test_oam_desrializer() {
+    fn test_oam_deserializer() {
         let filepath = PathBuf::from("./oam/simple1.json");
         let res = deserialize_json(filepath);
         match res {
@@ -159,8 +168,8 @@ mod test {
     }
     #[test]
     fn test_oam_serializer() {
-        let mut spreadVec: Vec<Spread> = Vec::new();
-        let spreadItem = Spread {
+        let mut spread_vec: Vec<Spread> = Vec::new();
+        let spread_item = Spread {
             name: "eastcoast".to_string(),
             requirements: BTreeMap::from([(
                 "zone".to_string(),
@@ -168,8 +177,8 @@ mod test {
             )]),
             weight: Some(80),
         };
-        spreadVec.push(spreadItem);
-        let spreadItem = Spread {
+        spread_vec.push(spread_item);
+        let spread_item = Spread {
             name: "westcoast".to_string(),
             requirements: BTreeMap::from([(
                 "zone".to_string(),
@@ -177,39 +186,45 @@ mod test {
             )]),
             weight: Some(20),
         };
-        spreadVec.push(spreadItem);
-        let mut traitVec: Vec<Traits> = Vec::new();
-        let traitItem = Traits {
-            trait_type: TraitType::spreadscaler,
-            properties: TraitPropertyItem::SpreadScalerProperty {
-                replicas: 4,
-                spread: spreadVec,
+        spread_vec.push(spread_item);
+        let mut trait_vec: Vec<Traits> = Vec::new();
+        let spreadscalerprop = SpreadScalerProperty {
+            replicas: 4,
+            spread: spread_vec,
+        };
+        let trait_item = Traits {
+            trait_type: TraitType::Spreadscaler,
+            properties: TraitPropertyItem::SpreadScalerProperty(spreadscalerprop),
+        };
+        trait_vec.push(trait_item);
+        let linkdefprop = LinkdefProperty {
+            target: "webcap".to_string(),
+            values: LinkdefValueItems {
+                uri: None,
+                address: None,
+                port: Some(4000),
             },
         };
-        traitVec.push(traitItem);
-        let traitItem = Traits {
-            trait_type: TraitType::linkdef,
-            properties: TraitPropertyItem::LinkdefProperty {
-                target: "webcap".to_string(),
-                values: LinkdefValueItems::port(4000),
-            },
+        let trait_item = Traits {
+            trait_type: TraitType::Linkdef,
+            properties: TraitPropertyItem::LinkdefProperty(linkdefprop),
         };
-        traitVec.push(traitItem);
-        let mut componentVec: Vec<ComponentItem> = Vec::new();
-        let componentItem = ComponentItem {
+        trait_vec.push(trait_item);
+        let mut component_vec: Vec<ComponentItem> = Vec::new();
+        let component_item = ComponentItem {
             name: "userinfo".to_string(),
-            component_type: ComponentType::actor,
+            component_type: ComponentType::Actor,
             properties: Properties {
                 image: "wasmcloud.azurecr.io/fake:1".to_string(),
                 contract: None,
                 link_name: None,
             },
-            traits: Some(traitVec),
+            traits: Some(trait_vec),
         };
-        componentVec.push(componentItem);
-        let componentItem = ComponentItem {
+        component_vec.push(component_item);
+        let component_item = ComponentItem {
             name: "webcap".to_string(),
-            component_type: ComponentType::capability,
+            component_type: ComponentType::Capability,
             properties: Properties {
                 image: "wasmcloud.azurecr.io/httpserver:0.13.1".to_string(),
                 contract: Some("wasmcloud:httpserver".to_string()),
@@ -217,41 +232,42 @@ mod test {
             },
             traits: None,
         };
-        componentVec.push(componentItem);
+        component_vec.push(component_item);
 
-        let mut spreadVec: Vec<Spread> = Vec::new();
-        let spreadItem = Spread {
+        let mut spread_vec: Vec<Spread> = Vec::new();
+        let spread_item = Spread {
             name: "haslights".to_string(),
             requirements: BTreeMap::from([(
                 "zone".to_string(),
-                SpreadRequirementValues::bool(true),
+                SpreadRequirementValues::Bool(true),
             )]),
             weight: default_weight(),
         };
-        spreadVec.push(spreadItem);
-        let mut traitVec: Vec<Traits> = Vec::new();
-        let traitItem = Traits {
-            trait_type: TraitType::spreadscaler,
-            properties: TraitPropertyItem::SpreadScalerProperty {
-                replicas: 1,
-                spread: spreadVec,
-            },
+        spread_vec.push(spread_item);
+        let spreadscalerprop = SpreadScalerProperty {
+            replicas: 1,
+            spread: spread_vec,
         };
-        traitVec.push(traitItem);
-        let componentItem = ComponentItem {
+        let mut trait_vec: Vec<Traits> = Vec::new();
+        let trait_item = Traits {
+            trait_type: TraitType::Spreadscaler,
+            properties: TraitPropertyItem::SpreadScalerProperty(spreadscalerprop),
+        };
+        trait_vec.push(trait_item);
+        let component_item = ComponentItem {
             name: "ledblinky".to_string(),
-            component_type: ComponentType::capability,
+            component_type: ComponentType::Capability,
             properties: Properties {
                 image: "wasmcloud.azurecr.io/ledblinky:0.0.1".to_string(),
                 contract: Some("wasmcloud:blinkenlights".to_string()),
                 link_name: default_link_name(),
             },
-            traits: Some(traitVec),
+            traits: Some(trait_vec),
         };
-        componentVec.push(componentItem);
+        component_vec.push(component_item);
 
         let spec = Components {
-            components: componentVec,
+            components: component_vec,
         };
         let metadata = Metadata {
             name: "my-example-app".to_string(),
@@ -261,17 +277,19 @@ mod test {
             },
         };
         let manifest = Manifest {
-            apiVersion: "core.oam.dev/v1beta1".to_string(),
+            api_version: "core.oam.dev/v1beta1".to_string(),
             kind: "application".to_string(),
-            metadata: metadata,
-            spec: spec,
+            metadata,
+            spec,
         };
         let serialized_json = serde_json::to_string(&manifest);
+
         match serialized_json {
             Ok(parse_results) => parse_results,
             Err(error) => panic!("Error {:?}", error),
         };
         let serialized_yaml = serde_yaml::to_string(&manifest);
+
         match serialized_yaml {
             Ok(parse_results) => parse_results,
             Err(error) => panic!("Error {:?}", error),

--- a/src/events/parser.rs
+++ b/src/events/parser.rs
@@ -1,0 +1,280 @@
+use anyhow::Result;
+use serde_json;
+use serde_yaml;
+use std::collections::BTreeMap;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ComponentType {
+    actor,
+    capability,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Annotations {
+    version: String,
+    description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    name: String,
+    annotations: Annotations,
+}
+
+fn default_link_name() -> Option<String> {
+    Some("default".to_string())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Properties {
+    image: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    contract: Option<String>,
+    #[serde(default = "default_link_name", skip_serializing_if = "Option::is_none")]
+    link_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum TraitType {
+    spreadscaler,
+    linkdef,
+}
+#[derive(Debug, Serialize, Deserialize)]
+pub enum SpreadRequirements {
+    app(String),
+    zone(String),
+    ledenabled(bool),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum LinkdefValueItems {
+    uri(String),
+    address(String),
+    port(i32),
+}
+
+fn default_weight() -> Option<i32> {
+    Some(100)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SpreadRequirementValues {
+    String(String),
+    bool(bool),
+    i32(i32),
+    char(char),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Spread {
+    name: String,
+    requirements: BTreeMap<String, SpreadRequirementValues>,
+    #[serde(default = "default_weight", skip_serializing_if = "Option::is_none")]
+    weight: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TraitPropertyItem {
+    LinkdefProperty {
+        target: String,
+        values: LinkdefValueItems,
+    },
+    SpreadScalerProperty {
+        replicas: i32,
+        spread: Vec<Spread>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Traits {
+    #[serde(rename = "type")]
+    trait_type: TraitType,
+    properties: TraitPropertyItem,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComponentItem {
+    name: String,
+    #[serde(rename = "type")]
+    component_type: ComponentType,
+    properties: Properties,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    traits: Option<Vec<Traits>>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Components {
+    components: Vec<ComponentItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manifest {
+    apiVersion: String,
+    kind: String,
+    metadata: Metadata,
+    spec: Components,
+}
+
+pub(crate) fn deserialize_yaml(filepath: PathBuf) -> Result<Manifest> {
+    let file = std::fs::File::open(filepath)?;
+    let reader = BufReader::new(file);
+    let yaml_string: Manifest = serde_yaml::from_reader(reader)?;
+    println!("Read YAML string: {:?}", yaml_string);
+    Ok(yaml_string)
+}
+
+pub(crate) fn deserialize_json(filepath: PathBuf) -> Result<Manifest> {
+    let file = std::fs::File::open(filepath)?;
+    let reader = BufReader::new(file);
+    let json_string: Manifest = serde_json::from_reader(reader)?;
+    println!("Read JSON string: {:?}", json_string);
+    Ok(json_string)
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_oam_desrializer() {
+        let filepath = PathBuf::from("./oam/simple1.json");
+        let res = deserialize_json(filepath);
+        match res {
+            Ok(parse_results) => parse_results,
+            Err(error) => panic!("Error {:?}", error),
+        };
+
+        let filepath = PathBuf::from("./oam/simple1.yaml");
+        let res = deserialize_yaml(filepath);
+        match res {
+            Ok(parse_results) => parse_results,
+            Err(error) => panic!("Error {:?}", error),
+        };
+    }
+    #[test]
+    fn test_oam_serializer() {
+        let mut spreadVec: Vec<Spread> = Vec::new();
+        let spreadItem = Spread {
+            name: "eastcoast".to_string(),
+            requirements: BTreeMap::from([(
+                "zone".to_string(),
+                SpreadRequirementValues::String("us-east-1".to_string()),
+            )]),
+            weight: Some(80),
+        };
+        spreadVec.push(spreadItem);
+        let spreadItem = Spread {
+            name: "westcoast".to_string(),
+            requirements: BTreeMap::from([(
+                "zone".to_string(),
+                SpreadRequirementValues::String("us-west-1".to_string()),
+            )]),
+            weight: Some(20),
+        };
+        spreadVec.push(spreadItem);
+        let mut traitVec: Vec<Traits> = Vec::new();
+        let traitItem = Traits {
+            trait_type: TraitType::spreadscaler,
+            properties: TraitPropertyItem::SpreadScalerProperty {
+                replicas: 4,
+                spread: spreadVec,
+            },
+        };
+        traitVec.push(traitItem);
+        let traitItem = Traits {
+            trait_type: TraitType::linkdef,
+            properties: TraitPropertyItem::LinkdefProperty {
+                target: "webcap".to_string(),
+                values: LinkdefValueItems::port(4000),
+            },
+        };
+        traitVec.push(traitItem);
+        let mut componentVec: Vec<ComponentItem> = Vec::new();
+        let componentItem = ComponentItem {
+            name: "userinfo".to_string(),
+            component_type: ComponentType::actor,
+            properties: Properties {
+                image: "wasmcloud.azurecr.io/fake:1".to_string(),
+                contract: None,
+                link_name: None,
+            },
+            traits: Some(traitVec),
+        };
+        componentVec.push(componentItem);
+        let componentItem = ComponentItem {
+            name: "webcap".to_string(),
+            component_type: ComponentType::capability,
+            properties: Properties {
+                image: "wasmcloud.azurecr.io/httpserver:0.13.1".to_string(),
+                contract: Some("wasmcloud:httpserver".to_string()),
+                link_name: Some("default".to_string()),
+            },
+            traits: None,
+        };
+        componentVec.push(componentItem);
+
+        let mut spreadVec: Vec<Spread> = Vec::new();
+        let spreadItem = Spread {
+            name: "haslights".to_string(),
+            requirements: BTreeMap::from([(
+                "zone".to_string(),
+                SpreadRequirementValues::bool(true),
+            )]),
+            weight: default_weight(),
+        };
+        spreadVec.push(spreadItem);
+        let mut traitVec: Vec<Traits> = Vec::new();
+        let traitItem = Traits {
+            trait_type: TraitType::spreadscaler,
+            properties: TraitPropertyItem::SpreadScalerProperty {
+                replicas: 1,
+                spread: spreadVec,
+            },
+        };
+        traitVec.push(traitItem);
+        let componentItem = ComponentItem {
+            name: "ledblinky".to_string(),
+            component_type: ComponentType::capability,
+            properties: Properties {
+                image: "wasmcloud.azurecr.io/ledblinky:0.0.1".to_string(),
+                contract: Some("wasmcloud:blinkenlights".to_string()),
+                link_name: default_link_name(),
+            },
+            traits: Some(traitVec),
+        };
+        componentVec.push(componentItem);
+
+        let spec = Components {
+            components: componentVec,
+        };
+        let metadata = Metadata {
+            name: "my-example-app".to_string(),
+            annotations: Annotations {
+                version: "v0.0.1".to_string(),
+                description: "This is my app".to_string(),
+            },
+        };
+        let manifest = Manifest {
+            apiVersion: "core.oam.dev/v1beta1".to_string(),
+            kind: "application".to_string(),
+            metadata: metadata,
+            spec: spec,
+        };
+        let serialized_json = serde_json::to_string(&manifest);
+        match serialized_json {
+            Ok(parse_results) => parse_results,
+            Err(error) => panic!("Error {:?}", error),
+        };
+        let serialized_yaml = serde_yaml::to_string(&manifest);
+        match serialized_yaml {
+            Ok(parse_results) => parse_results,
+            Err(error) => panic!("Error {:?}", error),
+        };
+    }
+}


### PR DESCRIPTION
## Feature or Problem
Parses OAM manifests for warm. Supports YAML and JSON configurations and converts them into in memory Rust structs.

## Related Issues
#43 

## Release Information
next

## Consumer Impact
Will support parsing option for manifests

## Testing
Unit tests added

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
test_oam_deserializer
test_oam_serializer

### Acceptance or Integration
NA

### Manual Verification
Manually verified with existing YAML/JSON files.
