### PR TITLE
feat(*): Notifies on manifest deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,7 @@ dependencies = [
  "async-nats 0.29.0",
  "async-trait",
  "atty",
+ "bytes",
  "chrono",
  "clap",
  "cloudevents-sdk 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2021"
 
 [features]
 default = []
-cli = ["clap", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry", "opentelemetry-otlp", "atty", "uuid"]
+cli = ["clap", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry", "opentelemetry-otlp", "atty"]
 
 [dependencies]
 anyhow = "1"
 async-nats = "0.29"
 async-trait = "0.1"
 atty = { version = "0.2", optional = true }
+bytes = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "cargo", "env"], optional = true }
 cloudevents-sdk = "0.7"
@@ -35,7 +36,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"], optional = true }
-uuid = { version = "1", optional = true }
+uuid = "1"
 # Temporary workaround until we can merge and release some fixes to wasmbus that require the use of
 # an older version of nats
 wasmcloud-control-interface = { version = "0.24", git = "https://github.com/thomastaylor312/control-interface-client.git", branch = "tmp/dep_workaround" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 pub mod commands;
 pub mod consumers;
 pub mod events;
+pub mod mirror;
 pub mod model;
 pub mod nats_utils;
 pub mod scaler;
@@ -22,8 +23,11 @@ pub const DEFAULT_EVENTS_TOPIC: &str = "wasmbus.evt.*";
 pub const DEFAULT_MULTITENANT_EVENTS_TOPIC: &str = "*.wasmbus.evt.*";
 /// Default topic to listen to for all commands
 pub const DEFAULT_COMMANDS_TOPIC: &str = "wadm.cmd.*";
+/// The default listen topic for the merged wadm events stream. This topic is an amalgamation of
+/// wasmbus.evt topics plus the wadm.internal topics
+pub const DEFAULT_WADM_EVENTS_TOPIC: &str = "wadm.evt.*";
 /// Managed by annotation used for labeling things properly in wadm
-pub const MANAGED_BY_ANNOTATION: &str = "wasmcloud.com/managed-by";
+pub const MANAGED_BY_ANNOTATION: &str = "wasmcloud.dev/managed-by";
 /// Identifier for managed by annotation. This is the value [`MANAGED_BY_ANNOTATION`] is set to
 pub const MANAGED_BY_IDENTIFIER: &str = "wadm";
 /// An annotation that denotes which model a resource belongs to

--- a/src/mirror/mod.rs
+++ b/src/mirror/mod.rs
@@ -1,0 +1,142 @@
+//! This is a temporary workaround to let us combine multiple topics into a single stream so
+//! consumers work properly. This will be removed once NATS 2.10 is out and we have upgraded to
+//! using it in wasmcloud projects
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_nats::{
+    jetstream::{
+        consumer::pull::{Config as PullConfig, Stream as MessageStream},
+        stream::Stream as JsStream,
+        Context,
+    },
+    Error as NatsError, HeaderMap,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use tokio::{sync::RwLock, task::JoinHandle};
+use tracing::{error, instrument, trace, warn};
+
+type WorkHandles = Arc<RwLock<HashMap<String, JoinHandle<anyhow::Result<()>>>>>;
+
+/// A simple NATS consumer that takes each incoming message and maps it to `{prefix}.{lattice-id}`
+/// (e.g. `wadm.evt.default`)
+pub struct Mirror {
+    stream: JsStream,
+    prefix: String,
+    handles: WorkHandles,
+}
+
+impl Mirror {
+    /// Returns a new Mirror for the given stream
+    pub fn new(stream: JsStream, prefix: &str) -> Mirror {
+        Mirror {
+            stream,
+            prefix: prefix.to_owned(),
+            handles: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub async fn monitor_lattice(&self, subject: &str, lattice_id: &str) -> Result<(), NatsError> {
+        if let Some(handle) = self.handles.read().await.get(lattice_id) {
+            if !handle.is_finished() {
+                return Ok(());
+            }
+            warn!("Handle was marked as completed. Starting monitor again");
+        }
+        let consumer_name = format!("wadm_mirror_{lattice_id}");
+        trace!("Creating mirror consumer for lattice");
+        let consumer = self
+            .stream
+            .get_or_create_consumer(
+                &consumer_name,
+                PullConfig {
+                    durable_name: Some(consumer_name.clone()),
+                    name: Some(consumer_name.clone()),
+                    description: Some(format!("Durable wadm mirror consumer for {lattice_id}")),
+                    ack_policy: async_nats::jetstream::consumer::AckPolicy::Explicit,
+                    ack_wait: std::time::Duration::from_secs(2),
+                    max_deliver: 3,
+                    deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::All,
+                    filter_subject: subject.to_owned(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let messages = consumer
+            .stream()
+            .max_messages_per_batch(1)
+            .messages()
+            .await?;
+        let handle = tokio::spawn(mirror_worker(
+            messages,
+            format!("{}.{lattice_id}", self.prefix),
+        ));
+
+        self.handles
+            .write()
+            .await
+            .insert(lattice_id.to_owned(), handle);
+        Ok(())
+    }
+}
+
+#[instrument(level = "info", skip(messages))]
+async fn mirror_worker(mut messages: MessageStream, publish_topic: String) -> anyhow::Result<()> {
+    loop {
+        match messages.next().await {
+            Some(Ok(msg)) => {
+                // NOTE(thomastaylor312): I can't actually consume the payload because I can't ack
+                // (without copy pasting the ack code) due to the partial move. I am working with
+                // the async_nats maintainers to see if we can add something to get around this, but
+                // in the meantime, we're just gonna deal with it
+                if let Err(e) = republish(
+                    &msg.context,
+                    publish_topic.clone(),
+                    msg.message.headers.clone().unwrap_or_default(),
+                    msg.message.payload.clone(),
+                )
+                .await
+                {
+                    error!(error = ?e, "Unable to republish message. Will nak and retry");
+                    if let Err(e) = msg
+                        .ack_with(async_nats::jetstream::AckKind::Nak(None))
+                        .await
+                    {
+                        warn!(error = ?e, "Unable to nak. This message will timeout and redeliver");
+                    }
+                } else if let Err(e) = msg.double_ack().await {
+                    // There isn't much we can do if this happens as this means we
+                    // successfully published, but couldn't nak
+                    error!(error = ?e, "Unable to ack. This message will timeout and redeliver a duplicate message");
+                }
+            }
+            Some(Err(e)) => {
+                warn!(error = ?e, "Error when processing message to mirror");
+                continue;
+            }
+            None => {
+                error!("Mirror stream stopped processing");
+                anyhow::bail!("Mirror stream stopped processing")
+            }
+        }
+    }
+}
+
+async fn republish(
+    context: &Context,
+    topic: String,
+    headers: HeaderMap,
+    payload: Bytes,
+) -> anyhow::Result<()> {
+    // NOTE(thomastaylor312): A future improvement could be retries here
+    let acker = context
+        .publish_with_headers(topic, headers, payload)
+        .await
+        .map_err(|e| anyhow::anyhow!("Unable to republish message: {e:?}"))?;
+    acker
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("Error waiting for message acknowledgement {e:?}"))
+}

--- a/src/server/notifier.rs
+++ b/src/server/notifier.rs
@@ -1,0 +1,99 @@
+use async_nats::jetstream::Context;
+use cloudevents::{EventBuilder, EventBuilderV10};
+use tracing::{instrument, trace};
+
+use crate::{
+    events::{EventType, ManifestPublished, ManifestUnpublished},
+    model::Manifest,
+};
+
+const WADM_SOURCE: &str = "wadm";
+
+/// A trait that indicates something can be used to notify via message or other forms of hooks about
+/// manifest changes
+#[async_trait::async_trait]
+pub trait ManifestNotifier {
+    /// Notifies about a recently deployed manifest. Returns an error if it was unable to send the
+    /// notification.
+    ///
+    /// It isn't required to confirm that the notification is received, but is recommended
+    async fn deployed(&self, lattice_id: &str, manifest: Manifest) -> anyhow::Result<()>;
+
+    /// Notifies about a manifest with the given name that has been undeployed. This is all that is
+    /// needed for undeploys because the name must be unique and it is possible that the manifest no
+    /// longer exists in the store. Returns an error if it was unable to send the notification.
+    ///
+    /// It isn't required to confirm that the notification is received, but is recommended
+    async fn undeployed(&self, lattice_id: &str, name: &str) -> anyhow::Result<()>;
+}
+
+/// A [`ManifestNotifier`] that publishes a NATS message using a jetstream context
+pub struct StreamNotifier {
+    prefix: String,
+    context: Context,
+}
+
+impl StreamNotifier {
+    /// Creates a new stream notifier with the given prefix. This prefix should be something like
+    /// `wadm.evt` that is used to form the full topic to send to
+    pub fn new(prefix: &str, context: Context) -> StreamNotifier {
+        let trimmer: &[_] = &['.', '>', '*'];
+        StreamNotifier {
+            prefix: prefix.trim().trim_matches(trimmer).to_owned(),
+            context,
+        }
+    }
+
+    #[instrument(level = "trace", skip(self, data))]
+    async fn send_event(
+        &self,
+        lattice_id: &str,
+        ty: &str,
+        data: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        let event = EventBuilderV10::new()
+            .id(uuid::Uuid::new_v4().to_string())
+            .source(WADM_SOURCE)
+            .time(chrono::Utc::now())
+            .ty(ty)
+            .data("application/json", data)
+            .build()?;
+        // NOTE(thomastaylor312): A future improvement could be retries here
+        trace!("Sending notification event");
+        let acker = self
+            .context
+            .publish(
+                format!("{}.{lattice_id}", self.prefix),
+                serde_json::to_vec(&event)?.into(),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Unable to send notification: {e:?}"))?;
+        acker
+            .await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Error waiting for message acknowledgement {e:?}"))
+    }
+}
+
+#[async_trait::async_trait]
+impl ManifestNotifier for StreamNotifier {
+    async fn deployed(&self, lattice_id: &str, manifest: Manifest) -> anyhow::Result<()> {
+        self.send_event(
+            lattice_id,
+            ManifestPublished::TYPE,
+            serde_json::to_value(manifest)?,
+        )
+        .await
+    }
+
+    async fn undeployed(&self, lattice_id: &str, name: &str) -> anyhow::Result<()> {
+        self.send_event(
+            lattice_id,
+            ManifestUnpublished::TYPE,
+            serde_json::json!({
+                "name": name,
+            }),
+        )
+        .await
+    }
+}

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -742,6 +742,14 @@ impl<S: Store + Send + Sync, C: ClaimsSource + InventorySource + Send + Sync> Wo
                 self.handle_provider_health_check(&message.lattice_id, host_id, data, true)
                     .await
             }
+            Event::ManifestPublished(_data) => {
+                // TODO: Will need to be handled for managing applications
+                Ok(())
+            }
+            Event::ManifestUnpublished(_data_manifest) => {
+                // TODO: Will need to be handled for managing applications
+                Ok(())
+            }
             // All other events we don't care about for state.
             _ => {
                 trace!("Got event we don't care about. Skipping");

--- a/test/data/events.json
+++ b/test/data/events.json
@@ -210,5 +210,112 @@
         "specversion": "1.0",
         "time": "2023-03-05T00:14:53.990820Z",
         "type": "com.wasmcloud.lattice.provider_start_failed"
+    },
+    {
+        "data": {
+            "apiVersion": "core.oam.dev/v1beta1",
+            "kind": "Application",
+            "metadata": {
+                "name": "my-example-app",
+                "annotations": {
+                    "version": "v0.0.1",
+                    "description": "This is my app"
+                }
+            },
+            "spec": {
+                "components": [
+                    {
+                        "name": "userinfo",
+                        "type": "actor",
+                        "properties": {
+                            "image": "wasmcloud.azurecr.io/fake:1"
+                        },
+                        "traits": [
+                            {
+                                "type": "spreadscaler",
+                                "properties": {
+                                    "replicas": 4,
+                                    "spread": [
+                                        {
+                                            "name": "eastcoast",
+                                            "requirements": {
+                                                "zone": "us-east-1"
+                                            },
+                                            "weight": 80
+                                        },
+                                        {
+                                            "name": "westcoast",
+                                            "requirements": {
+                                                "zone": "us-west-1"
+                                            },
+                                            "weight": 20
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "linkdef",
+                                "properties": {
+                                    "target": "webcap",
+                                    "values": {
+                                        "port": "8080"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "webcap",
+                        "type": "capability",
+                        "properties": {
+                            "contract": "wasmcloud:httpserver",
+                            "image": "wasmcloud.azurecr.io/httpserver:0.13.1",
+                            "link_name": "default"
+                        }
+                    },
+                    {
+                        "name": "ledblinky",
+                        "type": "capability",
+                        "properties": {
+                            "image": "wasmcloud.azurecr.io/ledblinky:0.0.1",
+                            "contract": "wasmcloud:blinkenlights"
+                        },
+                        "traits": [
+                            {
+                                "type": "spreadscaler",
+                                "properties": {
+                                    "replicas": 1,
+                                    "spread": [
+                                        {
+                                            "name": "haslights",
+                                            "requirements": {
+                                                "ledenabled": "true"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "datacontenttype": "application/json",
+        "id": "5a55cf82-713a-4043-be51-ab532d1c8a4d",
+        "source": "wadm",
+        "specversion": "1.0",
+        "time": "2023-03-05T00:14:53.990820Z",
+        "type": "com.wadm.manifest_published"
+    },
+    {
+        "data": {
+            "name": "foobar"
+        },
+        "datacontenttype": "application/json",
+        "id": "5a55cf82-713a-4043-be51-ab532d1c8a4d",
+        "source": "wadm",
+        "specversion": "1.0",
+        "time": "2023-03-05T00:14:53.990820Z",
+        "type": "com.wadm.manifest_unpublished"
     }
 ]


### PR DESCRIPTION
Please note that this is a bit big because I had to have a stream that combined internal wadm events with wasmbus ones. However, I did realize that we only care about streams for their configuration and delivery guarantees, and not for their storage capabilities. Because of this, we don't actually have to have the users configure the streams beforehand. So while this adds one more stream to manage combining the two topics (until nats 2.10 comes out and we move to it), the user no longer has to configure any of them.

Closes #49