### PR TITLE
feat(api): Implements all model operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2865,6 +2866,7 @@ dependencies = [
  "clap",
  "cloudevents-sdk 0.7.0",
  "futures",
+ "indexmap",
  "nkeys",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive", "cargo", "env"], optional = true }
 cloudevents-sdk = "0.7"
 futures = "0.3"
+indexmap = { version = "1", features = ["serde-1"] }
 nkeys = "0.2.0"
 # One version back to avoid clashes with 0.10 of otlp
 opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod consumers;
 pub mod events;
 pub mod model;
 pub mod nats_utils;
+pub mod server;
 pub mod storage;
 pub mod workers;
 

--- a/src/model/internal.rs
+++ b/src/model/internal.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::model::Manifest;
 use crate::storage::StateKind;
 
+/// This struct represents a single manfiest, with its version history. Internally these are stored
+/// as an indexmap keyed by version name
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct StoredManifest {
     // Ordering matters for how we store a manifest, so we need to use an index map to preserve
@@ -94,7 +96,7 @@ impl StoredManifest {
     }
 
     /// Returns whether or not this is a new (empty) manifest
-    pub fn is_new(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.manifests.is_empty()
     }
 

--- a/src/model/internal.rs
+++ b/src/model/internal.rs
@@ -1,0 +1,105 @@
+//! Contains the internal storage definition of a manifest
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::model::Manifest;
+use crate::storage::StateKind;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub(crate) struct StoredManifest {
+    // Ordering matters for how we store a manifest, so we need to use an index map to preserve
+    // insertion order _and_ have quick access to specific versions
+    manifests: IndexMap<String, Manifest>,
+    // Set only if a version is deployed
+    deployed_version: Option<String>,
+    // TODO: Figure out which status to store (probably just the status for each component). We can
+    // convert it to the external facing type from the server as needed
+}
+
+impl StateKind for StoredManifest {
+    const KIND: &'static str = "manifest";
+}
+
+impl StoredManifest {
+    /// Gets the current version of the manifest
+    pub fn current_version(&self) -> &str {
+        self.manifests
+            .last()
+            .map(|(v, _)| v.as_str())
+            .unwrap_or_default()
+    }
+
+    /// Adds the given manifest, returning `false` if unable to add (e.g. the version already
+    /// exists)
+    pub fn add_version(&mut self, manifest: Manifest) -> bool {
+        let version = manifest.version().to_owned();
+        if self.manifests.contains_key(&version) {
+            return false;
+        }
+        self.manifests.insert(version, manifest);
+        true
+    }
+
+    /// Deletes the given version from the manifest. Returning true if it was deleted
+    pub fn delete_version(&mut self, version: &str) -> bool {
+        self.manifests.shift_remove(version).is_some()
+    }
+
+    /// Returns an iterator over all stored manifests in creation order
+    pub fn all_manifests(&self) -> impl IntoIterator<Item = &Manifest> {
+        self.manifests.values()
+    }
+
+    /// Returns an iterator over all stored versions in creation order
+    pub fn all_versions(&self) -> impl IntoIterator<Item = &String> {
+        self.manifests.keys()
+    }
+
+    /// Returns a reference to the deployed version (if it is set)
+    pub fn deployed_version(&self) -> Option<&str> {
+        self.deployed_version.as_deref()
+    }
+
+    /// Helper method that returns true if the given version number was deployed
+    pub fn is_deployed(&self, version: &str) -> bool {
+        self.deployed_version
+            .as_deref()
+            .map(|v| v == version)
+            .unwrap_or(false)
+    }
+
+    /// Sets this manifest as undeployed
+    pub fn undeploy(&mut self) {
+        self.deployed_version = None
+    }
+
+    /// Sets the given version as the deployed manifest
+    pub fn deploy(&mut self, version: &str) {
+        self.deployed_version = Some(version.to_owned())
+    }
+
+    /// Returns a reference to the current manifest
+    pub fn get_current(&self) -> &Manifest {
+        // SAFETY: This is internal usage only so we will always have at least one thing in here.
+        // Panicking here means programmer error
+        self.manifests
+            .last()
+            .map(|(_, v)| v)
+            .expect("A manifest should always exist. This is programmer error")
+    }
+
+    /// Gets a reference to the specified version of the manifest
+    pub fn get_version(&self, version: &str) -> Option<&Manifest> {
+        self.manifests.get(version)
+    }
+
+    /// Returns whether or not this is a new (empty) manifest
+    pub fn is_new(&self) -> bool {
+        self.manifests.is_empty()
+    }
+
+    /// Returns the total count of manifests
+    pub fn count(&self) -> usize {
+        self.manifests.len()
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -22,7 +22,7 @@ pub const VERSION_ANNOTATION_KEY: &str = "version";
 pub const DESCRIPTION_ANNOTATION_KEY: &str = "description";
 
 /// An OAM manifest
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Manifest {
     /// The OAM version of the manifest
     #[serde(rename = "apiVersion")]
@@ -55,7 +55,7 @@ impl Manifest {
 }
 
 /// The metadata describing the manifest
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Metadata {
     /// The name of the manifest. This should be unique
     pub name: String,
@@ -65,14 +65,14 @@ pub struct Metadata {
 }
 
 /// A representation of an OAM specification
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Specification {
     /// The list of components for describing an application
     pub components: Vec<Component>,
 }
 
 /// A component definition
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Component {
     /// The name of this component
     pub name: String,
@@ -89,7 +89,7 @@ pub struct Component {
 }
 
 /// All possible component types we support
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ComponentType {
     /// An Actor component
     #[serde(rename = "actor")]
@@ -100,20 +100,20 @@ pub enum ComponentType {
 }
 
 /// Properties that can be defined for a component
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Properties {
     Actor(ActorProperties),
     Capability(CapabilityProperties),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActorProperties {
     /// The image reference to use
     pub image: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CapabilityProperties {
     /// The image reference to use
     pub image: String,
@@ -124,7 +124,7 @@ pub struct CapabilityProperties {
     pub link_name: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Trait {
     /// The type of trait specified
     // NOTE(thomastaylor312): Same thing goes here as described in the note for Component. We should
@@ -136,7 +136,7 @@ pub struct Trait {
 }
 
 /// All supported trait types in wadm
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum TraitType {
     /// A spreadscaler trait
     #[serde(rename = "spreadscaler")]
@@ -147,7 +147,7 @@ pub enum TraitType {
 }
 
 /// Properties for defining traits
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum TraitProperty {
     Linkdef(LinkdefProperty),
@@ -155,7 +155,7 @@ pub enum TraitProperty {
 }
 
 /// Properties for linkdefs
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LinkdefProperty {
     /// The target this linkdef applies to. This should be the name of an actor component
     pub target: String,
@@ -165,7 +165,7 @@ pub struct LinkdefProperty {
 }
 
 /// Properties for spread scalers
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SpreadScalerProperty {
     /// Number of replicas to scale
     pub replicas: usize,
@@ -174,7 +174,7 @@ pub struct SpreadScalerProperty {
 }
 
 /// Configuration for various spreading requirements
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Spread {
     /// The name of this spread requirement
     pub name: String,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+pub(crate) mod internal;
+
 /// The default weight for a spread
 pub const DEFAULT_SPREAD_WEIGHT: usize = 100;
 /// The default link name
@@ -12,6 +14,12 @@ pub const OAM_VERSION: &str = "core.oam.dev/v1beta1";
 // NOTE(thomastaylor312): If we ever end up supporting more than one kind, we should use an enum for
 // this
 pub const APPLICATION_KIND: &str = "Application";
+/// The version key, as predefined by the [OAM
+/// spec](https://github.com/oam-dev/spec/blob/master/metadata.md#annotations-format)
+pub const VERSION_ANNOTATION_KEY: &str = "version";
+/// The description key, as predefined by the [OAM
+/// spec](https://github.com/oam-dev/spec/blob/master/metadata.md#annotations-format)
+pub const DESCRIPTION_ANNOTATION_KEY: &str = "description";
 
 /// An OAM manifest
 #[derive(Debug, Serialize, Deserialize)]
@@ -25,6 +33,25 @@ pub struct Manifest {
     pub metadata: Metadata,
     /// The specification for this manifest
     pub spec: Specification,
+}
+
+impl Manifest {
+    /// Returns a reference to the current version
+    pub fn version(&self) -> &str {
+        self.metadata
+            .annotations
+            .get(VERSION_ANNOTATION_KEY)
+            .map(|v| v.as_str())
+            .unwrap_or_default()
+    }
+
+    /// Returns a reference to the current description if it exists
+    pub fn description(&self) -> Option<&str> {
+        self.metadata
+            .annotations
+            .get(DESCRIPTION_ANNOTATION_KEY)
+            .map(|v| v.as_str())
+    }
 }
 
 /// The metadata describing the manifest
@@ -293,8 +320,11 @@ mod test {
         let metadata = Metadata {
             name: "my-example-app".to_string(),
             annotations: BTreeMap::from([
-                ("version".to_string(), "v0.0.1".to_string()),
-                ("description".to_string(), "This is my app".to_string()),
+                (VERSION_ANNOTATION_KEY.to_string(), "v0.0.1".to_string()),
+                (
+                    DESCRIPTION_ANNOTATION_KEY.to_string(),
+                    "This is my app".to_string(),
+                ),
             ]),
         };
         let manifest = Manifest {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,0 +1,347 @@
+use async_nats::{Client, Message};
+use serde_json::json;
+use tracing::{debug, error, instrument, trace};
+
+use crate::{model::internal::StoredManifest, storage::Store};
+
+use super::{
+    parser::parse_manifest, DeleteModelRequest, DeleteModelResponse, DeleteResult, GetModelRequest,
+    ModelSummary, StatusType, VersionInfo,
+};
+
+pub(crate) struct Handler<S> {
+    pub(crate) store: S,
+    pub(crate) client: Client,
+}
+
+impl<S: Store + Send + Sync> Handler<S> {
+    #[instrument(level = "debug", skip(self, msg))]
+    pub async fn put_model(&self, msg: Message, lattice_id: &str, name: &str) {
+        trace!("Parsing incoming manifest");
+        let manifest = match parse_manifest(msg.payload.into(), msg.headers.as_ref()) {
+            Ok(m) => m,
+            Err(e) => {
+                self.send_error(msg.reply, format!("Unable to parse manifest: {e:?}"))
+                    .await;
+                return;
+            }
+        };
+        if manifest.metadata.name != name {
+            self.send_error(
+                msg.reply,
+                "Manifest name doesn't match name from topic".to_string(),
+            )
+            .await;
+            return;
+        }
+
+        trace!(
+            ?manifest,
+            "Manifest is valid. Fetching current manifests from store"
+        );
+
+        let mut current_manifests: StoredManifest = match self.store.get(lattice_id, name).await {
+            Ok(d) => d.unwrap_or_default(),
+            Err(e) => {
+                error!(error = %e, "Unable to fetch data from store");
+                self.send_error(msg.reply, "Internal storage error".to_string())
+                    .await;
+                return;
+            }
+        };
+
+        let current_version = manifest.version().to_owned();
+
+        // TODO: Trigger deploy of new manifest if the previous manifest was deployed
+        let result = if current_manifests.is_new() {
+            "created"
+        } else {
+            "newversion"
+        };
+
+        if !current_manifests.add_version(manifest) {
+            self.send_error(
+                msg.reply,
+                format!("Manifest version {current_version} already exists"),
+            )
+            .await;
+            return;
+        }
+        let total_versions = current_manifests.count();
+
+        trace!(total_manifests = %total_versions, "Storing manifests");
+        if let Err(e) = self
+            .store
+            .store(lattice_id, name.to_owned(), current_manifests)
+            .await
+        {
+            error!(error = %e, "Unable to store updated data");
+            self.send_error(msg.reply, "Internal storage error".to_string())
+                .await;
+            return;
+        }
+
+        trace!("Storage complete, sending reply");
+        self.send_reply(
+            msg.reply,
+            // SAFETY: We are constructing all data here
+            serde_json::to_vec(&json!({
+                "result": result,
+                "total_versions": total_versions,
+                "current_version": current_version,
+                "message": "Successfully put manifest",
+            }))
+            .unwrap(),
+        )
+        .await
+    }
+
+    #[instrument(level = "debug", skip(self, msg))]
+    pub async fn get_model(&self, msg: Message, lattice_id: &str, name: &str) {
+        // For empty payloads, just fetch the latest version
+        let req: GetModelRequest = if msg.payload.is_empty() {
+            GetModelRequest { version: None }
+        } else {
+            match serde_json::from_reader(std::io::Cursor::new(msg.payload)) {
+                Ok(r) => r,
+                Err(e) => {
+                    self.send_error(
+                        msg.reply,
+                        format!("Unable to parse get model request: {e:?}"),
+                    )
+                    .await;
+                    return;
+                }
+            }
+        };
+
+        let manifests: StoredManifest = match self.store.get(lattice_id, name).await {
+            Ok(Some(m)) => m,
+            Ok(None) => {
+                self.send_error(
+                    msg.reply,
+                    format!("Model with the name {name} doesn't exist"),
+                )
+                .await;
+                return;
+            }
+            Err(e) => {
+                error!(error = %e, "Unable to store updated data");
+                self.send_error(msg.reply, "Internal storage error".to_string())
+                    .await;
+                return;
+            }
+        };
+        let reply = match req.version {
+            Some(version) => {
+                if let Some(current) = manifests.get_version(&version) {
+                    // SAFETY: We _just_ deserialized this from the store above, so we should be just fine
+                    serde_json::to_vec(current).unwrap()
+                } else {
+                    self.send_error(
+                        msg.reply,
+                        format!("Model {name} with version {} doesn't exist", version),
+                    )
+                    .await;
+                    return;
+                }
+            }
+            None => {
+                // SAFETY: We _just_ deserialized this from the store above, so we should be just fine
+                serde_json::to_vec(manifests.get_current()).unwrap()
+            }
+        };
+        self.send_reply(msg.reply, reply).await
+    }
+
+    #[instrument(level = "debug", skip(self, msg))]
+    pub async fn list_models(&self, msg: Message, lattice_id: &str) {
+        let data: Vec<ModelSummary> = match self.store.list::<StoredManifest>(lattice_id).await {
+            Ok(manifests) => {
+                manifests
+                    .into_iter()
+                    .map(|(name, manifest)| {
+                        let current = manifest.get_current();
+                        let version = current.version();
+                        ModelSummary {
+                            name,
+                            version: version.to_owned(),
+                            description: current.description().map(|s| s.to_owned()),
+                            deployed: manifest.is_deployed(version),
+                            // TODO: Actually fetch the status info from the stored manifest once we
+                            // figure it out
+                            status: StatusType::default(),
+                        }
+                    })
+                    .collect()
+            }
+            Err(e) => {
+                error!(error = %e, "Unable to fetch data");
+                self.send_error(msg.reply, "Internal storage error".to_string())
+                    .await;
+                return;
+            }
+        };
+        // SAFETY: We _just_ deserialized this from the store above and then manually constructed
+        // it, so we should be just fine
+        self.send_reply(msg.reply, serde_json::to_vec(&data).unwrap())
+            .await
+    }
+
+    // NOTE(thomastaylor312): This method differs from the wadm 0.3 docs as it doesn't include
+    // timestamp (at least for now). However, this is guaranteed to return the list of versions
+    // ordered by time of creation. When we document, we should change this to reflect that
+    #[instrument(level = "debug", skip(self, msg))]
+    pub async fn list_versions(&self, msg: Message, lattice_id: &str, name: &str) {
+        let data: Vec<VersionInfo> = match self.store.get::<StoredManifest>(lattice_id, name).await
+        {
+            Ok(Some(manifest)) => manifest
+                .all_versions()
+                .into_iter()
+                .cloned()
+                .map(|v| {
+                    let deployed = manifest.is_deployed(&v);
+                    VersionInfo {
+                        version: v,
+                        deployed,
+                    }
+                })
+                .collect(),
+            Ok(None) => Vec::with_capacity(0),
+            Err(e) => {
+                error!(error = %e, "Unable to fetch data");
+                self.send_error(msg.reply, "Internal storage error".to_string())
+                    .await;
+                return;
+            }
+        };
+        // SAFETY: We _just_ deserialized this from the store above and then manually constructed
+        // it, so we should be just fine
+        self.send_reply(msg.reply, serde_json::to_vec(&data).unwrap())
+            .await
+    }
+
+    // NOTE(thomastaylor312): This is different than wadm 0.3. I found it remarkably confusing that
+    // you could delete something without undeploying it. So the new behavior is that if a manifest
+    // that is deployed is deleted, it is automatically undeployed, and we indicate that to the
+    // user. This should be documented when we get to our documentation tasks
+    #[instrument(level = "debug", skip(self, msg))]
+    pub async fn delete_model(&self, msg: Message, lattice_id: &str, name: &str) {
+        let req: DeleteModelRequest =
+            match serde_json::from_reader(std::io::Cursor::new(msg.payload)) {
+                Ok(r) => r,
+                Err(e) => {
+                    self.send_error(
+                        msg.reply,
+                        format!("Unable to parse delete model request: {e:?}"),
+                    )
+                    .await;
+                    return;
+                }
+            };
+        let reply_data = if req.delete_all {
+            match self.store.delete::<StoredManifest>(lattice_id, name).await {
+                Ok(_) => {
+                    DeleteModelResponse {
+                        result: DeleteResult::Deleted,
+                        message: "All models deleted".to_string(),
+                        // By default if it is all gone, we definited undeployed things
+                        undeploy: true,
+                    }
+                }
+                Err(e) => {
+                    error!(error = %e, "Unable to delete data");
+                    DeleteModelResponse {
+                        result: DeleteResult::Error,
+                        message: "Internal storage error".to_string(),
+                        undeploy: false,
+                    }
+                }
+            }
+        } else {
+            match self.store.get::<StoredManifest>(lattice_id, name).await {
+                Ok(Some(mut current)) => {
+                    if current.delete_version(&req.version) {
+                        // If the version we deleted was the deployed one, undeploy it
+                        let undeploy = if current.current_version() == req.version {
+                            current.undeploy();
+                            true
+                        } else {
+                            false
+                        };
+                        self.store
+                            .store(lattice_id, name.to_owned(), current)
+                            .await
+                            .map(|_| DeleteModelResponse {
+                                result: DeleteResult::Deleted,
+                                message: format!("Model version {} deleted", req.version),
+                                undeploy,
+                            })
+                            .unwrap_or_else(|e| {
+                                error!(error = %e, "Unable to delete data");
+                                DeleteModelResponse {
+                                    result: DeleteResult::Deleted,
+                                    message: "Internal storage error".to_string(),
+                                    undeploy: false,
+                                }
+                            })
+                    } else {
+                        DeleteModelResponse {
+                            result: DeleteResult::Noop,
+                            message: format!("Model version {} doesn't exist", req.version),
+                            undeploy: false,
+                        }
+                    }
+                }
+                Ok(None) => DeleteModelResponse {
+                    result: DeleteResult::Noop,
+                    message: format!("Model {name} doesn't exist"),
+                    undeploy: false,
+                },
+                Err(e) => {
+                    error!(error = %e, "Unable to fetch current data data");
+                    DeleteModelResponse {
+                        result: DeleteResult::Error,
+                        message: "Internal storage error".to_string(),
+                        undeploy: false,
+                    }
+                }
+            }
+        };
+
+        // SAFETY: We control all the data getting sent in here
+        self.send_reply(msg.reply, serde_json::to_vec(&reply_data).unwrap())
+            .await
+    }
+
+    /// Sends a reply to the topic with the given data, logging an error if one occurs when
+    /// sending the reply
+    #[instrument(level = "debug", skip(self, data))]
+    pub async fn send_reply(&self, reply: Option<String>, data: Vec<u8>) {
+        let reply_topic = match reply {
+            Some(t) => t,
+            None => {
+                debug!("No reply topic was sent. Skipping reply");
+                return;
+            }
+        };
+
+        if let Err(e) = self.client.publish(reply_topic, data.into()).await {
+            error!(error = %e, "Unable to send reply");
+        }
+    }
+
+    /// Sends an error reply
+    #[instrument(level = "error", skip(self, error_message))]
+    pub async fn send_error(&self, reply: Option<String>, error_message: String) {
+        // SAFETY: We control the construction of the JSON here and all data going in,
+        // so this shouldn't fail except in some sort of really odd case. And even then
+        // it will just panic
+        let response = serde_json::to_vec(&json!({
+            "result": "error",
+            "message": error_message,
+        }))
+        .unwrap();
+        self.send_reply(reply, response).await;
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,191 @@
+use async_nats::{Client, Subscriber};
+use futures::StreamExt;
+use tracing::{info, instrument, warn};
+
+use crate::storage::Store;
+
+mod handlers;
+mod parser;
+mod types;
+
+use handlers::Handler;
+pub use parser::CONTENT_TYPE_HEADER;
+pub use types::*;
+
+/// The default topic prefix for the wadm API;
+pub const DEFAULT_WADM_TOPIC_PREFIX: &str = "wadm.api";
+
+const QUEUE_GROUP: &str = "wadm_server";
+
+/// A server for the wadm API
+pub struct Server<S> {
+    handler: Handler<S>,
+    subscriber: Subscriber,
+    prefix: String,
+}
+
+impl<S: Store + Send + Sync> Server<S> {
+    /// Returns a new server configured with the given store, NATS client, and optional topic
+    /// prefix. Returns an error if it can't subscribe on the right topics
+    ///
+    /// In most cases, you shouldn't need a custom topic prefix, but it is exposed for the cases
+    /// when you may need to set a custom prefix for security purposes or topic segregation
+    #[instrument(level = "info", skip_all)]
+    pub async fn new(
+        store: S,
+        client: Client,
+        topic_prefix: Option<&str>,
+    ) -> anyhow::Result<Server<S>> {
+        // Trim off any spaces or trailing/preceding dots
+        let prefix = topic_prefix
+            .unwrap_or(DEFAULT_WADM_TOPIC_PREFIX)
+            .trim()
+            .trim_matches('.')
+            .to_owned();
+        if prefix.is_empty() {
+            anyhow::bail!("Given prefix was empty")
+        }
+
+        let topic = format!("{prefix}.>");
+        info!(%topic, "Creating API subscriber");
+        let subscriber = client
+            .queue_subscribe(topic, QUEUE_GROUP.to_owned())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+        Ok(Server {
+            handler: Handler { store, client },
+            subscriber,
+            prefix,
+        })
+    }
+
+    /// Starts the server, consuming it.
+    ///
+    /// This function will run until it either returns an error (which should always be fatal) or
+    /// you stop polling the future
+    #[instrument(level = "info", skip_all)]
+    pub async fn serve(mut self) -> anyhow::Result<()> {
+        while let Some(msg) = self.subscriber.next().await {
+            if !msg.subject.starts_with(&self.prefix) {
+                warn!(subject = %msg.subject, "Received message on an invalid subject");
+                continue;
+            }
+
+            // Cloning here to avoid using owned string matching _everywhere_. If we don't use a
+            // struct with borrowed strings, then the matches in the block below have to be owned
+            // strings. But we need to pass the message to consume the data off of it in the
+            // handlers
+            let subject = msg.subject.clone();
+            let parsed = match self.parse_subject(&subject) {
+                Ok(p) => p,
+                Err(e) => {
+                    self.handler
+                        .send_error(msg.reply, format!("Invalid subject: {e:?}"))
+                        .await;
+                    continue;
+                }
+            };
+
+            match parsed {
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "list",
+                    object_name: None,
+                } => self.handler.list_models(msg, lattice_id).await,
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "get",
+                    object_name: Some(name),
+                } => self.handler.get_model(msg, lattice_id, name).await,
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "put",
+                    object_name: Some(name),
+                } => self.handler.put_model(msg, lattice_id, name).await,
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "del",
+                    object_name: Some(name),
+                } => self.handler.delete_model(msg, lattice_id, name).await,
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "versions",
+                    object_name: Some(name),
+                } => self.handler.list_versions(msg, lattice_id, name).await,
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "deploy",
+                    object_name: Some(name),
+                } => todo!(),
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "undeploy",
+                    object_name: Some(name),
+                } => todo!(),
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "status",
+                    object_name: Some(name),
+                } => todo!(),
+                ParsedSubject {
+                    lattice_id,
+                    category: "model",
+                    operation: "history",
+                    object_name: Some(name),
+                } => todo!(),
+                _ => {
+                    let err = format!("Unsupported subject: {}", msg.subject);
+                    self.handler.send_error(msg.reply, err).await;
+                }
+            }
+        }
+        return Err(anyhow::anyhow!("Subscriber terminated"));
+    }
+
+    fn parse_subject<'a>(&self, subject: &'a str) -> anyhow::Result<ParsedSubject<'a>> {
+        // Topic structure: wadm.api.{lattice-id}.{category}.{operation}.{object}
+        // First, clean off the prefix and then split and iterate
+        let mut trimmed = subject
+            .trim_start_matches(&self.prefix)
+            .trim_start_matches('.')
+            .split('.')
+            .fuse();
+        let lattice_id = trimmed
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Expected to find lattice ID"))?;
+        let category = trimmed
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Expected to find API category"))?;
+        let operation = trimmed
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Expected to find operation"))?;
+        // Some commands don't have names, so this is optional
+        let object_name = trimmed.next();
+        // Catch malformed long subjects
+        if trimmed.next().is_some() {
+            anyhow::bail!("Found extra components of subject")
+        }
+        Ok(ParsedSubject {
+            lattice_id,
+            category,
+            operation,
+            object_name,
+        })
+    }
+}
+
+struct ParsedSubject<'a> {
+    lattice_id: &'a str,
+    category: &'a str,
+    operation: &'a str,
+    object_name: Option<&'a str>,
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -48,6 +48,11 @@ impl<S: Store + Send + Sync> Server<S> {
 
         let topic = format!("{prefix}.>");
         info!(%topic, "Creating API subscriber");
+        // NOTE(thomastaylor312): Technically there is a condition where two people try to send an
+        // update to the same manifest. We are protected against this overwriting each other (we
+        // ensure the revision is the same in the underlying store), but it will lead to a weird
+        // error reply about a storage error. This is more of an inconvenience that we can probably
+        // solve for when we get concrete error types in NATS
         let subscriber = client
             .queue_subscribe(topic, QUEUE_GROUP.to_owned())
             .await

--- a/src/server/parser.rs
+++ b/src/server/parser.rs
@@ -1,0 +1,49 @@
+use async_nats::HeaderMap;
+
+use crate::model::Manifest;
+
+/// The name of the header in the NATS request to use for content type inference. The header value
+/// should be a valid MIME type
+pub const CONTENT_TYPE_HEADER: &str = "Content-Type";
+
+// NOTE(thomastaylor312): If we do _anything_ else with mime types in the server, we should just
+// pull in the `mime` crate instead
+const YAML_MIME: &str = "application/yaml";
+const JSON_MIME: &str = "application/json";
+
+/// Parse the incoming bytes to a manifest
+///
+/// This function takes the optional headers from a NATS request to use them as a type hint for
+/// parsing
+pub fn parse_manifest(data: Vec<u8>, headers: Option<&HeaderMap>) -> anyhow::Result<Manifest> {
+    // There is far too much cloning here, but there is no way to just return a reference to a &str
+    let content_type = headers
+        .and_then(|map| map.get(CONTENT_TYPE_HEADER).cloned())
+        .map(|value| value.as_str().to_owned());
+    if let Some(content_type) = content_type {
+        match content_type.as_str() {
+            JSON_MIME => serde_json::from_slice(&data).map_err(anyhow::Error::from),
+            YAML_MIME => serde_yaml::from_slice(&data).map_err(anyhow::Error::from),
+            _ => {
+                // If the user passed a non-supported mime type, we should let them know rather than
+                // just falling back
+                Err(anyhow::anyhow!(
+                    "Unsupported content type {content_type} given. Wadm supports YAML and JSON"
+                ))
+            }
+        }
+    } else {
+        parse_yaml_or_json(data)
+    }
+}
+
+/// Parse the bytes as yaml or json (in that order)
+fn parse_yaml_or_json(data: Vec<u8>) -> anyhow::Result<Manifest> {
+    serde_yaml::from_slice(&data).or_else(|e| {
+        serde_json::from_slice(&data).map_err(|err| {
+            // Combine both errors in case one was a legit parsing failure due to invalid data
+            anyhow::anyhow!("JSON parsing failed: {err:?}")
+                .context(format!("YAML parsing failed: {e:?}"))
+        })
+    })
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,0 +1,170 @@
+use serde::{Deserialize, Serialize};
+
+/// The request body for getting a manifest
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetModelRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModelSummary {
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub deployed: bool,
+    pub status: StatusType,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VersionInfo {
+    pub version: String,
+    pub deployed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteModelRequest {
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub delete_all: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteModelResponse {
+    pub result: DeleteResult,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub undeploy: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeleteResult {
+    Deleted,
+    Error,
+    Noop,
+}
+
+/// The current status of a model
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Status {
+    #[serde(rename = "status")]
+    pub info: StatusInfo,
+    pub deployed: bool,
+    // TODO: Fill out the rest of the status stuff
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct StatusInfo {
+    #[serde(rename = "type")]
+    pub status_type: StatusType,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum StatusType {
+    Undeployed,
+    Compensating,
+    Ready,
+    Failed,
+}
+
+impl Default for StatusType {
+    fn default() -> Self {
+        StatusType::Undeployed
+    }
+}
+
+// Implementing add makes it easy for use to get an aggregate status by summing all of them together
+impl std::ops::Add for StatusType {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        // If any match, return the same status
+        if self == rhs {
+            return self;
+        }
+
+        // Because we match on exact matches above, we don't have to handle them in the match below.
+        // For all of the statuses _except_ ready, they will override the other status. Order of the
+        // matching matters below
+        match (self, rhs) {
+            // Anything that is failed means the whole thing is failed
+            (Self::Failed, _) => Self::Failed,
+            (_, Self::Failed) => Self::Failed,
+            // If anything is undeployed, the whole thing is
+            (Self::Undeployed, _) => Self::Undeployed,
+            (_, Self::Undeployed) => Self::Undeployed,
+            (Self::Compensating, _) => Self::Compensating,
+            (_, Self::Compensating) => Self::Compensating,
+            _ => unreachable!("aggregating StatusType failure. This is programmer error"),
+        }
+    }
+}
+
+impl std::iter::Sum for StatusType {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(
+            // Start with Ready because it is the first thing overridden
+            Self::Ready,
+            |a, b| a + b,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_status_aggregate() {
+        assert!(matches!(
+            [StatusType::Ready, StatusType::Ready].into_iter().sum(),
+            StatusType::Ready
+        ));
+
+        assert!(matches!(
+            [StatusType::Undeployed, StatusType::Undeployed]
+                .into_iter()
+                .sum(),
+            StatusType::Undeployed
+        ));
+
+        assert!(matches!(
+            [StatusType::Undeployed, StatusType::Failed]
+                .into_iter()
+                .sum(),
+            StatusType::Failed
+        ));
+
+        assert!(matches!(
+            [StatusType::Compensating, StatusType::Undeployed]
+                .into_iter()
+                .sum(),
+            StatusType::Undeployed
+        ));
+
+        assert!(matches!(
+            [StatusType::Ready, StatusType::Undeployed]
+                .into_iter()
+                .sum(),
+            StatusType::Undeployed
+        ));
+
+        assert!(matches!(
+            [
+                StatusType::Ready,
+                StatusType::Compensating,
+                StatusType::Undeployed,
+                StatusType::Failed
+            ]
+            .into_iter()
+            .sum(),
+            StatusType::Failed
+        ));
+    }
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::model::Manifest;
+
 /// The request body for getting a manifest
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetModelRequest {
@@ -7,6 +9,47 @@ pub struct GetModelRequest {
     pub version: Option<String>,
 }
 
+/// The response from a get request
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetModelResponse {
+    pub result: GetResult,
+    #[serde(default)]
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<Manifest>,
+}
+
+/// Possible outcomes of a get request
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GetResult {
+    Error,
+    Success,
+    NotFound,
+}
+
+/// The type returned when putting a model
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PutModelResponse {
+    pub result: PutResult,
+    #[serde(default)]
+    pub total_versions: usize,
+    #[serde(default)]
+    pub current_version: String,
+    #[serde(default)]
+    pub message: String,
+}
+
+/// Possible outcomes of a put request
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PutResult {
+    Error,
+    Created,
+    NewVersion,
+}
+
+/// Summary of a given model returned when listing
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModelSummary {
     pub name: String,
@@ -16,12 +59,14 @@ pub struct ModelSummary {
     pub status: StatusType,
 }
 
+/// Information about a given version of a model, returned as part of a list of all versions
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VersionInfo {
     pub version: String,
     pub deployed: bool,
 }
 
+/// A request for deleting a model
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteModelRequest {
     #[serde(default)]
@@ -30,6 +75,7 @@ pub struct DeleteModelRequest {
     pub delete_all: bool,
 }
 
+/// A response from a delete request
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteModelResponse {
     pub result: DeleteResult,
@@ -39,6 +85,7 @@ pub struct DeleteModelResponse {
     pub undeploy: bool,
 }
 
+/// All possible outcomes of a delete operation
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DeleteResult {
@@ -56,6 +103,7 @@ pub struct Status {
     // TODO: Fill out the rest of the status stuff
 }
 
+/// Common high-level status information
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct StatusInfo {
     #[serde(rename = "type")]
@@ -64,6 +112,7 @@ pub struct StatusInfo {
     pub message: String,
 }
 
+/// All possible status types
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum StatusType {


### PR DESCRIPTION
This PR implements the wadm NATS api and backend storage for the manifests. Anywhere I have deviated from the current wadm_0.3 api, I have tried to document it with a note so we can update the docs later. In a follow up PR, I will finish implementing the actual deployment operations of the API. For now, I wanted to make sure this didn't get _too_ big to review.

Partially closes #43 and closes #44 