### PR TITLE
feat(*): Automatically observe lattices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1174495e436c928905018f10a36160f7a8a6786450f50f4ce7fba05d1539704c"
+dependencies = [
+ "async-nats-tokio-rustls-deps",
+ "base64 0.13.1",
+ "base64-url",
+ "bytes",
+ "futures",
+ "http",
+ "itoa",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "rand",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time 0.3.20",
+ "tokio",
+ "tokio-retry",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-nats-tokio-rustls-deps"
+version = "0.24.0-ALPHA.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdefe54cd7867d937c0a507d2a3a830af410044282cd3e4002b5b7860e1892e"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,7 +1087,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls",
 ]
@@ -1194,12 +1239,6 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1868,7 +1907,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1960,6 +1999,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +2029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2132,14 +2193,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2495,7 +2557,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
 ]
@@ -2815,6 +2877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,7 +2927,7 @@ name = "wadm"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.29.0",
  "async-trait",
  "atty",
  "chrono",
@@ -3015,7 +3083,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e61f6be0a90660de63951fb782dbb37979d03203c60176b6041ec36f6d367136"
 dependencies = [
- "async-nats",
+ "async-nats 0.27.1",
  "async-trait",
  "atty",
  "base64 0.13.1",
@@ -3028,8 +3096,6 @@ dependencies = [
  "minicbor-ser",
  "nkeys",
  "once_cell",
- "opentelemetry",
- "opentelemetry-otlp",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -3041,7 +3107,6 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
  "wascap",
@@ -3052,10 +3117,9 @@ dependencies = [
 [[package]]
 name = "wasmcloud-control-interface"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1105968693598b601247e74b24d8edee7c36eaeaa44fbd5333a38fa23d33de7c"
+source = "git+https://github.com/thomastaylor312/control-interface-client.git?branch=tmp/dep_workaround#05ba71dd1fdb66091e11d3a96a87f97844a2be1a"
 dependencies = [
- "async-nats",
+ "async-nats 0.29.0",
  "cloudevents-sdk 0.6.0",
  "data-encoding",
  "futures",
@@ -3267,15 +3331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ cli = ["clap", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry", "
 
 [dependencies]
 anyhow = "1"
-async-nats = "0.27"
+async-nats = "0.29"
 async-trait = "0.1"
 atty = { version = "0.2", optional = true }
 chrono = "0.4"
@@ -27,7 +27,7 @@ opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-clie
 prometheus = { version = "0.13", optional = true }
 serde = "1"
 serde_json = "1"
-serde_yaml = "0.8.7"
+serde_yaml = "0.9"
 sha2 = "0.10.2"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
@@ -36,7 +36,9 @@ tracing-futures = "0.2"
 tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"], optional = true }
 uuid = { version = "1", optional = true }
-wasmcloud-control-interface = "0.24"
+# Temporary workaround until we can merge and release some fixes to wasmbus that require the use of
+# an older version of nats
+wasmcloud-control-interface = { version = "0.24", git = "https://github.com/thomastaylor312/control-interface-client.git", branch = "tmp/dep_workaround" }
 semver = { version = "1.0.16", features = [ "serde" ] }
 
 [dev-dependencies]

--- a/bin/connections.rs
+++ b/bin/connections.rs
@@ -1,11 +1,6 @@
 //! A module for connection pools and generators. This is needed because control interface clients
 //! (and possibly other things like nats connections in the future) are lattice scoped or need
 //! different credentials
-
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use tokio::sync::RwLock;
 use wasmcloud_control_interface::{Client, ClientBuilder};
 
 #[derive(Debug, Default, Clone)]
@@ -16,39 +11,26 @@ pub struct ControlClientConfig {
     pub topic_prefix: Option<String>,
 }
 
-/// A connection pool for wasmCloud control interface clients, identified by a lattice ID
+/// A client constructor for wasmCloud control interface clients, identified by a lattice ID
+// NOTE: Yes, this sounds java-y. Deal with it.
 #[derive(Clone)]
-pub struct ControlClientPool {
+pub struct ControlClientConstructor {
     client: async_nats::Client,
     config: ControlClientConfig,
-    // NOTE(thomastaylor312): At some point we should revisit this. If we are in a massive
-    // multi-tenant environment with thousands of lattices, that means this could be thousands of
-    // items big. I initially attempted to use the `lru` crate to have a limited number cached in
-    // memory (basically all of the hottest ones), but that type doesn't work very well in async
-    // contexts behind a RwLock due to the need for it to be `mut`. Having it always locked behind a
-    // mutex would introduce its own set of issues. So we may need to come up with another form of
-    // eviction here to let it scale a bit better at some point. We could also decide that just
-    // creating the client every time is fine as well
-    pool: Arc<RwLock<HashMap<String, Client>>>,
 }
 
-impl ControlClientPool {
+impl ControlClientConstructor {
     /// Creates a new client pool that is all backed using the same NATS client. The given NATS
     /// client should be using credentials that can access all desired lattices.
-    pub fn new(client: async_nats::Client, config: ControlClientConfig) -> ControlClientPool {
-        ControlClientPool {
-            client,
-            config,
-            pool: Arc::new(RwLock::new(HashMap::new())),
-        }
+    pub fn new(
+        client: async_nats::Client,
+        config: ControlClientConfig,
+    ) -> ControlClientConstructor {
+        ControlClientConstructor { client, config }
     }
 
     /// Get the client for the given lattice ID
     pub async fn get_connection(&self, id: &str) -> anyhow::Result<Client> {
-        if let Some(client) = self.pool.read().await.get(id) {
-            return Ok(client.clone());
-        }
-
         let builder = ClientBuilder::new(self.client.clone()).lattice_prefix(id);
         let builder = if let Some(domain) = self.config.js_domain.as_deref() {
             builder.js_domain(domain)
@@ -60,12 +42,9 @@ impl ControlClientPool {
         } else {
             builder
         };
-        let client = builder
+        builder
             .build()
             .await
-            .map_err(|e| anyhow::anyhow!("Error building client for {id}: {e:?}"))?;
-        let mut pool = self.pool.write().await;
-        pool.insert(id.to_owned(), client.clone());
-        Ok(client)
+            .map_err(|e| anyhow::anyhow!("Error building client for {id}: {e:?}"))
     }
 }

--- a/bin/nats.rs
+++ b/bin/nats.rs
@@ -81,7 +81,7 @@ async fn get_seed(seed: String) -> Result<nkeys::KeyPair> {
 pub async fn ensure_stream(
     context: &Context,
     name: String,
-    subject: String,
+    subjects: Vec<String>,
     description: Option<String>,
 ) -> Result<Stream> {
     context
@@ -90,7 +90,7 @@ pub async fn ensure_stream(
             description,
             num_replicas: 1,
             retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
-            subjects: vec![subject],
+            subjects,
             max_age: DEFAULT_EXPIRY_TIME,
             storage: async_nats::jetstream::stream::StorageType::File,
             allow_rollup: false,

--- a/bin/observer.rs
+++ b/bin/observer.rs
@@ -1,0 +1,113 @@
+//! Types for observing a nats cluster for new lattices
+
+use async_nats::Subscriber;
+use futures::{stream::SelectAll, StreamExt, TryFutureExt};
+use tracing::{debug, error, instrument, trace, warn};
+
+use wadm::{
+    consumers::{manager::ConsumerManager, CommandConsumer, EventConsumer},
+    events::{EventType, HostHeartbeat, HostStarted},
+    nats_utils::LatticeIdParser,
+    storage::{nats_kv::NatsKvStore, reaper::Reaper, Store},
+    workers::{CommandWorker, EventWorker},
+    DEFAULT_COMMANDS_TOPIC,
+};
+
+use super::connections::ControlClientConstructor;
+
+pub(crate) struct Observer<S> {
+    pub(crate) client_builder: ControlClientConstructor,
+    pub(crate) parser: LatticeIdParser,
+    pub(crate) command_manager: ConsumerManager<CommandConsumer>,
+    pub(crate) event_manager: ConsumerManager<EventConsumer>,
+    pub(crate) client: async_nats::Client,
+    pub(crate) store: S,
+    pub(crate) reaper: Reaper<NatsKvStore>,
+}
+
+impl<S: Store + Send + Sync + Clone + 'static> Observer<S> {
+    /// Watches the given topic (with wildcards) for wasmbus events. If it finds a lattice that it
+    /// isn't managing, it will start managing it immediately
+    ///
+    /// If this errors, it should be considered fatal
+    #[instrument(level = "info", skip(self))]
+    pub(crate) async fn observe(mut self, subscribe_topics: Vec<String>) -> anyhow::Result<()> {
+        let mut sub = get_subscriber(&self.client, subscribe_topics.clone()).await?;
+        loop {
+            match sub.next().await {
+                Some(msg) => {
+                    if !is_event_we_care_about(&msg.payload) {
+                        continue;
+                    }
+                    let lattice_id = match self.parser.parse(&msg.subject) {
+                        Some(id) => id,
+                        None => {
+                            trace!(subject = %msg.subject, "Found non-matching lattice subject");
+                            continue;
+                        }
+                    };
+
+                    // Create the reaper for this lattice. This operation returns early if it is
+                    // already running
+                    self.reaper.observe(lattice_id);
+
+                    let needs_command = !self.command_manager.has_consumer(&msg.subject).await;
+                    let needs_event = !self.event_manager.has_consumer(&msg.subject).await;
+                    let client = if needs_command || needs_event {
+                        match self.client_builder.get_connection(lattice_id).await {
+                            Ok(c) => c,
+                            Err(e) => {
+                                error!(error = %e, %lattice_id, "Couldn't construct control client for consumer. Will retry on next heartbeat");
+                                continue;
+                            }
+                        }
+                    } else {
+                        continue;
+                    };
+                    if needs_command {
+                        debug!(%lattice_id, subject = %msg.subject, "Found unmonitored lattice, adding command consumer");
+                        self.command_manager.add_for_lattice(&DEFAULT_COMMANDS_TOPIC.replace('*', lattice_id), lattice_id, CommandWorker::new(client.clone())).await.unwrap_or_else(|e| {
+                            error!(error = %e, %lattice_id, "Couldn't add command consumer. Will retry on next heartbeat");
+                        })
+                    }
+                    if needs_event {
+                        debug!(%lattice_id, subject = %msg.subject, "Found unmonitored lattice, adding event consumer");
+                        self.event_manager.add_for_lattice(&msg.subject, lattice_id, EventWorker::new(self.store.clone(), client)).await.unwrap_or_else(|e| {
+                            error!(error = %e, %lattice_id, "Couldn't add event consumer. Will retry on next heartbeat");
+                        })
+                    }
+                }
+                None => {
+                    warn!("Observer subscriber hang up. Attempting to restart");
+                    sub = get_subscriber(&self.client, subscribe_topics.clone()).await?;
+                }
+            }
+        }
+    }
+}
+
+// This is a stupid hacky function to check that this is a host started or host heartbeat event
+// without actually parsing
+fn is_event_we_care_about(data: &[u8]) -> bool {
+    let string_data = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    string_data.contains(HostStarted::TYPE) || string_data.contains(HostHeartbeat::TYPE)
+}
+
+async fn get_subscriber(
+    client: &async_nats::Client,
+    subscribe_topics: Vec<String>,
+) -> anyhow::Result<SelectAll<Subscriber>> {
+    let futs = subscribe_topics
+        .clone()
+        .into_iter()
+        .map(|t| client.subscribe(t).map_err(|e| anyhow::anyhow!("{e:?}")));
+    let subs: Vec<Subscriber> = futures::future::join_all(futs)
+        .await
+        .into_iter()
+        .collect::<Result<_, anyhow::Error>>()?;
+    Ok(futures::stream::select_all(subs))
+}

--- a/src/consumers/events.rs
+++ b/src/consumers/events.rs
@@ -33,19 +33,17 @@ impl EventConsumer {
     /// Creates a new event consumer, returning an error if unable to create or access the durable
     /// consumer on the given stream.
     ///
-    /// The `topic` param should be a valid topic where lattice events are expected to be sent (e.g.
-    /// `wasmbus.evt.<lattice_prefix>`). An error will be returned if the topic is not in a
-    /// recognized format. This is due to the need to fetch the lattice id off of the topic and
-    /// match the correct inbound events
-    pub async fn new(stream: JsStream, topic: &str) -> Result<EventConsumer, NatsError> {
-        // Basically there should always be 3 strings when split per topic. <bus prefix>.evt.<lattice_id>
-        if topic.split('.').count() != 3 {
-            return Err(format!("Subject {topic} is not valid").into());
+    /// The `topic` param should be a valid topic where lattice events are expected to be sent and
+    /// should match the given lattice ID. An error will be returned if the given lattice ID is not
+    /// contained in the topic
+    pub async fn new(
+        stream: JsStream,
+        topic: &str,
+        lattice_id: &str,
+    ) -> Result<EventConsumer, NatsError> {
+        if !topic.contains(lattice_id) {
+            return Err(format!("Topic {topic} does not match for lattice ID {lattice_id}").into());
         }
-
-        // Safety: We can unwrap here because we already checked that we got 3 items on the split above
-        let lattice_id = topic.rsplit_once('.').unwrap().1.to_owned();
-
         let consumer_name = format!("{EVENTS_CONSUMER_PREFIX}_{lattice_id}");
         let consumer = stream
             .get_or_create_consumer(
@@ -72,7 +70,7 @@ impl EventConsumer {
             .await?;
         Ok(EventConsumer {
             stream: messages,
-            lattice_id,
+            lattice_id: lattice_id.to_owned(),
         })
     }
 }
@@ -146,7 +144,8 @@ impl CreateConsumer for EventConsumer {
     async fn create(
         stream: async_nats::jetstream::stream::Stream,
         topic: &str,
+        lattice_id: &str,
     ) -> Result<Self::Output, NatsError> {
-        EventConsumer::new(stream, topic).await
+        EventConsumer::new(stream, topic, lattice_id).await
     }
 }

--- a/src/consumers/manager.rs
+++ b/src/consumers/manager.rs
@@ -68,6 +68,17 @@ pub trait Worker {
     async fn do_work(&self, message: ScopedMessage<Self::Message>) -> WorkResult<()>;
 }
 
+/// A trait used for dynamically creating workers.
+///
+/// This is mostly available as a workaround so that a manager can create a worker for a lattice
+/// when reconciling. See the main wadm binary code for an example of how to do this
+#[async_trait::async_trait]
+pub trait WorkerCreator {
+    type Output: Worker + Send + Sync + 'static;
+
+    async fn create(&self, lattice_id: &str) -> anyhow::Result<Self::Output>;
+}
+
 /// A manager of a specific type of Consumer that handles giving out permits to work and managing
 /// per lattice consumers.
 ///
@@ -88,22 +99,84 @@ impl<C> ConsumerManager<C> {
     /// Returns a new consumer manager set up to use the given permit pool. This meant to use a
     /// shared pool of permits with other consumer managers to manage the amount of simultaneous
     /// work, so the Semaphore must be wrapped in an [`Arc`].
-    pub fn new(permit_pool: Arc<Semaphore>, stream: NatsStream) -> ConsumerManager<C> {
-        ConsumerManager {
+    ///
+    /// This function will attempt to populate this itself with all existing consumers. Any errors
+    /// that occur during population will only log and not error out as it is recoverable. Because
+    /// of this, it requires something that can generate the desired worker
+    pub async fn new<W, F>(
+        permit_pool: Arc<Semaphore>,
+        stream: NatsStream,
+        worker_generator: F,
+    ) -> ConsumerManager<C>
+    where
+        W: Worker + Send + Sync + 'static,
+        C: Stream<Item = Result<ScopedMessage<W::Message>, async_nats::Error>>
+            + CreateConsumer<Output = C>
+            + Send
+            + Unpin
+            + 'static,
+        F: WorkerCreator<Output = W>,
+    {
+        let mut manager = ConsumerManager {
             handles: Arc::new(RwLock::new(HashMap::default())),
             permits: permit_pool,
             stream,
             phantom: PhantomData,
-        }
-    }
-}
+        };
 
-impl<C> ConsumerManager<C> {
+        let handles: HashMap<String, JoinHandle<WorkResult<()>>> = manager.stream.consumers().filter_map(|res| async {
+            let info = match res {
+                Ok(info) => info,
+                Err(e) => {
+                    error!(error = %e, "Error when trying to read current consumers");
+                    return None
+                }
+            };
+            // TODO: This is somewhat brittle as we could change naming schemes, but it is
+            // good enough for now. We are just taking the name (which should be of the
+            // format `<consumer_prefix>_<lattice_id>`), but this makes sure we are always
+            // getting the last thing in case of other underscores
+            let lattice_id = match info.name.split('_').last() {
+                Some(id) => id,
+                None => return None,
+            };
+            // NOTE(thomastaylor312): It might be nicer for logs if we add an extra param for a
+            // friendly consumer manager name
+            trace!(%lattice_id, "Adding consumer for lattice");
+
+            let worker = match worker_generator.create(lattice_id).await {
+                Ok(w) => w,
+                Err(e) => {
+                    error!(error = %e, %lattice_id, "Unable to add consumer for lattice. Error when generating worker");
+                    return None;
+                }
+            };
+
+            match manager
+                .spawn_handler(&info.config.filter_subject, lattice_id, worker)
+                .await {
+                    Ok(handle) => Some((lattice_id.to_owned(), handle)),
+                    Err(e) => {
+                        error!(error = %e, %lattice_id, "Unable to add consumer for lattice");
+                        None
+                    }
+                }
+        }).collect().await;
+
+        manager.handles = Arc::new(RwLock::new(handles));
+        manager
+    }
+
     /// Starts a new consumer for the given topic. This method will only fail if there was an error
     /// setting up the consumer.
     ///
     /// The given work function should attempt to handle the event
-    pub async fn add_for_lattice<W>(&self, topic: &str, worker: W) -> Result<(), async_nats::Error>
+    pub async fn add_for_lattice<W>(
+        &self,
+        topic: &str,
+        lattice_id: &str,
+        worker: W,
+    ) -> Result<(), async_nats::Error>
     where
         W: Worker + Send + Sync + 'static,
         C: Stream<Item = Result<ScopedMessage<W::Message>, async_nats::Error>>
@@ -113,16 +186,32 @@ impl<C> ConsumerManager<C> {
             + 'static,
     {
         if !self.has_consumer(topic).await {
-            let consumer = C::create(self.stream.clone(), topic).await?;
-            let permits = self.permits.clone();
-            let handle = tokio::spawn(
-                work_fn(consumer, permits, worker)
-                    .instrument(tracing::info_span!("consumer_worker", %topic)),
-            );
+            let handle = self.spawn_handler(topic, lattice_id, worker).await?;
             let mut handles = self.handles.write().await;
             handles.insert(topic.to_owned(), handle);
         }
         Ok(())
+    }
+
+    async fn spawn_handler<W>(
+        &self,
+        topic: &str,
+        lattice_id: &str,
+        worker: W,
+    ) -> Result<JoinHandle<WorkResult<()>>, async_nats::Error>
+    where
+        W: Worker + Send + Sync + 'static,
+        C: Stream<Item = Result<ScopedMessage<W::Message>, async_nats::Error>>
+            + CreateConsumer<Output = C>
+            + Send
+            + Unpin
+            + 'static,
+    {
+        let consumer = C::create(self.stream.clone(), topic, lattice_id).await?;
+        let permits = self.permits.clone();
+        Ok(tokio::spawn(work_fn(consumer, permits, worker).instrument(
+            tracing::info_span!("consumer_worker", %topic),
+        )))
     }
 
     /// Checks if this manager has a consumer for the given topic. Returns `false` if it doesn't

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub mod test_util;
 pub const DEFAULT_EXPIRY_TIME: Duration = Duration::from_secs(70);
 /// Default topic to listen to for all lattice events
 pub const DEFAULT_EVENTS_TOPIC: &str = "wasmbus.evt.*";
+/// Default topic to listen to for all lattice events in a multitenant deployment
+pub const DEFAULT_MULTITENANT_EVENTS_TOPIC: &str = "*.wasmbus.evt.*";
 /// Default topic to listen to for all commands
 pub const DEFAULT_COMMANDS_TOPIC: &str = "wadm.cmd.*";
 /// Managed by annotation used for labeling things properly in wadm

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -362,8 +362,9 @@ mod test {
         let serialized_json =
             serde_json::to_vec(&manifest).expect("Should be able to serialize JSON");
 
-        let serialized_yaml =
-            serde_yaml::to_vec(&manifest).expect("Should be able to serialize YAML");
+        let serialized_yaml = serde_yaml::to_string(&manifest)
+            .expect("Should be able to serialize YAML")
+            .into_bytes();
 
         // Test the round trip back in
         let json_manifest: Manifest = serde_json::from_slice(&serialized_json)

--- a/src/nats_utils.rs
+++ b/src/nats_utils.rs
@@ -1,21 +1,128 @@
 //! Helper utilities for interacting with NATS
-use async_nats::jetstream::Context;
-use serde::Serialize;
+const EVENT_SUBJECT: &str = "evt";
 
-/// A helper function that serializes data and ensures a message was sent and received by a stream.
-/// Returns an error if the message could not be serialized, sent, or if the message wasn't
-/// acknowledged
-pub async fn ensure_send<T: Serialize>(
-    context: &Context,
-    subject: String,
-    data: &T,
-) -> anyhow::Result<()> {
-    // TODO: wrap this in a struct with the subject and the client so things can be flushed after every message
-    let fut = context
-        .publish(subject, serde_json::to_vec(data)?.into())
-        .await
-        .map_err(|e| anyhow::anyhow!("Unable to publish message: {e:?}"))?;
-    fut.await
-        .map(|_| ())
-        .map_err(|e| anyhow::anyhow!("Never received ack from server: {e:?}"))
+/// A parser for NATS subjects that parses out a lattice ID for any given subject
+pub struct LatticeIdParser {
+    // NOTE(thomastaylor312): We don't actually support specific prefixes right now, but we could in
+    // the future as we already do for control topics. So this is just trying to future proof
+    prefix: String,
+    multitenant: bool,
+}
+
+impl LatticeIdParser {
+    /// Returns a new parser configured to use the given prefix. If `multitenant` is set to true,
+    /// this parser will also attempt to parse a subject as if it were an account imported topic
+    /// (e.g. `A****.wasmbus.evt.{lattice-id}`) if it doesn't match the normally expected pattern
+    pub fn new(prefix: &str, multitenant: bool) -> LatticeIdParser {
+        LatticeIdParser {
+            prefix: prefix.to_owned(),
+            multitenant,
+        }
+    }
+
+    /// Parses the given subject based on settings and then returns the lattice ID of the subject.
+    /// Returns None if it couldn't parse the topic
+    pub fn parse<'a>(&self, subject: &'a str) -> Option<&'a str> {
+        let separated: Vec<&str> = subject.split('.').collect();
+        // For reference, topics look like the following:
+        //
+        // Normal: `{prefix}.evt.{lattice-id}`
+        // Multitenant: `{account-id}.{prefix}.evt.{lattice-id}`
+        //
+        // Note that the account ID should be prefaced with an `A`
+        match separated[..] {
+            [prefix, evt, lattice_id] if prefix == self.prefix && evt == EVENT_SUBJECT => {
+                Some(lattice_id)
+            }
+            [account_id, prefix, evt, lattice_id]
+                if self.multitenant
+                    && prefix == self.prefix
+                    && evt == EVENT_SUBJECT
+                    && account_id.starts_with('A') =>
+            {
+                Some(lattice_id)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_valid_subjects() {
+        // Default first
+        let parser = LatticeIdParser::new("wasmbus", false);
+
+        assert_eq!(
+            parser
+                .parse("wasmbus.evt.blahblah")
+                .expect("Should return lattice id"),
+            "blahblah",
+            "Should return the right ID"
+        );
+
+        // Shouldn't parse a multitenant
+        assert!(
+            parser.parse("ACCOUNTID.wasmbus.evt.default").is_none(),
+            "Shouldn't parse a multitenant topic"
+        );
+
+        // Multitenant second
+        let parser = LatticeIdParser::new("wasmbus", true);
+
+        assert_eq!(
+            parser
+                .parse("wasmbus.evt.blahblah")
+                .expect("Should return lattice id"),
+            "blahblah",
+            "Should return the right ID"
+        );
+
+        assert_eq!(
+            parser
+                .parse("ACCOUNTID.wasmbus.evt.blahblah")
+                .expect("Should return lattice id"),
+            "blahblah",
+            "Should return the right ID"
+        );
+    }
+
+    #[test]
+    fn test_invalid_subjects() {
+        let parser = LatticeIdParser::new("wasmbus", true);
+
+        // Test 3 and 4 part subjects to make sure they don't parse
+        assert!(
+            parser.parse("BLAH.wasmbus.notevt.default").is_none(),
+            "Shouldn't parse 4 part invalid topic"
+        );
+
+        assert!(
+            parser.parse("wasmbus.notme.default").is_none(),
+            "Shouldn't parse 3 part invalid topic"
+        );
+
+        assert!(
+            parser.parse("lebus.evt.default").is_none(),
+            "Shouldn't parse an non-matching prefix"
+        );
+
+        assert!(
+            parser.parse("wasmbus.evt").is_none(),
+            "Shouldn't parse a too short topic"
+        );
+
+        assert!(
+            parser.parse("BADACCOUNT.wasmbus.evt.default").is_none(),
+            "Shouldn't parse invalid account topic"
+        );
+
+        assert!(
+            parser.parse("wasmbus.notme.default.bar.baz").is_none(),
+            "Shouldn't parse long topic"
+        );
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -160,7 +160,7 @@ impl<S: Store + Send + Sync> Server<S> {
                 }
             }
         }
-        return Err(anyhow::anyhow!("Subscriber terminated"));
+        Err(anyhow::anyhow!("Subscriber terminated"))
     }
 
     fn parse_subject<'a>(&self, subject: &'a str) -> anyhow::Result<ParsedSubject<'a>> {

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -193,19 +193,14 @@ pub struct StatusInfo {
 }
 
 /// All possible status types
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Copy, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum StatusType {
+    #[default]
     Undeployed,
     Compensating,
     Ready,
     Failed,
-}
-
-impl Default for StatusType {
-    fn default() -> Self {
-        StatusType::Undeployed
-    }
 }
 
 // Implementing add makes it easy for use to get an aggregate status by summing all of them together

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -134,7 +134,7 @@ async fn test_crud_operations() {
     let resp: PutModelResponse = test_server
         .get_response(
             "default.model.put.my-example-app",
-            serde_yaml::to_vec(&manifest).unwrap(),
+            serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
         .await;
@@ -147,7 +147,7 @@ async fn test_crud_operations() {
     let resp: PutModelResponse = test_server
         .get_response(
             "default.model.put.my-example-app",
-            serde_yaml::to_vec(&manifest).unwrap(),
+            serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
         .await;
@@ -540,7 +540,7 @@ async fn test_deploy() {
     let resp: PutModelResponse = test_server
         .get_response(
             "default.model.put.petclinic",
-            serde_yaml::to_vec(&manifest).unwrap(),
+            serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
         .await;

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -52,7 +52,7 @@ async fn get_event_consumer(nats_url: String) -> EventConsumer {
             ..Default::default()
         }).await.expect("Should be able to create test stream")
     };
-    EventConsumer::new(stream, WASMBUS_EVENT_TOPIC)
+    EventConsumer::new(stream, WASMBUS_EVENT_TOPIC, "default")
         .await
         .expect("Unable to setup stream")
 }

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -263,7 +263,7 @@ impl StreamWrapper {
             .await
             .expect("Should be able to create test stream")
         };
-        let stream = CommandConsumer::new(stream, &topic)
+        let stream = CommandConsumer::new(stream, &topic, "default")
             .await
             .expect("Unable to setup stream");
         StreamWrapper {


### PR DESCRIPTION
This commit makes it so that wadm automatically watches for new lattices to appear and then manages them. As part of this, it made sense to actually make sure this is mutlitenant ready as well. So this implements the functionality to properly observe for multitenant (read: cross account importing) architectures.

Not gonna lie that some of the stuff to start watching pre-observed lattices is a bit messy, but I did test it out and it is real slick