### PR TITLE
Modified spread requirements to be a simple Map

### DIFF
--- a/oam/simple1.json
+++ b/oam/simple1.json
@@ -75,7 +75,7 @@
                                 {
                                     "name": "haslights",
                                     "requirements": {
-                                        "ledenabled": true
+                                        "ledstatus": "enabled"
                                     }
                                 }
                             ]

--- a/oam/simple1.yaml
+++ b/oam/simple1.yaml
@@ -50,5 +50,5 @@ spec:
             spread:
               - name: haslights
                 requirements:
-                  ledenabled: true
+                  ledstatus: enabled
                 # default weight is 100

--- a/oam/simple2.yaml
+++ b/oam/simple2.yaml
@@ -49,4 +49,4 @@ spec:
             spread:
               - name: haslights
                 requirements:
-                  ledenabled: true                
+                  ledstatus: enabled                

--- a/src/events/parser.rs
+++ b/src/events/parser.rs
@@ -60,18 +60,9 @@ fn default_weight() -> Option<i32> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum SpreadRequirementValues {
-    String(String),
-    Bool(bool),
-    I32(i32),
-    Char(char),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct Spread {
     pub name: String,
-    pub requirements: BTreeMap<String, SpreadRequirementValues>,
+    pub requirements: BTreeMap<String, String>,
     #[serde(default = "default_weight", skip_serializing_if = "Option::is_none")]
     pub weight: Option<i32>,
 }
@@ -171,19 +162,13 @@ mod test {
         let mut spread_vec: Vec<Spread> = Vec::new();
         let spread_item = Spread {
             name: "eastcoast".to_string(),
-            requirements: BTreeMap::from([(
-                "zone".to_string(),
-                SpreadRequirementValues::String("us-east-1".to_string()),
-            )]),
+            requirements: BTreeMap::from([("zone".to_string(), "us-east-1".to_string())]),
             weight: Some(80),
         };
         spread_vec.push(spread_item);
         let spread_item = Spread {
             name: "westcoast".to_string(),
-            requirements: BTreeMap::from([(
-                "zone".to_string(),
-                SpreadRequirementValues::String("us-west-1".to_string()),
-            )]),
+            requirements: BTreeMap::from([("zone".to_string(), "us-west-1".to_string())]),
             weight: Some(20),
         };
         spread_vec.push(spread_item);
@@ -237,10 +222,7 @@ mod test {
         let mut spread_vec: Vec<Spread> = Vec::new();
         let spread_item = Spread {
             name: "haslights".to_string(),
-            requirements: BTreeMap::from([(
-                "zone".to_string(),
-                SpreadRequirementValues::Bool(true),
-            )]),
+            requirements: BTreeMap::from([("zone".to_string(), "enabled".to_string())]),
             weight: default_weight(),
         };
         spread_vec.push(spread_item);


### PR DESCRIPTION
Modified spread requirements to be a simple Map
Modified tests and OAM manifests to contain strings only

## Feature or Problem
Extension to #66 that changes Spread requirements to be a BTreeMap with keys and values as <String, String> instead of the earlier <String, SpreadRequirementValues> which consisted an enum of a variety of values. 
Modified the sample manifests to contain string values as well instead of the earlier present boolean values.

## Related Issues
#66 

## Release Information
next

## Consumer Impact
If other components are using the manifests, they need to accommodate for the new values in them.

## Testing
Unit tests added

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Unit test modified -
test_oam_deserializer
test_oam_serializer

### Acceptance or Integration
NA

### Manual Verification
Manually verified the test results.
