### PR TITLE
Scaler trait and sample implementation with a SimpleScaler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod consumers;
 pub mod events;
 pub mod model;
 pub mod nats_utils;
+pub mod scaler;
 pub mod server;
 pub mod storage;
 pub mod workers;

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -2,15 +2,16 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashSet;
 
-use crate::{commands::Command, events::Event, storage::ReadStore};
+use crate::{commands::Command, events::Event};
 
 mod simplescaler;
 
 /// A trait describing a struct that can be configured to compute the difference between
 /// desired state and configured state, returning a set of commands to approach desired state.
 ///
-/// State is given to a scaler using a [ReadStore](crate::storage::ReadStore) so that it can retrieve
-/// current information from the proper store without changing state directly.
+/// Implementers of this trait can choose how to access state, but it's generally recommended to
+/// use a [ReadStore](crate::storage::ReadStore) so that it can retrieve current information about
+/// state using a common trait that only allows store access and not modification
 ///
 /// Typically a Scaler should be configured with `update_config`, then use the `reconcile` method
 /// for an inital set of commands. As events change the state, they should also be given to the Scaler
@@ -23,12 +24,8 @@ pub trait Scaler {
     fn update_config(&mut self, config: Self::Config) -> Result<bool>;
 
     /// Compute commands that must be taken given an event that changes the lattice state
-    async fn handle_event<S: ReadStore + Send + Sync>(
-        &self,
-        store: S,
-        event: Event,
-    ) -> Result<HashSet<Command>>;
+    async fn handle_event(&self, event: Event) -> Result<HashSet<Command>>;
 
     /// Compute commands that must be taken to achieve desired state as specified in config
-    async fn reconcile<S: ReadStore + Send + Sync>(&self, store: S) -> Result<HashSet<Command>>;
+    async fn reconcile(&self) -> Result<HashSet<Command>>;
 }

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashSet;
+
+use crate::{commands::Command, events::Event, storage::ReadStore};
+
+mod simplescaler;
+
+/// A trait describing a struct that can be configured to compute the difference between
+/// desired state and configured state, returning a set of commands to approach desired state.
+///
+/// State is given to a scaler using a [ReadStore](crate::storage::ReadStore) so that it can retrieve
+/// current information from the proper store without changing state directly.
+///
+/// Typically a Scaler should be configured with `update_config`, then use the `reconcile` method
+/// for an inital set of commands. As events change the state, they should also be given to the Scaler
+/// to determine if actions need to be taken in response to an event
+#[async_trait]
+pub trait Scaler {
+    type Config: Send + Sync;
+
+    /// Provide a scaler with configuration to use internally when computing commands
+    fn update_config(&mut self, config: Self::Config) -> Result<bool>;
+
+    /// Compute commands that must be taken given an event that changes the lattice state
+    async fn handle_event<S: ReadStore + Send + Sync>(
+        &self,
+        store: S,
+        event: Event,
+    ) -> Result<HashSet<Command>>;
+
+    /// Compute commands that must be taken to achieve desired state as specified in config
+    async fn reconcile<S: ReadStore + Send + Sync>(&self, store: S) -> Result<HashSet<Command>>;
+}

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -1,0 +1,387 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashSet;
+
+use crate::{
+    commands::{Command, StartActor, StopActor},
+    events::Event,
+    scaler::Scaler,
+    storage::{Actor, Host, ReadStore},
+};
+
+/// Config for a SimpleActorScaler, which ensures that an actor as referenced by
+/// `actor_reference` in lattice `lattice_id` runs with `replicas` replicas
+struct SimpleScalerConfig {
+    // Sourced from the component `image` property
+    actor_reference: String,
+    // Sourced from the lattice that the scaler is configured on
+    lattice_id: String,
+    // Required configuration in the `simplescaler` block
+    replicas: usize,
+}
+
+/// The SimpleScaler ensures that a certain number of replicas are running
+/// for a certain public key.
+///
+/// This is primarily to demonstrate the functionality and ergonomics of the
+/// [Scaler](crate::scaler::Scaler) trait and doesn't make any guarantees
+/// about spreading replicas evenly
+struct SimpleActorScaler {
+    pub config: SimpleScalerConfig,
+}
+
+#[async_trait]
+impl Scaler for SimpleActorScaler {
+    type Config = SimpleScalerConfig;
+
+    fn update_config(&mut self, config: Self::Config) -> Result<bool> {
+        self.config = config;
+        Ok(true)
+    }
+
+    async fn handle_event<S: ReadStore + Send + Sync>(
+        &self,
+        store: S,
+        event: Event,
+    ) -> Result<HashSet<Command>> {
+        match event {
+            Event::ActorStarted(_) | Event::ActorStopped(_) | Event::HostStopped(_) => {
+                self.compute_actor_commands(store).await
+            }
+            // No other event impacts the job of this scaler so we can ignore it
+            _ => Ok(HashSet::new()),
+        }
+    }
+
+    async fn reconcile<S: ReadStore + Send + Sync>(&self, store: S) -> Result<HashSet<Command>> {
+        self.compute_actor_commands(store).await
+    }
+}
+
+impl SimpleActorScaler {
+    #[allow(unused)]
+    /// Construct a new SimpleActorScaler with specified configuration values
+    fn new(actor_reference: String, lattice_id: String, replicas: usize) -> Self {
+        Self {
+            config: SimpleScalerConfig {
+                actor_reference,
+                lattice_id,
+                replicas,
+            },
+        }
+    }
+
+    /// Given a readable store containing the state of the lattice, compute the
+    /// required commands to either stop extra actor instances or start new
+    /// actor instances to reach the configured replica count
+    async fn compute_actor_commands<S: ReadStore + Send + Sync>(
+        &self,
+        store: S,
+    ) -> Result<HashSet<Command>> {
+        // NOTE(brooksmtownsend): This will fail to look up the actor ID if an actor is not running in the lattice currently.
+        // This is acceptable for the simplescaler but might require a helper function in the future
+        let actor_id = store
+            .list::<Actor>(&self.config.lattice_id)
+            .await?
+            .iter()
+            .find(|(_id, actor)| actor.reference == self.config.actor_reference)
+            .map(|(id, _actor)| id.to_owned())
+            // Default here means the below `get` will find zero running actors, which is fine because
+            // that accurately describes the current lattice having zero instances.
+            .unwrap_or_default();
+
+        Ok(
+            match store
+                .get::<Actor>(&self.config.lattice_id, &actor_id)
+                .await?
+            {
+                Some(actors) => {
+                    // NOTE(brooksmtownsend): This should ideally take into account the annotations to ensure the actors
+                    // we're comparing against are wadm managed actors
+                    let count = self.config.replicas as i16 - actors.count() as i16;
+
+                    // It doesn't read cleaner to do this in a comparison chain
+                    #[allow(clippy::comparison_chain)]
+                    if count > 0 {
+                        // Choosing to retrieve the first host that an actor is running on over querying the store for efficiency
+                        let host_id = actors.count.keys().next().cloned().unwrap_or_default();
+
+                        HashSet::from_iter([Command::StartActor(StartActor {
+                            reference: self.config.actor_reference.to_owned(),
+                            count: count as usize, // It's a positive integer so we know this will succeed
+                            host_id,
+                        })])
+                    } else if count < 0 {
+                        // This is written iteratively rather than functionally just because it reads better.
+                        let mut remaining = count.unsigned_abs() as usize;
+                        let mut commands = HashSet::new();
+
+                        // For each host running this actor, request actor stops until
+                        // the total number of stops equals the number of extra instances
+                        for (host_id, count) in actors.count {
+                            if remaining == 0 {
+                                break;
+                            } else if remaining >= count {
+                                commands.insert(Command::StopActor(StopActor {
+                                    actor_id: actor_id.to_owned(),
+                                    host_id,
+                                    count,
+                                }));
+                                remaining -= count;
+                            } else {
+                                commands.insert(Command::StopActor(StopActor {
+                                    actor_id: actor_id.to_owned(),
+                                    host_id,
+                                    count: remaining,
+                                }));
+                                remaining = 0;
+                            }
+                        }
+
+                        commands
+                    } else {
+                        HashSet::new()
+                    }
+                }
+                None => {
+                    if let Some(host_id) = store
+                        .list::<Host>(&self.config.lattice_id)
+                        .await?
+                        .iter()
+                        .next()
+                        .map(|(host_id, _host)| host_id)
+                    {
+                        HashSet::from_iter([Command::StartActor(StartActor {
+                            reference: self.config.actor_reference.to_owned(),
+                            count: self.config.replicas,
+                            host_id: host_id.to_owned(),
+                        })])
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "No hosts running, unable to return actor start commands"
+                        ));
+                    }
+                }
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, sync::Arc};
+
+    use crate::{
+        commands::{Command, StartActor},
+        consumers::{manager::Worker, ScopedMessage},
+        events::{ActorClaims, ActorStarted, Event, HostStarted},
+        scaler::{simplescaler::SimpleActorScaler, Scaler},
+        test_util::TestStore,
+        workers::EventWorker,
+    };
+
+    #[tokio::test]
+    async fn can_return_error_with_no_hosts() {
+        let lattice_id = "hoohah_no_host";
+        let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let replicas = 12;
+
+        let store = Arc::new(TestStore::default());
+        let simple_scaler =
+            SimpleActorScaler::new(actor_reference, lattice_id.to_string(), replicas);
+
+        let cmds = simple_scaler.reconcile(store).await;
+        assert!(cmds.is_err());
+        assert_eq!(
+            cmds.unwrap_err().to_string(),
+            "No hosts running, unable to return actor start commands".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn can_request_start_actor() {
+        let lattice_id = "hoohah_start_actor";
+        let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let replicas = 12;
+
+        // *** STATE SETUP BEGIN ***
+        // Lattice State: One empty host
+
+        let store = Arc::new(TestStore::default());
+        let worker = EventWorker::new(store.clone(), HashMap::default());
+
+        let host_id = "NASDASDIAMAREALHOST".to_string();
+        let host_name = "I am a real host".to_string();
+
+        let labels = HashMap::from([("real".to_string(), "true".to_string())]);
+
+        worker
+            .do_work(ScopedMessage::<Event> {
+                lattice_id: lattice_id.to_string(),
+                inner: Event::HostStarted(HostStarted {
+                    labels,
+                    friendly_name: host_name,
+                    id: host_id.to_string(),
+                }),
+                acker: None,
+            })
+            .await
+            .expect("Should be able to handle the host started event");
+        // *** STATE SETUP END ***
+        // Expected Actions: Start 12 replicas of the actor on the one host
+
+        let simple_scaler = SimpleActorScaler::new(
+            actor_reference.to_string(),
+            lattice_id.to_string(),
+            replicas,
+        );
+
+        let cmds = simple_scaler
+            .reconcile(store)
+            .await
+            .expect("Should have computed a set of commands");
+        assert_eq!(cmds.len(), 1);
+        let command = cmds
+            .iter()
+            .next()
+            .expect("Should have computed one command");
+        assert_eq!(
+            command,
+            &Command::StartActor(StartActor {
+                reference: actor_reference,
+                host_id,
+                count: replicas
+            })
+        )
+    }
+
+    #[tokio::test]
+    async fn can_request_multiple_stop_actor() {
+        let lattice_id = "hoohah_multi_stop_actor";
+        let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let actor_id = "MASDASDIAMAREALACTOR";
+        let replicas = 2;
+
+        let store = Arc::new(TestStore::default());
+        let worker = EventWorker::new(store.clone(), HashMap::default());
+
+        // *** STATE SETUP BEGIN ***
+        // Lattice State: One host with 4 instances of the actor, and one host with 3 instances
+
+        let host_id_1 = "NASDASDIAMAREALHOST".to_string();
+        let host_name_1 = "I am a real host".to_string();
+        let host_id_2 = "NASDASDIAMAREALHOSTV2FINAL".to_string();
+        let host_name_2 = "I am a real host v2 final".to_string();
+
+        let labels = HashMap::from([("real".to_string(), "true".to_string())]);
+
+        worker
+            .do_work(ScopedMessage::<Event> {
+                lattice_id: lattice_id.to_string(),
+                inner: Event::HostStarted(HostStarted {
+                    labels: labels.clone(),
+                    friendly_name: host_name_1,
+                    id: host_id_1.to_string(),
+                }),
+                acker: None,
+            })
+            .await
+            .expect("Should be able to handle the host started event");
+
+        worker
+            .do_work(ScopedMessage::<Event> {
+                lattice_id: lattice_id.to_string(),
+                inner: Event::HostStarted(HostStarted {
+                    labels,
+                    friendly_name: host_name_2,
+                    id: host_id_2.to_string(),
+                }),
+                acker: None,
+            })
+            .await
+            .expect("Should be able to handle the host started event");
+
+        for n in 0..4 {
+            // Start 4 actors on the first host
+            worker
+                .do_work(ScopedMessage::<Event> {
+                    lattice_id: lattice_id.to_string(),
+                    inner: Event::ActorStarted(ActorStarted {
+                        annotations: HashMap::new(),
+                        api_version: 1, // ??
+                        claims: dummy_actor_claims(),
+                        image_ref: actor_reference.to_string(),
+                        instance_id: format!("{actor_id}_{host_id_1}_{n}"),
+                        public_key: actor_id.to_string(),
+                        host_id: host_id_1.to_string(),
+                    }),
+                    acker: None,
+                })
+                .await
+                .expect("Should be able to handle the actor started event");
+        }
+
+        for n in 0..3 {
+            // Start 3 actors on the second host
+            worker
+                .do_work(ScopedMessage::<Event> {
+                    lattice_id: lattice_id.to_string(),
+                    inner: Event::ActorStarted(ActorStarted {
+                        annotations: HashMap::new(),
+                        api_version: 1, // ??
+                        claims: dummy_actor_claims(),
+                        image_ref: actor_reference.to_string(),
+                        instance_id: format!("{actor_id}_{host_id_2}_{n}"),
+                        public_key: actor_id.to_string(),
+                        host_id: host_id_2.to_string(),
+                    }),
+                    acker: None,
+                })
+                .await
+                .expect("Should be able to handle the actor started event");
+        }
+        // *** STATE SETUP END ***
+        // Expected Actions: Two ActorStop commands, requesting either (depending on map order):
+        // - 4 stopped actors on the first host and 1 on the other
+        // - 2 stopped actors on the first host and 3 on the other
+
+        let simple_scaler = SimpleActorScaler::new(
+            actor_reference.to_string(),
+            lattice_id.to_string(),
+            replicas,
+        );
+
+        let cmds = simple_scaler
+            .reconcile(store)
+            .await
+            .expect("Should have computed a set of commands");
+
+        assert_eq!(cmds.len(), 2);
+
+        // Asserting we requested 5 total stops, whether 4 and 1 or 3 and 2
+        let stop_count_requested = cmds
+            .iter()
+            .map(|cmd| match cmd {
+                Command::StopActor(stop_cmd) => stop_cmd.count,
+                _ => panic!("unexpected command in list"),
+            })
+            .sum::<usize>();
+
+        assert_eq!(stop_count_requested, 5)
+    }
+
+    // helper function to Returns dummy actor claims object
+    fn dummy_actor_claims() -> ActorClaims {
+        ActorClaims {
+            call_alias: None,
+            capabilites: vec![],
+            expires_human: "N/A".to_string(),
+            issuer: "AASDASDIAMAREALISSUER".to_string(),
+            name: "real actor".to_string(),
+            not_before_human: "N/A".to_string(),
+            revision: 1,
+            tags: None,
+            version: "v0.1.0".to_string(),
+        }
+    }
+}

--- a/src/storage/nats_kv.rs
+++ b/src/storage/nats_kv.rs
@@ -24,7 +24,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, error, field::Empty, instrument, trace};
 use tracing_futures::Instrument;
 
-use super::{StateKind, Store};
+use super::{ReadStore, StateKind, Store};
 
 /// Errors that can be encountered by NATS KV Store implemenation
 #[derive(Debug, thiserror::Error)]
@@ -97,7 +97,7 @@ impl NatsKvStore {
 // https://morestina.net/blog/1843/the-stable-hashmap-trap). We can also swap out encoding formats
 // to something like bincode or cbor and focus on things like avoiding allocations
 #[async_trait]
-impl Store for NatsKvStore {
+impl ReadStore for NatsKvStore {
     type Error = NatsStoreError;
 
     /// Get the state for the specified kind with the given ID.
@@ -131,7 +131,10 @@ impl Store for NatsKvStore {
             .await
             .map(|(data, _)| data)
     }
+}
 
+#[async_trait]
+impl Store for NatsKvStore {
     /// Store multiple items of the same type. This should overwrite existing state entries. This
     /// allows for stores to perform multiple writes simultaneously or to leverage transactions
     ///

--- a/src/storage/reaper.rs
+++ b/src/storage/reaper.rs
@@ -238,7 +238,10 @@ mod test {
     use super::*;
     use std::{collections::HashSet, sync::Arc};
 
-    use crate::{storage::ProviderStatus, test_util::TestStore};
+    use crate::{
+        storage::{ProviderStatus, ReadStore},
+        test_util::TestStore,
+    };
 
     #[tokio::test]
     async fn test_reaping() {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -16,7 +16,7 @@ pub struct TestStore {
 }
 
 #[async_trait::async_trait]
-impl crate::storage::Store for TestStore {
+impl crate::storage::ReadStore for TestStore {
     type Error = Infallible;
 
     async fn get<T>(&self, lattice_id: &str, id: &str) -> Result<Option<T>, Self::Error>
@@ -48,7 +48,10 @@ impl crate::storage::Store for TestStore {
             .map(|raw| serde_json::from_slice(raw).unwrap())
             .unwrap_or_default())
     }
+}
 
+#[async_trait::async_trait]
+impl crate::storage::Store for TestStore {
     async fn store_many<T, D>(&self, lattice_id: &str, data: D) -> Result<(), Self::Error>
     where
         T: Serialize + DeserializeOwned + StateKind + Send,

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -626,7 +626,7 @@ mod test {
 
     use super::*;
 
-    use crate::test_util::TestStore;
+    use crate::{storage::ReadStore, test_util::TestStore};
 
     #[async_trait::async_trait]
     impl ClaimsSource for HashMap<String, Claims> {

--- a/tests/storage_nats_kv.rs
+++ b/tests/storage_nats_kv.rs
@@ -4,7 +4,9 @@ use chrono::Utc;
 
 use wadm::{
     events::ProviderInfo,
-    storage::{nats_kv::NatsKvStore, Actor, Host, Provider, ProviderStatus, Store as WadmStore},
+    storage::{
+        nats_kv::NatsKvStore, Actor, Host, Provider, ProviderStatus, ReadStore, Store as WadmStore,
+    },
 };
 
 mod helpers;


### PR DESCRIPTION
## Primary Reviewer
@thomastaylor312 

The Scaler trait, which defines a trait that can be implemented to handle the scaling of a single component (be it actors, linkdefs, or providers) looks like this:
```rust
#[async_trait]
pub trait Scaler {
    type Config: Send + Sync;

    /// Provide a scaler with configuration to use internally when computing commands
    fn update_config(&mut self, config: Self::Config) -> Result<bool>;

    /// Compute commands that must be taken given an event that changes the lattice state
    async fn handle_event<S: ReadStore + Send + Sync>(
        &self,
        store: S,
        event: Event,
    ) -> Result<HashSet<Command>>;

    /// Compute commands that must be taken to achieve desired state as specified in config
    async fn reconcile<S: ReadStore + Send + Sync>(&self, store: S) -> Result<HashSet<Command>>;
}
```

Essentially, you construct a scaler and give it configuration to use for events, and then it has a function you can call at any point to reconcile between current and desired state. Each event coming in that updates the state should also be passed to the scaler, which can then trigger compensating commands to return to desired state. The `reconcile` function can also be used as a helper function to determine if the Scaler is currently satisfied (e.g. `scaler.reconcile(store).unwrap().is_empty()`)

This PR includes a sample implementation, `SimpleActorScaler`, that uses a set config to compute required start/stop actor commands to reach a number of replicas. If it would better illustrate the flexibility of the trait, I could also add in a `SimpleProviderScaler` or `SimpleLinkdefScaler` which monitors events, but I felt the actor implementation would be enough to illustrate.

## Feature or Problem
Addresses #48 

## Related Issues
#48 

## Release Information
wadm_0.4

## Consumer Impact
Consumers of wadm can implement their own scalers with custom config, specified in a manifest. 

This PR also separates the `Store` trait into a `ReadStore` and a supertrait `Store: ReadStore`. This allows a single Store implementation to easily give read-only access to a store to different code paths, which is useful to ensure that state is not modified when it only needs to be queried.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Wrote two basic unit tests to ensure the SimpleActorScaler can handle enforcing a number of actor replicas on a lattice

### Acceptance or Integration
Unit tests

### Manual Verification
Creating the simplescaler is partial manual verification that the API is ergonomic and works well to describe what kind of thing we are trying to assert with a Scaler. I ensured that I wrote a test to validate that the `Hash` implementation does not block us from returning, say, two StopActor commands with different parameters.
