### PR TITLE
(feat) Implement the ActorSpreadScaler

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,7 @@ macro_rules! from_impl {
 }
 
 /// All possible compensatory commands for a lattice
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 // In order to keep things clean, we are using untagged enum serialization. So it will just try to
 // match on data without tagging (see https://serde.rs/enum-representations.html for more info on
 // what the other options look like). These types are purely internal to wadm, but for greater
@@ -35,7 +35,7 @@ pub enum Command {
 }
 
 /// Struct for the StartActor command
-#[derive(Clone, Debug, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, Eq)]
 pub struct StartActor {
     /// The OCI or bindle reference to start
     pub reference: String,
@@ -45,25 +45,24 @@ pub struct StartActor {
     pub count: usize,
     /// The name of the model/manifest that generated this command
     pub model_name: String,
+    /// Additional annotations to attach on this command
+    pub annotations: HashMap<String, String>,
 }
 
 from_impl!(StartActor);
 
 impl PartialEq for StartActor {
-    fn eq(&self, other: &StartActor) -> bool {
-        self.reference == other.reference && self.host_id == other.host_id
-    }
-}
-
-impl Hash for StartActor {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.reference.hash(state);
-        self.host_id.hash(state);
+    fn eq(&self, other: &Self) -> bool {
+        self.reference == other.reference
+            && self.host_id == other.host_id
+            && self.count == other.count
+            && self.model_name == other.model_name
+            && self.annotations == other.annotations
     }
 }
 
 /// Struct for the StopActor command
-#[derive(Clone, Debug, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, Eq)]
 pub struct StopActor {
     /// The ID of the actor to stop
     pub actor_id: String,
@@ -73,20 +72,19 @@ pub struct StopActor {
     pub count: usize,
     /// The name of the model/manifest that generated this command
     pub model_name: String,
+    /// Additional annotations to attach on this command
+    pub annotations: HashMap<String, String>,
 }
 
 from_impl!(StopActor);
 
 impl PartialEq for StopActor {
-    fn eq(&self, other: &StopActor) -> bool {
-        self.actor_id == other.actor_id && self.host_id == other.host_id
-    }
-}
-
-impl Hash for StopActor {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.actor_id.hash(state);
-        self.host_id.hash(state);
+    fn eq(&self, other: &Self) -> bool {
+        self.actor_id == other.actor_id
+            && self.host_id == other.host_id
+            && self.count == other.count
+            && self.model_name == other.model_name
+            && self.annotations == other.annotations
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -194,7 +194,7 @@ pub struct SpreadScalerProperty {
 }
 
 /// Configuration for various spreading requirements
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct Spread {
     /// The name of this spread requirement
     pub name: String,

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use std::collections::HashSet;
 
 use crate::{commands::Command, events::Event};
 
@@ -23,11 +22,11 @@ pub trait Scaler {
 
     /// Provide a scaler with configuration to use internally when computing commands
     /// This should trigger a reconcile with the new configuration
-    async fn update_config(&mut self, config: Self::Config) -> Result<HashSet<Command>>;
+    async fn update_config(&mut self, config: Self::Config) -> Result<Vec<Command>>;
 
     /// Compute commands that must be taken given an event that changes the lattice state
-    async fn handle_event(&self, event: Event) -> Result<HashSet<Command>>;
+    async fn handle_event(&self, event: &Event) -> Result<Vec<Command>>;
 
     /// Compute commands that must be taken to achieve desired state as specified in config
-    async fn reconcile(&self) -> Result<HashSet<Command>>;
+    async fn reconcile(&self) -> Result<Vec<Command>>;
 }

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -22,7 +22,8 @@ pub trait Scaler {
     type Config: Send + Sync;
 
     /// Provide a scaler with configuration to use internally when computing commands
-    fn update_config(&mut self, config: Self::Config) -> Result<bool>;
+    /// This should trigger a reconcile with the new configuration
+    async fn update_config(&mut self, config: Self::Config) -> Result<HashSet<Command>>;
 
     /// Compute commands that must be taken given an event that changes the lattice state
     async fn handle_event(&self, event: Event) -> Result<HashSet<Command>>;

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use crate::{commands::Command, events::Event};
 
 mod simplescaler;
+pub mod spreadscaler;
 
 /// A trait describing a struct that can be configured to compute the difference between
 /// desired state and configured state, returning a set of commands to approach desired state.

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -35,9 +35,10 @@ struct SimpleActorScaler<S: ReadStore + Send + Sync> {
 impl<S: ReadStore + Send + Sync> Scaler for SimpleActorScaler<S> {
     type Config = SimpleScalerConfig;
 
-    fn update_config(&mut self, config: Self::Config) -> Result<bool> {
+    async fn update_config(&mut self, config: Self::Config) -> Result<HashSet<Command>> {
         self.config = config;
-        Ok(true)
+
+        self.reconcile().await
     }
 
     async fn handle_event(&self, event: Event) -> Result<HashSet<Command>> {

--- a/src/scaler/spreadscaler.rs
+++ b/src/scaler/spreadscaler.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::{
-    cmp::{self, Ordering},
+    cmp::Ordering,
     collections::{HashMap, HashSet},
 };
 use tracing::log::warn;
 
 use crate::{
     commands::{Command, StartActor, StopActor},
-    events::Event,
+    events::{Event, HostStarted, HostStopped},
     model::{Spread, SpreadScalerProperty, DEFAULT_SPREAD_WEIGHT},
     scaler::Scaler,
     storage::{Actor, Host, ReadStore},
@@ -36,24 +36,48 @@ struct ActorSpreadScaler<S: ReadStore + Send + Sync> {
 impl<S: ReadStore + Send + Sync> Scaler for ActorSpreadScaler<S> {
     type Config = ActorSpreadConfig;
 
-    fn update_config(&mut self, config: Self::Config) -> Result<bool> {
+    async fn update_config(&mut self, config: Self::Config) -> Result<HashSet<Command>> {
         self.config = config;
-        Ok(true)
+        self.reconcile().await
     }
 
     async fn handle_event(&self, event: Event) -> Result<HashSet<Command>> {
         match event {
-            // TODO Spread out to better encapsulate what needs to happen in each scenario
-
-            // see if we need to reduce actor instances
-            Event::ActorStarted(_)
-            // see if we need to increase actor instances
-            | Event::ActorStopped(_)
-            // see if we need to adjust spread
-            | Event::HostStopped(_)
-            // see if we need to adjust spread
-            | Event::HostStarted(_) => {
-                todo!()
+            Event::ActorStarted(actor_started) => {
+                if actor_started.image_ref == self.config.actor_reference {
+                    self.reconcile().await
+                } else {
+                    Ok(HashSet::new())
+                }
+            }
+            Event::ActorStopped(actor_stopped) => {
+                let actor_id = self.actor_id().await?;
+                // Different actor, no action needed
+                if actor_stopped.public_key == actor_id {
+                    self.reconcile().await
+                } else {
+                    Ok(HashSet::new())
+                }
+            }
+            Event::HostStopped(HostStopped { labels, .. })
+            | Event::HostStarted(HostStarted { labels, .. }) => {
+                // If this host's labels match any spread requirement, perform reconcile
+                if self
+                    .config
+                    .spread_config
+                    .spread
+                    .iter()
+                    .find(|spread| {
+                        spread.requirements.iter().all(|(key, value)| {
+                            labels.get(key).map(|val| val == value).unwrap_or(false)
+                        })
+                    })
+                    .is_some()
+                {
+                    Ok(HashSet::new())
+                } else {
+                    self.reconcile().await
+                }
             }
             // No other event impacts the job of this scaler so we can ignore it
             _ => Ok(HashSet::new()),
@@ -61,50 +85,13 @@ impl<S: ReadStore + Send + Sync> Scaler for ActorSpreadScaler<S> {
     }
 
     async fn reconcile(&self) -> Result<HashSet<Command>> {
-        todo!()
-    }
-}
-
-impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
-    #[allow(unused)]
-    /// Construct a new SimpleActorScaler with specified configuration values
-    fn new(
-        store: S,
-        actor_reference: String,
-        lattice_id: String,
-        spread_config: SpreadScalerProperty,
-    ) -> Self {
-        Self {
-            store,
-            config: ActorSpreadConfig {
-                actor_reference,
-                lattice_id,
-                spread_config,
-            },
-        }
-    }
-
-    /// Given a spread config, compute the necessary commands to properly spread actors across a set
-    /// of hosts
-    async fn spread_commands(&self) -> Result<HashSet<Command>> {
         let spread_requirements = compute_spread(&self.config.spread_config)?;
-
         let hosts = self.store.list::<Host>(&self.config.lattice_id).await?;
-
-        let actor_id = self
-            .store
-            .list::<Actor>(&self.config.lattice_id)
-            .await?
-            .iter()
-            .find(|(_id, actor)| actor.reference == self.config.actor_reference)
-            .map(|(id, _actor)| id.to_owned())
-            // Default here means the below `get` will find zero running actors, which is fine because
-            // that accurately describes the current lattice having zero instances.
-            .unwrap_or_default();
+        let actor_id = self.actor_id().await?;
 
         // NOTE(brooksmtownsend) it's easier to assign one host per list of requirements than
         // balance within those requirements. Users should be specific with their requirements
-        // as wadm is not responsible for ambiguity
+        // as wadm is not responsible for ambiguity, a future scaler like a DaemonScaler could handle this
 
         let commands = spread_requirements
             .iter()
@@ -118,7 +105,7 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
                         total + *host.actors.get(&actor_id).unwrap_or(&0)
                     });
 
-                    let final_cmd = match current_count.cmp(count) {
+                    match current_count.cmp(count) {
                         // No action needed
                         Ordering::Equal => None,
                         // Start actors to reach desired replicas
@@ -133,8 +120,7 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
                             host_id: first_host.id.to_owned(),
                             count: current_count - count,
                         })),
-                    };
-                    final_cmd
+                    }
                 } else {
                     // No hosts were eligible, so we can't attempt to add or remove actors
                     None
@@ -165,6 +151,43 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
     }
 }
 
+impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
+    #[allow(unused)]
+    /// Construct a new ActorSpreadScaler with specified configuration values
+    fn new(
+        store: S,
+        actor_reference: String,
+        lattice_id: String,
+        spread_config: SpreadScalerProperty,
+    ) -> Self {
+        Self {
+            store,
+            config: ActorSpreadConfig {
+                actor_reference,
+                lattice_id,
+                spread_config,
+            },
+        }
+    }
+
+    // TODO(brooksmtownsend): Need to consider a better way to grab this. It will fail to find
+    // the actor ID if it's not running in the lattice currently, which seems brittle
+    /// Helper function to retrieve the actor ID for the configured actor
+    async fn actor_id(&self) -> Result<String> {
+        Ok(self
+            .store
+            .list::<Actor>(&self.config.lattice_id)
+            .await?
+            .iter()
+            .find(|(_id, actor)| actor.reference == self.config.actor_reference)
+            .map(|(id, _actor)| id.to_owned())
+            // Default here means the below `get` will find zero running actors, which is fine because
+            // that accurately describes the current lattice having zero instances.
+            .unwrap_or_default())
+    }
+}
+
+/// Helper function that computes a list of eligible hosts to match with a spread
 fn eligible_hosts<'a>(all_hosts: &'a HashMap<String, Host>, spread: &Spread) -> Vec<&'a Host> {
     all_hosts
         .iter()
@@ -181,10 +204,7 @@ fn eligible_hosts<'a>(all_hosts: &'a HashMap<String, Host>, spread: &Spread) -> 
 /// Given a spread config, return a vector of tuples that represents the spread
 /// and the actual number of actors to start for a specific spread requirement
 fn compute_spread(spread_config: &SpreadScalerProperty) -> Result<Vec<(&Spread, usize)>> {
-    // ideal return would be a Vec<(num_actors, Spread)>?
     let replicas = spread_config.replicas;
-    // TODO: what should the default weight be? 100 would clobber anyone who uses 1, maybe default is the
-    // same as the minimum weight specified?
     let total_weight = spread_config
         .spread
         .iter()
@@ -203,7 +223,8 @@ fn compute_spread(spread_config: &SpreadScalerProperty) -> Result<Vec<(&Spread, 
         })
         .collect();
 
-    // Sanity check to see if we need to add more replicas
+    // Because of math, we may end up rounding a few instances away. Evenly distribute them
+    // among the remaining hosts
     let total_replicas = spreads.iter().map(|(_s, count)| count).sum::<usize>();
     let spreads = match total_replicas.cmp(&replicas) {
         Ordering::Less => {
@@ -245,9 +266,14 @@ mod test {
 
     use crate::{
         commands::{Command, StartActor},
+        consumers::{manager::Worker, ScopedMessage},
+        events::{
+            ActorStopped, Event, Linkdef, LinkdefDeleted, LinkdefSet, ProviderClaims,
+            ProviderStarted, ProviderStopped,
+        },
         model::{Spread, SpreadScalerProperty},
-        scaler::spreadscaler::ActorSpreadScaler,
-        storage::{Host, Store},
+        scaler::{spreadscaler::ActorSpreadScaler, Scaler},
+        storage::{Actor, Host, Store},
         test_util::TestStore,
         workers::EventWorker,
     };
@@ -409,11 +435,9 @@ mod test {
     async fn can_compute_spread_commands() -> Result<()> {
         let lattice_id = "hoohah_multi_stop_actor";
         let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
-        let actor_id = "MASDASDIAMAREALACTOR";
         let host_id = "NASDASDIMAREALHOST";
 
         let store = Arc::new(TestStore::default());
-        let worker = EventWorker::new(store.clone(), HashMap::default());
 
         // STATE SETUP BEGIN, ONE HOST
         store
@@ -472,7 +496,7 @@ mod test {
             complex_spread,
         );
 
-        let cmds = spreadscaler.spread_commands().await?;
+        let cmds = spreadscaler.reconcile().await?;
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds.iter().next().expect("should have one command"),
@@ -482,6 +506,575 @@ mod test {
                 count: 103,
             })
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_scale_up_and_down() -> Result<()> {
+        let lattice_id = "computing_spread_commands";
+        let echo_ref = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let echo_id = "MASDASDIAMAREALACTORECHO";
+        let blobby_ref = "fakecloud.azurecr.io/blobby:0.5.2".to_string();
+        let blobby_id = "MASDASDIAMAREALACTORBLOBBY";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+        let host_id_three = "NASDASDIMAREALHOSTTREE";
+
+        let store = Arc::new(TestStore::default());
+
+        store
+            .store(
+                lattice_id,
+                echo_id.to_string(),
+                Actor {
+                    id: echo_id.to_string(),
+                    name: "Echo".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    count: HashMap::from_iter([
+                        (host_id_one.to_string(), 1),
+                        (host_id_two.to_string(), 103),
+                        (host_id_three.to_string(), 400),
+                    ]),
+                    reference: echo_ref.to_string(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                blobby_id.to_string(),
+                Actor {
+                    id: blobby_id.to_string(),
+                    name: "Blobby".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    count: HashMap::from_iter([
+                        (host_id_one.to_string(), 2),
+                        (host_id_two.to_string(), 19),
+                    ]),
+                    reference: blobby_ref.to_string(),
+                },
+            )
+            .await?;
+
+        // STATE SETUP BEGIN
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    actors: HashMap::from_iter([
+                        (echo_id.to_string(), 1),
+                        (blobby_id.to_string(), 3),
+                        ("MSOMEOTHERACTOR".to_string(), 3),
+                    ]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-brooks-1".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    actors: HashMap::from_iter([
+                        (echo_id.to_string(), 103),
+                        (blobby_id.to_string(), 19),
+                    ]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "real".to_string()),
+                        ("region".to_string(), "us-midwest-4".to_string()),
+                        ("label".to_string(), "value".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_three.to_string(),
+                Host {
+                    actors: HashMap::from_iter([(echo_id.to_string(), 400)]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "purgatory".to_string()),
+                        ("location".to_string(), "edge".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_three.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // STATE SETUP END
+
+        let echo_spread_property = SpreadScalerProperty {
+            replicas: 412,
+            spread: vec![
+                Spread {
+                    name: "RunInFakeCloud".to_string(),
+                    requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                    weight: Some(50), // 206
+                },
+                Spread {
+                    name: "RunInRealCloud".to_string(),
+                    requirements: BTreeMap::from_iter([("cloud".to_string(), "real".to_string())]),
+                    weight: Some(25), // 103
+                },
+                Spread {
+                    name: "RunInPurgatoryCloud".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "purgatory".to_string(),
+                    )]),
+                    weight: Some(25), // 103
+                },
+            ],
+        };
+
+        let blobby_spread_property = SpreadScalerProperty {
+            replicas: 9,
+            spread: vec![
+                Spread {
+                    name: "CrossRegionCustom".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "region".to_string(),
+                        "us-brooks-1".to_string(),
+                    )]),
+                    weight: Some(33), // 3
+                },
+                Spread {
+                    name: "CrossRegionReal".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "region".to_string(),
+                        "us-midwest-4".to_string(),
+                    )]),
+                    weight: Some(33), // 3
+                },
+                Spread {
+                    name: "RunOnEdge".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "location".to_string(),
+                        "edge".to_string(),
+                    )]),
+                    weight: Some(33), // 3
+                },
+            ],
+        };
+
+        let echo_spreadscaler = ActorSpreadScaler::new(
+            store.clone(),
+            echo_ref.to_string(),
+            lattice_id.to_string(),
+            echo_spread_property,
+        );
+
+        let cmds = echo_spreadscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 2);
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    assert_eq!(start.host_id, host_id_one.to_string());
+                    assert_eq!(start.count, 205);
+                    assert_eq!(start.reference, echo_ref);
+                }
+                Command::StopActor(stop) => {
+                    assert_eq!(stop.host_id, host_id_three.to_string());
+                    assert_eq!(stop.count, 297);
+                    assert_eq!(stop.actor_id, echo_id);
+                }
+                _ => panic!("Unexpected command in spreadscaler list"),
+            }
+        }
+
+        let blobby_spreadscaler = ActorSpreadScaler::new(
+            store.clone(),
+            blobby_ref.to_string(),
+            lattice_id.to_string(),
+            blobby_spread_property,
+        );
+
+        let cmds = blobby_spreadscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 2);
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    assert_eq!(start.host_id, host_id_three.to_string());
+                    assert_eq!(start.count, 3);
+                    assert_eq!(start.reference, blobby_ref);
+                }
+                Command::StopActor(stop) => {
+                    assert_eq!(stop.host_id, host_id_two.to_string());
+                    assert_eq!(stop.count, 16);
+                    assert_eq!(stop.actor_id, blobby_id);
+                }
+                _ => panic!("Unexpected command in spreadscaler list"),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// NOTE(brooksmtownsend): This test currently doesn't pass due to the need for annotations.
+    /// It's included so we can bring the functionality in later and have it properly work.
+    #[tokio::test]
+    async fn can_handle_multiple_spread_matches() -> Result<()> {
+        let lattice_id = "multiple_spread_matches";
+        let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let actor_id = "MASDASDASDASDASDADSDDAAASDDD".to_string();
+        let host_id = "NASDASDIMAREALHOST";
+
+        let store = Arc::new(TestStore::default());
+
+        // STATE SETUP BEGIN, ONE HOST
+        store
+            .store(
+                lattice_id,
+                host_id.to_string(),
+                Host {
+                    actors: HashMap::from_iter([(actor_id.to_string(), 10)]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("region".to_string(), "east".to_string()),
+                        ("resilient".to_string(), "true".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                actor_id.to_string(),
+                Actor {
+                    id: actor_id.to_string(),
+                    name: "Faketor".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    count: HashMap::from_iter([(host_id.to_string(), 10)]),
+                    reference: actor_reference.to_string(),
+                },
+            )
+            .await?;
+
+        // Run 75% in east, 25% on resilient hosts
+        let real_spread = SpreadScalerProperty {
+            replicas: 20,
+            spread: vec![
+                Spread {
+                    name: "SimpleOne".to_string(),
+                    requirements: BTreeMap::from_iter([("region".to_string(), "east".to_string())]),
+                    weight: Some(75),
+                },
+                Spread {
+                    name: "SimpleTwo".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "resilient".to_string(),
+                        "true".to_string(),
+                    )]),
+                    weight: Some(25),
+                },
+            ],
+        };
+
+        let spreadscaler = ActorSpreadScaler::new(
+            store.clone(),
+            actor_reference.to_string(),
+            lattice_id.to_string(),
+            real_spread,
+        );
+
+        let _cmds = spreadscaler.reconcile().await?;
+        // NOTE(brooksmtownsend): IDEALLY we would start 10 instances on the host
+        // in order to satisfy the requirements of 20 replicas, however each spread
+        // is evaluated individually and the existing actors aren't properly divvied
+        // up into the spreads. Need annotations to do this properly.
+        assert!(true);
+
+        // assert_eq!(cmds.len(), 1);
+        // assert_eq!(
+        //     cmds.iter().next().expect("should have one command"),
+        //     &Command::StartActor(StartActor {
+        //         reference: actor_reference.to_string(),
+        //         host_id: host_id.to_string(),
+        //         count: 10,
+        //     })
+        // );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_react_to_events() -> Result<()> {
+        let lattice_id = "computing_spread_commands";
+        let blobby_ref = "fakecloud.azurecr.io/blobby:0.5.2".to_string();
+        let blobby_id = "MASDASDIAMAREALACTORBLOBBY";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+        let host_id_three = "NASDASDIMAREALHOSTTREE";
+
+        let store = Arc::new(TestStore::default());
+        let worker = EventWorker::new(store.clone(), HashMap::default());
+
+        store
+            .store(
+                lattice_id,
+                blobby_id.to_string(),
+                Actor {
+                    id: blobby_id.to_string(),
+                    name: "Blobby".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    count: HashMap::from_iter([
+                        (host_id_one.to_string(), 3),
+                        (host_id_two.to_string(), 19),
+                    ]),
+                    reference: blobby_ref.to_string(),
+                },
+            )
+            .await?;
+
+        // STATE SETUP BEGIN
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    actors: HashMap::from_iter([
+                        (blobby_id.to_string(), 3),
+                        ("MSOMEOTHERACTOR".to_string(), 3),
+                    ]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-brooks-1".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    actors: HashMap::from_iter([(blobby_id.to_string(), 19)]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "real".to_string()),
+                        ("region".to_string(), "us-midwest-4".to_string()),
+                        ("label".to_string(), "value".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_three.to_string(),
+                Host {
+                    actors: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "purgatory".to_string()),
+                        ("location".to_string(), "edge".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_three.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // STATE SETUP END
+
+        let blobby_spread_property = SpreadScalerProperty {
+            replicas: 9,
+            spread: vec![
+                Spread {
+                    name: "CrossRegionCustom".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "region".to_string(),
+                        "us-brooks-1".to_string(),
+                    )]),
+                    weight: Some(33), // 3
+                },
+                Spread {
+                    name: "CrossRegionReal".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "region".to_string(),
+                        "us-midwest-4".to_string(),
+                    )]),
+                    weight: Some(33), // 3
+                },
+                Spread {
+                    name: "RunOnEdge".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "location".to_string(),
+                        "edge".to_string(),
+                    )]),
+                    weight: Some(33), // 3
+                },
+            ],
+        };
+
+        let blobby_spreadscaler = ActorSpreadScaler::new(
+            store.clone(),
+            blobby_ref.to_string(),
+            lattice_id.to_string(),
+            blobby_spread_property,
+        );
+
+        // Don't care about these events
+        assert!(blobby_spreadscaler
+            .handle_event(Event::ProviderStarted(ProviderStarted {
+                annotations: HashMap::new(),
+                claims: ProviderClaims::default(),
+                contract_id: "".to_string(),
+                image_ref: "".to_string(),
+                instance_id: "".to_string(),
+                link_name: "".to_string(),
+                public_key: "".to_string(),
+                host_id: host_id_one.to_string()
+            }))
+            .await?
+            .is_empty());
+        assert!(blobby_spreadscaler
+            .handle_event(Event::ProviderStopped(ProviderStopped {
+                contract_id: "".to_string(),
+                instance_id: "".to_string(),
+                link_name: "".to_string(),
+                public_key: "".to_string(),
+                reason: "".to_string(),
+                host_id: host_id_two.to_string()
+            }))
+            .await?
+            .is_empty());
+        assert!(blobby_spreadscaler
+            .handle_event(Event::LinkdefSet(LinkdefSet {
+                linkdef: Linkdef::default()
+            }))
+            .await?
+            .is_empty());
+        assert!(blobby_spreadscaler
+            .handle_event(Event::LinkdefDeleted(LinkdefDeleted {
+                linkdef: Linkdef::default()
+            }))
+            .await?
+            .is_empty());
+
+        let cmds = blobby_spreadscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 2);
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    assert_eq!(start.host_id, host_id_three.to_string());
+                    assert_eq!(start.count, 3);
+                    assert_eq!(start.reference, blobby_ref);
+                }
+                Command::StopActor(stop) => {
+                    assert_eq!(stop.host_id, host_id_two.to_string());
+                    assert_eq!(stop.count, 16);
+                    assert_eq!(stop.actor_id, blobby_id);
+                }
+                _ => panic!("Unexpected command in spreadscaler list"),
+            }
+        }
+
+        // Stop an instance of an actor, and expect a modified list of commands
+
+        let modifying_event = ActorStopped {
+            instance_id: "IAMANINSTANCE".to_string(),
+            public_key: blobby_id.to_string(),
+            host_id: host_id_two.to_string(),
+        };
+
+        worker
+            .do_work(ScopedMessage::<Event> {
+                lattice_id: lattice_id.to_string(),
+                inner: Event::ActorStopped(modifying_event.clone()),
+                acker: None,
+            })
+            .await
+            .expect("should be able to handle an event");
+
+        let cmds = blobby_spreadscaler
+            .handle_event(Event::ActorStopped(modifying_event))
+            .await?;
+        assert_eq!(cmds.len(), 2);
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    assert_eq!(start.host_id, host_id_three.to_string());
+                    assert_eq!(start.count, 3);
+                    assert_eq!(start.reference, blobby_ref);
+                }
+                Command::StopActor(stop) => {
+                    assert_eq!(stop.host_id, host_id_two.to_string());
+                    assert_eq!(stop.count, 15);
+                    assert_eq!(stop.actor_id, blobby_id);
+                }
+                _ => panic!("Unexpected command in spreadscaler list"),
+            }
+        }
 
         Ok(())
     }

--- a/src/scaler/spreadscaler.rs
+++ b/src/scaler/spreadscaler.rs
@@ -1,0 +1,488 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::{
+    cmp::{self, Ordering},
+    collections::{HashMap, HashSet},
+};
+use tracing::log::warn;
+
+use crate::{
+    commands::{Command, StartActor, StopActor},
+    events::Event,
+    model::{Spread, SpreadScalerProperty, DEFAULT_SPREAD_WEIGHT},
+    scaler::Scaler,
+    storage::{Actor, Host, ReadStore},
+};
+
+/// Config for an ActorSpreadScaler
+struct ActorSpreadConfig {
+    actor_reference: String,
+    lattice_id: String,
+    spread_config: SpreadScalerProperty,
+}
+
+/// The SimpleScaler ensures that a certain number of replicas are running
+/// for a certain public key.
+///
+/// This is primarily to demonstrate the functionality and ergonomics of the
+/// [Scaler](crate::scaler::Scaler) trait and doesn't make any guarantees
+/// about spreading replicas evenly
+struct ActorSpreadScaler<S: ReadStore + Send + Sync> {
+    pub config: ActorSpreadConfig,
+    store: S,
+}
+
+#[async_trait]
+impl<S: ReadStore + Send + Sync> Scaler for ActorSpreadScaler<S> {
+    type Config = ActorSpreadConfig;
+
+    fn update_config(&mut self, config: Self::Config) -> Result<bool> {
+        self.config = config;
+        Ok(true)
+    }
+
+    async fn handle_event(&self, event: Event) -> Result<HashSet<Command>> {
+        match event {
+            // TODO Spread out to better encapsulate what needs to happen in each scenario
+
+            // see if we need to reduce actor instances
+            Event::ActorStarted(_)
+            // see if we need to increase actor instances
+            | Event::ActorStopped(_)
+            // see if we need to adjust spread
+            | Event::HostStopped(_)
+            // see if we need to adjust spread
+            | Event::HostStarted(_) => {
+                todo!()
+            }
+            // No other event impacts the job of this scaler so we can ignore it
+            _ => Ok(HashSet::new()),
+        }
+    }
+
+    async fn reconcile(&self) -> Result<HashSet<Command>> {
+        todo!()
+    }
+}
+
+impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
+    #[allow(unused)]
+    /// Construct a new SimpleActorScaler with specified configuration values
+    fn new(
+        store: S,
+        actor_reference: String,
+        lattice_id: String,
+        spread_config: SpreadScalerProperty,
+    ) -> Self {
+        Self {
+            store,
+            config: ActorSpreadConfig {
+                actor_reference,
+                lattice_id,
+                spread_config,
+            },
+        }
+    }
+
+    /// Given a spread config, compute the necessary commands to properly spread actors across a set
+    /// of hosts
+    async fn spread_commands(&self) -> Result<HashSet<Command>> {
+        let spread_requirements = compute_spread(&self.config.spread_config)?;
+
+        let hosts = self.store.list::<Host>(&self.config.lattice_id).await?;
+
+        let actor_id = self
+            .store
+            .list::<Actor>(&self.config.lattice_id)
+            .await?
+            .iter()
+            .find(|(_id, actor)| actor.reference == self.config.actor_reference)
+            .map(|(id, _actor)| id.to_owned())
+            // Default here means the below `get` will find zero running actors, which is fine because
+            // that accurately describes the current lattice having zero instances.
+            .unwrap_or_default();
+
+        // NOTE(brooksmtownsend) it's easier to assign one host per list of requirements than
+        // balance within those requirements. Users should be specific with their requirements
+        // as wadm is not responsible for ambiguity
+
+        let commands = spread_requirements
+            .iter()
+            .filter_map(|(spread, count)| {
+                let eligible_hosts = eligible_hosts(&hosts, spread);
+                if let Some(first_host) = eligible_hosts.get(0) {
+                    // NOTE(brooksmtownsend): Once we care about annotations, we'll need to check that annotations
+                    // match here to compute the current count
+                    // Compute all current actors running on this spread's eligible hosts
+                    let current_count = eligible_hosts.iter().fold(0, |total, host| {
+                        total + *host.actors.get(&actor_id).unwrap_or(&0)
+                    });
+
+                    let final_cmd = match current_count.cmp(count) {
+                        // No action needed
+                        Ordering::Equal => None,
+                        // Start actors to reach desired replicas
+                        Ordering::Less => Some(Command::StartActor(StartActor {
+                            reference: self.config.actor_reference.to_owned(),
+                            host_id: first_host.id.to_owned(),
+                            count: count - current_count,
+                        })),
+                        // Stop actors to reach desired replicas
+                        Ordering::Greater => Some(Command::StopActor(StopActor {
+                            actor_id: actor_id.to_owned(),
+                            host_id: first_host.id.to_owned(),
+                            count: current_count - count,
+                        })),
+                    };
+                    final_cmd
+                } else {
+                    // No hosts were eligible, so we can't attempt to add or remove actors
+                    None
+                }
+            })
+            // Collapse multiple commands for the same actor and same host
+            // into single StopActor commands
+            .fold(HashSet::new(), |mut cmd_set, cmd| {
+                if let Some(prev_cmd) = cmd_set.get(&cmd) {
+                    match (prev_cmd, cmd) {
+                        (Command::StartActor(prev), Command::StartActor(new)) => {
+                            let thing_to_add = Command::StartActor(StartActor {
+                                count: prev.count + new.count,
+                                ..new
+                            });
+                            cmd_set.replace(thing_to_add);
+                            cmd_set
+                        }
+                        _ => cmd_set,
+                    }
+                } else {
+                    cmd_set.insert(cmd);
+                    cmd_set
+                }
+            });
+
+        Ok(commands)
+    }
+}
+
+fn eligible_hosts<'a>(all_hosts: &'a HashMap<String, Host>, spread: &Spread) -> Vec<&'a Host> {
+    all_hosts
+        .iter()
+        .filter(|(_id, host)| {
+            spread
+                .requirements
+                .iter()
+                .all(|(key, value)| host.labels.get(key).map(|v| v.eq(value)).unwrap_or(false))
+        })
+        .map(|(_id, host)| host)
+        .collect::<Vec<&Host>>()
+}
+
+/// Given a spread config, return a vector of tuples that represents the spread
+/// and the actual number of actors to start for a specific spread requirement
+fn compute_spread(spread_config: &SpreadScalerProperty) -> Result<Vec<(&Spread, usize)>> {
+    // ideal return would be a Vec<(num_actors, Spread)>?
+    let replicas = spread_config.replicas;
+    // TODO: what should the default weight be? 100 would clobber anyone who uses 1, maybe default is the
+    // same as the minimum weight specified?
+    let total_weight = spread_config
+        .spread
+        .iter()
+        .map(|s| s.weight.unwrap_or(DEFAULT_SPREAD_WEIGHT))
+        .sum::<usize>();
+
+    let spreads: Vec<(&Spread, usize)> = spread_config
+        .spread
+        .iter()
+        .map(|s| {
+            (
+                s,
+                // Order is important here since usizes chop off remaining decimals
+                (replicas * s.weight.unwrap_or(DEFAULT_SPREAD_WEIGHT)) / total_weight,
+            )
+        })
+        .collect();
+
+    // Sanity check to see if we need to add more replicas
+    let total_replicas = spreads.iter().map(|(_s, count)| count).sum::<usize>();
+    let spreads = match total_replicas.cmp(&replicas) {
+        Ordering::Less => {
+            // Take the remainder of replicas and evenly distribute among remaining spreads
+            let mut diff = replicas - total_replicas;
+            spreads
+                .into_iter()
+                .map(|(spread, count)| {
+                    let additional = if diff > 0 {
+                        diff -= 1;
+                        1
+                    } else {
+                        0
+                    };
+                    (spread, count + additional)
+                })
+                .collect()
+        }
+        // This isn't possible (usizes round down) but I added an arm _just in case_
+        // there was a case that I didn't imagine
+        Ordering::Greater => {
+            warn!("Requesting more actor instances than were specified");
+            spreads
+        }
+        Ordering::Equal => spreads,
+    };
+
+    Ok(spreads)
+}
+
+#[cfg(test)]
+mod test {
+    use anyhow::Result;
+    use chrono::Utc;
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use crate::{
+        commands::{Command, StartActor},
+        model::{Spread, SpreadScalerProperty},
+        scaler::spreadscaler::ActorSpreadScaler,
+        storage::{Host, Store},
+        test_util::TestStore,
+        workers::EventWorker,
+    };
+
+    use super::compute_spread;
+
+    #[test]
+    fn can_spread_properly() -> Result<()> {
+        // Basic test to ensure our types are correct
+        let simple_spread = SpreadScalerProperty {
+            replicas: 1,
+            spread: vec![Spread {
+                name: "Simple".to_string(),
+                requirements: BTreeMap::new(),
+                weight: Some(100),
+            }],
+        };
+
+        let simple_spread_res = compute_spread(&simple_spread)?;
+        assert_eq!(simple_spread_res[0].1, 1);
+
+        // Ensure we spread evenly with equal weights, clean division
+        let multi_spread_even = SpreadScalerProperty {
+            replicas: 10,
+            spread: vec![
+                Spread {
+                    name: "SimpleOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(100),
+                },
+                Spread {
+                    name: "SimpleTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(100),
+                },
+            ],
+        };
+
+        let multi_spread_even_res = compute_spread(&multi_spread_even)?;
+        assert_eq!(multi_spread_even_res[0].1, 5);
+        assert_eq!(multi_spread_even_res[1].1, 5);
+
+        // Ensure we spread an odd number with clean dividing weights
+        let multi_spread_odd = SpreadScalerProperty {
+            replicas: 7,
+            spread: vec![
+                Spread {
+                    name: "SimpleOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(30),
+                },
+                Spread {
+                    name: "SimpleTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(40),
+                },
+            ],
+        };
+
+        let multi_spread_even_res = compute_spread(&multi_spread_odd)?;
+        assert_eq!(multi_spread_even_res[0].1, 3);
+        assert_eq!(multi_spread_even_res[1].1, 4);
+
+        // Ensure we spread an odd number with unclean dividing weights
+        let multi_spread_odd = SpreadScalerProperty {
+            replicas: 7,
+            spread: vec![
+                Spread {
+                    name: "SimpleOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(100),
+                },
+                Spread {
+                    name: "SimpleTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(100),
+                },
+            ],
+        };
+
+        let multi_spread_even_res = compute_spread(&multi_spread_odd)?;
+        assert_eq!(multi_spread_even_res[0].1, 4);
+        assert_eq!(multi_spread_even_res[1].1, 3);
+
+        // Ensure we compute if a weights aren't specified
+        let multi_spread_even_no_weight = SpreadScalerProperty {
+            replicas: 10,
+            spread: vec![
+                Spread {
+                    name: "SimpleOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: None,
+                },
+                Spread {
+                    name: "SimpleTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: None,
+                },
+            ],
+        };
+
+        let multi_spread_even_no_weight = compute_spread(&multi_spread_even_no_weight)?;
+        assert_eq!(multi_spread_even_no_weight[0].1, 5);
+        assert_eq!(multi_spread_even_no_weight[1].1, 5);
+
+        // Ensure we compute if weights are partially specified
+        // Ensure we compute if spread vec is empty?
+        let simple_spread_replica_only = SpreadScalerProperty {
+            replicas: 12,
+            spread: vec![],
+        };
+
+        let simple_replica_only = compute_spread(&simple_spread_replica_only)?;
+        // NOTE(brooksmtownsend): The defaut behavior is to return no spreads, consumers
+        // of this function should be responsible for knowing that there are no requirements
+        assert_eq!(simple_replica_only.len(), 0);
+        // Ensure we handle an all around complex case
+
+        // Ensure we compute if a weights aren't specified
+        let complex_spread = SpreadScalerProperty {
+            replicas: 103,
+            spread: vec![
+                Spread {
+                    // 9 + 1 (remainder trip)
+                    name: "ComplexOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(42),
+                },
+                Spread {
+                    // 0 + 1 (remainder trip)
+                    name: "ComplexTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(3),
+                },
+                Spread {
+                    // 8
+                    name: "ComplexThree".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(37),
+                },
+                Spread {
+                    // 84
+                    name: "ComplexFour".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(384),
+                },
+            ],
+        };
+        let complex_spread_res = compute_spread(&complex_spread)?;
+        assert_eq!(complex_spread_res[0].1, 10);
+        assert_eq!(complex_spread_res[1].1, 1);
+        assert_eq!(complex_spread_res[2].1, 8);
+        assert_eq!(complex_spread_res[3].1, 84);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_compute_spread_commands() -> Result<()> {
+        let lattice_id = "hoohah_multi_stop_actor";
+        let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let actor_id = "MASDASDIAMAREALACTOR";
+        let host_id = "NASDASDIMAREALHOST";
+
+        let store = Arc::new(TestStore::default());
+        let worker = EventWorker::new(store.clone(), HashMap::default());
+
+        // STATE SETUP BEGIN, ONE HOST
+        store
+            .store(
+                lattice_id,
+                host_id.to_string(),
+                Host {
+                    actors: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::new(),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // Ensure we compute if a weights aren't specified
+        let complex_spread = SpreadScalerProperty {
+            replicas: 103,
+            spread: vec![
+                Spread {
+                    // 9 + 1 (remainder trip)
+                    name: "ComplexOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(42),
+                },
+                Spread {
+                    // 0 + 1 (remainder trip)
+                    name: "ComplexTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(3),
+                },
+                Spread {
+                    // 8
+                    name: "ComplexThree".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(37),
+                },
+                Spread {
+                    // 84
+                    name: "ComplexFour".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(384),
+                },
+            ],
+        };
+
+        let spreadscaler = ActorSpreadScaler::new(
+            store.clone(),
+            actor_reference.to_string(),
+            lattice_id.to_string(),
+            complex_spread,
+        );
+
+        let cmds = spreadscaler.spread_commands().await?;
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(
+            cmds.iter().next().expect("should have one command"),
+            &Command::StartActor(StartActor {
+                reference: actor_reference.to_string(),
+                host_id: host_id.to_string(),
+                count: 103,
+            })
+        );
+
+        Ok(())
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,7 +6,7 @@ pub mod nats_kv;
 pub mod reaper;
 mod state;
 
-pub use state::{Actor, Host, Provider, ProviderStatus};
+pub use state::{Actor, Host, Provider, ProviderStatus, WadmActorInstance};
 
 /// A trait that must be implemented with a unique identifier for the given type. This is used in
 /// the construction of keys for a store

--- a/src/workers/command.rs
+++ b/src/workers/command.rs
@@ -36,7 +36,9 @@ impl Worker for CommandWorker {
     async fn do_work(&self, mut message: ScopedMessage<Self::Message>) -> WorkResult<()> {
         let res = match message.as_ref() {
             Command::StartActor(actor) => {
-                let mut annotations = MANAGED_BY_ANNOTATIONS.clone();
+                // Order here is intentional to prevent scalers from overwriting managed annotations
+                let mut annotations = actor.annotations.clone();
+                annotations.extend(MANAGED_BY_ANNOTATIONS.clone());
                 annotations.insert(APP_SPEC_ANNOTATION.to_owned(), actor.model_name.clone());
                 self.client
                     .start_actor(
@@ -48,7 +50,9 @@ impl Worker for CommandWorker {
                     .await
             }
             Command::StopActor(actor) => {
-                let mut annotations = MANAGED_BY_ANNOTATIONS.clone();
+                // Order here is intentional to prevent scalers from overwriting managed annotations
+                let mut annotations = actor.annotations.clone();
+                annotations.extend(MANAGED_BY_ANNOTATIONS.clone());
                 annotations.insert(APP_SPEC_ANNOTATION.to_owned(), actor.model_name.clone());
                 self.client
                     .stop_actor(

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -6,4 +6,4 @@ mod command;
 mod event;
 
 pub use command::CommandWorker;
-pub use event::EventWorker;
+pub use event::{Claims, ClaimsSource, EventWorker, InventorySource};

--- a/tests/command_consumer_integration.rs
+++ b/tests/command_consumer_integration.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use futures::TryStreamExt;
 use serial_test::serial;
 use tokio::time::{timeout, Duration};
@@ -18,6 +20,7 @@ async fn test_consumer_stream() {
             host_id: "fakehost".to_string(),
             count: 3,
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
     wrapper
@@ -99,6 +102,7 @@ async fn test_consumer_stream() {
             host_id: "fakehost".to_string(),
             count: 1,
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
 
@@ -127,6 +131,7 @@ async fn test_nack_and_rereceive() {
             host_id: "fakehost".to_string(),
             count: 3,
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
 

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use futures::StreamExt;
 use serial_test::serial;
 
@@ -47,6 +49,7 @@ async fn test_commands() {
             host_id: host_id.clone(),
             count: 2,
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
 
@@ -257,6 +260,7 @@ async fn test_commands() {
             count: 2,
             host_id: host_id.clone(),
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
 
@@ -318,6 +322,7 @@ async fn test_annotation_stop() {
             host_id: host_id.clone(),
             count: 2,
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
 
@@ -370,6 +375,7 @@ async fn test_annotation_stop() {
             count: 2,
             host_id: host_id.clone(),
             model_name: "fake".into(),
+            annotations: HashMap::new(),
         })
         .await;
 

--- a/tests/storage_nats_kv.rs
+++ b/tests/storage_nats_kv.rs
@@ -6,6 +6,7 @@ use wadm::{
     events::ProviderInfo,
     storage::{
         nats_kv::NatsKvStore, Actor, Host, Provider, ProviderStatus, ReadStore, Store as WadmStore,
+        WadmActorInstance,
     },
 };
 
@@ -24,7 +25,13 @@ async fn test_round_trip() {
         name: "Test Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: HashMap::from([("testhost".to_string(), 1)]),
+        instances: HashMap::from([(
+            "testhost".to_string(),
+            HashSet::from_iter([WadmActorInstance {
+                instance_id: "1".to_string(),
+                annotations: HashMap::new(),
+            }]),
+        )]),
         reference: "fake.oci.repo/testactor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -34,7 +41,13 @@ async fn test_round_trip() {
         name: "Another Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: HashMap::from([("testhost".to_string(), 1)]),
+        instances: HashMap::from([(
+            "testhost".to_string(),
+            HashSet::from_iter([WadmActorInstance {
+                instance_id: "2".to_string(),
+                annotations: HashMap::new(),
+            }]),
+        )]),
         reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -198,7 +211,13 @@ async fn test_multiple_lattice() {
         name: "Test Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: HashMap::from([("testhost".to_string(), 1)]),
+        instances: HashMap::from([(
+            "testhost".to_string(),
+            HashSet::from_iter([WadmActorInstance {
+                instance_id: "1".to_string(),
+                annotations: HashMap::new(),
+            }]),
+        )]),
         reference: "fake.oci.repo/testactor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -208,7 +227,13 @@ async fn test_multiple_lattice() {
         name: "Another Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: HashMap::from([("testhost".to_string(), 1)]),
+        instances: HashMap::from([(
+            "testhost".to_string(),
+            HashSet::from_iter([WadmActorInstance {
+                instance_id: "2".to_string(),
+                annotations: HashMap::new(),
+            }]),
+        )]),
         reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -265,7 +290,13 @@ async fn test_store_and_delete_many() {
         name: "Test Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: HashMap::from([("testhost".to_string(), 1)]),
+        instances: HashMap::from([(
+            "testhost".to_string(),
+            HashSet::from_iter([WadmActorInstance {
+                instance_id: "1".to_string(),
+                annotations: HashMap::new(),
+            }]),
+        )]),
         reference: "fake.oci.repo/testactor:0.1.0".to_string(),
         ..Default::default()
     };
@@ -275,7 +306,13 @@ async fn test_store_and_delete_many() {
         name: "Another Actor".to_string(),
         capabilities: vec!["wasmcloud:httpserver".to_string()],
         issuer: "afakekey".to_string(),
-        count: HashMap::from([("testhost".to_string(), 1)]),
+        instances: HashMap::from([(
+            "testhost".to_string(),
+            HashSet::from_iter([WadmActorInstance {
+                instance_id: "2".to_string(),
+                annotations: HashMap::new(),
+            }]),
+        )]),
         reference: "fake.oci.repo/anotheractor:0.1.0".to_string(),
         ..Default::default()
     };


### PR DESCRIPTION
Fixes #51 

This PR adds the `ActorSpreadScaler`, an implementation of the `Scaler` trait which spreads replicas of actors across a list of spread requirements. It does not attempt to evenly spread on hosts that match requirements, as that's more complicated and better suited for another Scaler implementation.

Currently marking as ready for review, but two (or three?) outstanding things I need to address
- [x] Host state is not modified in the store when an actor is stopped or started. Updated PR to ensure host state is updated when actors and providers start/stop
- [x] There may be an edge case where multiple spread requirements match on the same host, resulting in conflicting commands. Annotations will be required to solve this, may have to add support in this PR.
    - After rebasing and adding in #76, this functionality was added _and_ required a ton of work to refactor our current state to take into account instance IDs and annotations.
- [x] (future PR) This scaler ignores linkdef and provider events. If desired to show a similar implementation for those scalers, they will be in different files as different `Scaler` implementations

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Added multiple unit tests to ensure proper functionality of the spreadscaler

### Manual Verification
I ran the tests but did not run for reals since the mechanism for publishing commands isn't hooked up quite yet
