### PR TITLE
feat(*): Integrates in the scalers into the event workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,6 +2941,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "prometheus",
+ "rand",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-client"], optional = true }
 # TODO: Actually leverage prometheus
 prometheus = { version = "0.13", optional = true }
+rand = { version = "0.8", features = ["small_rng"] }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9"

--- a/bin/nats.rs
+++ b/bin/nats.rs
@@ -100,6 +100,27 @@ pub async fn ensure_stream(
         .map_err(|e| anyhow::anyhow!("{e:?}"))
 }
 
+/// A helper that ensures that the notify stream exists
+pub async fn ensure_notify_stream(
+    context: &Context,
+    name: String,
+    subjects: Vec<String>,
+) -> Result<Stream> {
+    context
+        .get_or_create_stream(StreamConfig {
+            name,
+            description: Some("A stream for capturing all notification events for wadm".into()),
+            num_replicas: 1,
+            retention: async_nats::jetstream::stream::RetentionPolicy::Interest,
+            subjects,
+            max_age: DEFAULT_EXPIRY_TIME,
+            storage: async_nats::jetstream::stream::StorageType::File,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))
+}
+
 /// A helper that ensures that the given KV bucket exists, using defaults to create if it does
 /// not. Returns the handle to the stream
 pub async fn ensure_kv_bucket(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,12 +19,6 @@ macro_rules! from_impl {
 
 /// All possible compensatory commands for a lattice
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-// In order to keep things clean, we are using untagged enum serialization. So it will just try to
-// match on data without tagging (see https://serde.rs/enum-representations.html for more info on
-// what the other options look like). These types are purely internal to wadm, but for greater
-// flexibility in the future, we may want to write custom serialize and deserialize for people who
-// may write other schedulers
-#[serde(untagged)]
 pub enum Command {
     StartActor(StartActor),
     StopActor(StopActor),

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -212,7 +212,8 @@ pub enum ConversionError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActorStarted {
     pub annotations: HashMap<String, String>,
-    pub api_version: usize,
+    // Commented out for now because the host broken it and we actually don't use this right now
+    // pub api_version: usize,
     pub claims: ActorClaims,
     pub image_ref: String,
     // TODO: Parse as UUID?
@@ -232,6 +233,8 @@ event_impl!(
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActorStopped {
+    #[serde(default)]
+    pub annotations: HashMap<String, String>,
     pub instance_id: String,
     // TODO: Parse as nkey?
     pub public_key: String,
@@ -286,6 +289,8 @@ event_impl!(
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ProviderStopped {
+    #[serde(default)]
+    pub annotations: HashMap<String, String>,
     pub contract_id: String,
     // TODO: parse as UUID?
     pub instance_id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod events;
 pub mod mirror;
 pub mod model;
 pub mod nats_utils;
+pub mod publisher;
 pub mod scaler;
 pub mod server;
 pub mod storage;

--- a/src/model/internal.rs
+++ b/src/model/internal.rs
@@ -117,6 +117,13 @@ impl StoredManifest {
         self.manifests.get(version)
     }
 
+    /// Returns the deployed version of the manifest (if it is deployed)
+    pub fn get_deployed(&self) -> Option<&Manifest> {
+        self.deployed_version
+            .as_ref()
+            .and_then(|v| self.manifests.get(v))
+    }
+
     /// Returns whether or not this is a new (empty) manifest
     pub fn is_empty(&self) -> bool {
         self.manifests.is_empty()

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -174,6 +174,24 @@ pub enum TraitProperty {
     Custom(serde_json::Value),
 }
 
+impl From<LinkdefProperty> for TraitProperty {
+    fn from(value: LinkdefProperty) -> Self {
+        Self::Linkdef(value)
+    }
+}
+
+impl From<SpreadScalerProperty> for TraitProperty {
+    fn from(value: SpreadScalerProperty) -> Self {
+        Self::SpreadScaler(value)
+    }
+}
+
+impl From<serde_json::Value> for TraitProperty {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Custom(value)
+    }
+}
+
 /// Properties for linkdefs
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LinkdefProperty {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -1,0 +1,50 @@
+//! A module that defines a generic publisher trait and several common publishers that can be passed
+//! into various structs in wadm. Often times this is used for testing, but it also allows for
+//! flexibility for others who may want to publish to other sources
+
+use async_nats::{jetstream::Context, Client};
+
+#[async_trait::async_trait]
+pub trait Publisher {
+    /// Publishes the given data to an optional destination (i.e. subject or topic). Implementors
+    /// are responsible for documenting guarantees of delivery for published data
+    ///
+    /// The destination is optional for two reasons: Sometimes a client cannot be scoped to a
+    /// specific topic and also, some implementations may not use subject/topic based delivery
+    async fn publish(&self, data: Vec<u8>, destination: Option<&str>) -> anyhow::Result<()>;
+}
+
+/// The publisher implementation for a normal NATS client constrained to the given topic. This only
+/// has guarantees that the message was sent, not that it was received
+#[async_trait::async_trait]
+impl Publisher for Client {
+    async fn publish(&self, data: Vec<u8>, destination: Option<&str>) -> anyhow::Result<()> {
+        let subject = match destination {
+            Some(s) => s.to_owned(),
+            None => anyhow::bail!("NATS publishes require a destination"),
+        };
+        self.publish(subject, data.into())
+            .await
+            .map_err(anyhow::Error::from)
+    }
+}
+
+/// The publisher implementation for a NATS jetstream client. This implementation will guarantee
+/// that a sent message is received by a stream
+#[async_trait::async_trait]
+impl Publisher for Context {
+    async fn publish(&self, data: Vec<u8>, destination: Option<&str>) -> anyhow::Result<()> {
+        let subject = match destination {
+            Some(s) => s.to_owned(),
+            None => anyhow::bail!("NATS publishes require a destination"),
+        };
+        let ack = self
+            .publish(subject, data.into())
+            .await
+            .map_err(|e| anyhow::anyhow!("Unable to publish message").context(e))?;
+
+        ack.await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Unable to verify receipt of message").context(e))
+    }
+}

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -1,0 +1,528 @@
+//! A struct that manages creating and removing scalers for all manifests
+
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+use anyhow::Result;
+use async_nats::jetstream::{
+    consumer::pull::{Config as PullConfig, Stream as MessageStream},
+    stream::Stream as JsStream,
+    AckKind,
+};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::{
+    sync::{
+        mpsc::{self, Receiver, Sender},
+        OwnedRwLockReadGuard, RwLock,
+    },
+    task::JoinHandle,
+};
+use tracing::{debug, error, info, instrument, trace, warn};
+
+use crate::{
+    model::{
+        internal::StoredManifest, Component, ComponentType, Manifest, Properties, Trait,
+        TraitProperty, SPREADSCALER_TRAIT,
+    },
+    publisher::Publisher,
+    scaler::{spreadscaler::ActorSpreadScaler, Command, Scaler},
+    storage::ReadStore,
+    workers::CommandPublisher,
+};
+
+pub type BoxedScaler = Box<dyn Scaler + Send + Sync + 'static>;
+pub type ScalerList = Vec<BoxedScaler>;
+
+pub const WADM_NOTIFY_PREFIX: &str = "wadm.notify";
+// The backoff channel buffer size. This is an arbitrary number, but we want to make sure we cap it
+// so we can't consume all memory
+const CHANNEL_BUFFER_SIZE: usize = 250;
+
+/// All events sent for manifest notifications
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Notifications {
+    CreateScalers(Manifest),
+    DeleteScalers(String),
+    BackoffScaler(String),
+}
+
+/// A wrapper type returned when getting a list of scalers. Implements a backoff operation that can
+/// be called to tell all returned scalers to back off and notifiying with a message so other
+/// consumers can backoff as well
+pub struct Scalers<'a, P> {
+    pub scalers: OwnedRwLockReadGuard<HashMap<String, ScalerList>, ScalerList>,
+    publisher: &'a P,
+    name: &'a str,
+    subject: &'a str,
+    sender: Sender<String>,
+}
+
+impl<'a, P> Deref for Scalers<'a, P> {
+    type Target = ScalerList;
+
+    fn deref(&self) -> &Self::Target {
+        self.scalers.deref()
+    }
+}
+
+impl<'a, P> Scalers<'a, P>
+where
+    P: Publisher,
+{
+    /// Publishes a backoff notification and sets all current scalers to backoff. Returns an error
+    /// if unable to publish the backoff notification (and will not set current scalers to backoff)
+    pub async fn backoff(&self) -> Result<()> {
+        // Publish the message first because otherwise we could get scalers that don't go to backoff
+        // mode
+        let data = serde_json::to_vec(&Notifications::BackoffScaler(self.name.to_owned()))?;
+        self.publisher.publish(data, Some(self.subject)).await?;
+        futures::future::join_all(
+            self.scalers
+                .iter()
+                .map(|scaler| scaler.backoff(self.sender.clone())),
+        )
+        .await;
+        Ok(())
+    }
+}
+
+/// A wrapper type returned when getting all scalers. Implements a backoff operation that can be
+/// called to tell all returned scalers to back off and notifiying with a message so other consumers
+/// can backoff as well
+pub struct AllScalers<'a, P> {
+    pub scalers: OwnedRwLockReadGuard<HashMap<String, ScalerList>>,
+    publisher: &'a P,
+    subject: &'a str,
+    sender: Sender<String>,
+}
+
+impl<'a, P> Deref for AllScalers<'a, P> {
+    type Target = HashMap<String, ScalerList>;
+
+    fn deref(&self) -> &Self::Target {
+        self.scalers.deref()
+    }
+}
+
+impl<'a, P> AllScalers<'a, P>
+where
+    P: Publisher,
+{
+    /// Publishes a backoff notification and sets all listed scalers to backoff. Returns an error
+    /// if unable to publish the backoff notification (and will not set current scalers to backoff)
+    pub async fn backoff(&self, scalers_to_backoff: Vec<&str>) -> Result<()> {
+        for name in scalers_to_backoff.into_iter() {
+            let scalers = if let Some(scalers) = self.scalers.get(name) {
+                scalers
+            } else {
+                continue;
+            };
+            let data = serde_json::to_vec(&Notifications::BackoffScaler(name.to_owned()))?;
+            self.publisher.publish(data, Some(self.subject)).await?;
+            futures::future::join_all(
+                scalers
+                    .iter()
+                    .map(|scaler| scaler.backoff(self.sender.clone())),
+            )
+            .await;
+        }
+        Ok(())
+    }
+}
+
+/// A manager that consumes notifications from a stream for a lattice and then either adds or removes the
+/// necessary scalers
+#[derive(Clone)]
+pub struct ScalerManager<StateStore, P: Clone> {
+    handle: Option<Arc<JoinHandle<Result<()>>>>,
+    scalers: Arc<RwLock<HashMap<String, ScalerList>>>,
+    client: P,
+    subject: String,
+    lattice_id: String,
+    state_store: StateStore,
+    publisher: CommandPublisher<P>,
+    backoff_sender: Sender<String>,
+}
+
+impl<StateStore, P: Clone> Drop for ScalerManager<StateStore, P> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort()
+        }
+    }
+}
+
+impl<StateStore, P> ScalerManager<StateStore, P>
+where
+    StateStore: ReadStore + Send + Sync + Clone + 'static,
+    P: Publisher + Clone + Send + Sync + 'static,
+{
+    /// Creates a new ScalerManager configured to notify messages to `wadm.notify.{lattice_id}`
+    /// using the given jetstream client. Also creates an ephemeral consumer for notifications on
+    /// the given stream
+    pub async fn new<ManifestStore>(
+        client: P,
+        stream: JsStream,
+        lattice_id: &str,
+        state_store: StateStore,
+        manifest_store: ManifestStore,
+        publisher: CommandPublisher<P>,
+    ) -> Result<ScalerManager<StateStore, P>>
+    where
+        ManifestStore: ReadStore + Send + Sync + Clone + 'static,
+    {
+        // Create the consumer first so that we can make sure we don't miss anything during the
+        // first reconcile pass
+        let subject = format!("{WADM_NOTIFY_PREFIX}.{lattice_id}");
+        let consumer = stream
+            .create_consumer(PullConfig {
+                // TODO(thomastaylor312): We should probably generate a friendly consumer name
+                // using an optional unique identifier
+                description: Some(format!(
+                    "Ephemeral wadm notifier consumer for lattice {lattice_id}"
+                )),
+                ack_policy: async_nats::jetstream::consumer::AckPolicy::Explicit,
+                ack_wait: std::time::Duration::from_secs(2),
+                max_deliver: 3,
+                deliver_policy: async_nats::jetstream::consumer::DeliverPolicy::All,
+                filter_subject: subject.clone(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("Unable to create ephemeral consumer: {e:?}"))?;
+        let messages = consumer
+            .messages()
+            .await
+            .map_err(|e| anyhow::anyhow!("Unable to subscribe to consumer: {e:?}"))?;
+
+        // Get current scalers set up
+        let all_manifests = manifest_store.list::<StoredManifest>(lattice_id).await?;
+        let scalers: HashMap<String, ScalerList> = all_manifests
+            .into_iter()
+            .filter_map(|(name, manifest)| {
+                let data = manifest.get_deployed()?;
+                let scalers =
+                    components_to_scalers(&data.spec.components, &state_store, lattice_id, &name);
+                Some((name, scalers))
+            })
+            .collect();
+
+        let scalers = Arc::new(RwLock::new(scalers));
+        let (tx, rx) = mpsc::channel(CHANNEL_BUFFER_SIZE);
+        let mut manager = ScalerManager {
+            handle: None,
+            scalers,
+            client,
+            subject,
+            lattice_id: lattice_id.to_owned(),
+            state_store,
+            publisher,
+            backoff_sender: tx,
+        };
+        let cloned = manager.clone();
+        let handle = tokio::spawn(async move { cloned.notify(messages, rx).await });
+        manager.handle = Some(Arc::new(handle));
+        Ok(manager)
+    }
+
+    // NOTE(thomastaylor312): This is a little gross as it is purely for testing, but we needed a
+    // way to work around creating a consumer when starting stuff
+    #[cfg(test)]
+    pub(crate) async fn test_new(
+        client: P,
+        lattice_id: &str,
+        state_store: StateStore,
+        publisher: CommandPublisher<P>,
+    ) -> ScalerManager<StateStore, P> {
+        let (tx, mut rx) = mpsc::channel(CHANNEL_BUFFER_SIZE);
+        // Spawn the receiver into something that will just receive and drop the message. This makes
+        // it so things won't error when sending messages
+        tokio::spawn(async move {
+            loop {
+                let _ = rx.recv().await;
+            }
+        });
+        ScalerManager {
+            handle: None,
+            scalers: Arc::new(RwLock::new(HashMap::new())),
+            client,
+            subject: format!("{WADM_NOTIFY_PREFIX}.{lattice_id}"),
+            lattice_id: lattice_id.to_owned(),
+            state_store,
+            publisher,
+            backoff_sender: tx,
+        }
+    }
+
+    /// Adds scalers for the given manifest. Emitting an event to notify other wadm processes that
+    /// they should create them as well. Only returns an error if it can't notify. Returns the
+    /// scaler list for immediate use in reconciliation
+    ///
+    /// This only constructs the scalers and doesn't reconcile. The returned [`Scalers`] type can be
+    /// used to set this model to backoff mode
+    #[instrument(level = "trace", skip_all, fields(name = %manifest.metadata.name, lattice_id = %self.lattice_id))]
+    pub async fn add_scalers<'a>(&'a self, manifest: &'a Manifest) -> Result<Scalers<'a, P>> {
+        let scalers = components_to_scalers(
+            &manifest.spec.components,
+            &self.state_store,
+            &self.lattice_id,
+            &manifest.metadata.name,
+        );
+        self.add_raw_scalers(&manifest.metadata.name, scalers).await;
+        let notification = serde_json::to_vec(&Notifications::CreateScalers(manifest.to_owned()))?;
+        self.client
+            .publish(notification, Some(&self.subject))
+            .await?;
+
+        // The error case here would be _really_ weird as something would have removed it right
+        // after we added, but handling it just in case
+        self.get_scalers(&manifest.metadata.name)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Data error: scalers no longer exist after creation"))
+    }
+
+    /// Gets the scalers for the given model name, returning None if they don't exist.
+    ///
+    /// The returned [`Scalers`] type can be used to set this model to backoff mode
+    #[instrument(level = "trace", skip(self), fields(lattice_id = %self.lattice_id))]
+    pub async fn get_scalers<'a>(&'a self, name: &'a str) -> Option<Scalers<'a, P>> {
+        let lock = self.scalers.clone().read_owned().await;
+        OwnedRwLockReadGuard::try_map(lock, |scalers| scalers.get(name))
+            .ok()
+            .map(|scalers| Scalers {
+                scalers,
+                publisher: &self.client,
+                name,
+                subject: self.subject.as_str(),
+                sender: self.backoff_sender.clone(),
+            })
+    }
+
+    /// Gets all current managed scalers
+    ///
+    /// The returned [`AllScalers`] type can be used to set verious models to backoff mode
+    #[instrument(level = "trace", skip(self), fields(lattice_id = %self.lattice_id))]
+    pub async fn get_all_scalers(&self) -> AllScalers<'_, P> {
+        AllScalers {
+            scalers: self.scalers.clone().read_owned().await,
+            publisher: &self.client,
+            subject: self.subject.as_str(),
+            sender: self.backoff_sender.clone(),
+        }
+    }
+
+    /// Removes the scalers for a given model name, publishing all commands needed for cleanup.
+    /// Returns `None` when no scaler with the name was found
+    ///
+    /// This function will notify other wadms that they should remove the scalers as well. If the
+    /// notification or handling commands fails, then this function will reinsert the scalers back into the internal map
+    /// and return an error (so this function can be called again)
+    // NOTE(thomastaylor312): This was designed the way it is to avoid race conditions. We only ever
+    // stop actors and providers that have the right annotation. So if for some reason this leaves
+    // something hanging, we should probably add something to the reaper
+    #[instrument(level = "debug", skip(self), fields(lattice_id = %self.lattice_id))]
+    pub async fn remove_scalers(&self, name: &str) -> Option<Result<()>> {
+        let scalers = match self.remove_scalers_internal(name).await {
+            Some(Ok(s)) => s,
+            Some(Err(e)) => return Some(Err(e)),
+            None => return None,
+        };
+        // SAFETY: This is entirely data in our control and should be safe to unwrap
+        if let Err(e) = self
+            .client
+            .publish(
+                serde_json::to_vec(&Notifications::DeleteScalers(name.to_owned())).unwrap(),
+                Some(&self.subject),
+            )
+            .await
+        {
+            error!(error = %e, "Unable to publish notification");
+            self.scalers.write().await.insert(name.to_owned(), scalers);
+            Some(Err(e))
+        } else {
+            Some(Ok(()))
+        }
+    }
+
+    /// An internal function to allow pushing the scalers without any of the publishing
+    async fn add_raw_scalers(&self, name: &str, scalers: ScalerList) {
+        self.scalers.write().await.insert(name.to_owned(), scalers);
+    }
+
+    /// Does everything except sending the notification
+    #[instrument(level = "debug", skip(self), fields(lattice_id = %self.lattice_id))]
+    async fn remove_scalers_internal(&self, name: &str) -> Option<Result<ScalerList>> {
+        let scalers = self.scalers.write().await.remove(name)?;
+        let commands =
+            match futures::future::join_all(scalers.iter().map(|scaler| scaler.cleanup()))
+                .await
+                .into_iter()
+                .collect::<Result<Vec<Vec<Command>>, anyhow::Error>>()
+                .map(|all| all.into_iter().flatten().collect::<Vec<Command>>())
+            {
+                Ok(c) => c,
+                Err(e) => return Some(Err(e)),
+            };
+        trace!(?commands, "Publishing cleanup commands");
+        if let Err(e) = self.publisher.publish_commands(commands).await {
+            error!(error = %e, "Unable to publish cleanup commands");
+            self.scalers.write().await.insert(name.to_owned(), scalers);
+            return Some(Err(e));
+        }
+        Some(Ok(scalers))
+    }
+
+    #[instrument(level = "debug", skip_all, fields(lattice_id = %self.lattice_id))]
+    async fn notify(
+        &self,
+        mut messages: MessageStream,
+        mut backoff_receiver: Receiver<String>,
+    ) -> Result<()> {
+        loop {
+            tokio::select! {
+                res = messages.next() => {
+                    match res {
+                        Some(Ok(msg)) => {
+                            let notification: Notifications = match serde_json::from_slice(&msg.payload) {
+                                Ok(n) => n,
+                                Err(e) => {
+                                    warn!(error = %e, "Received unparsable message from consumer");
+                                    continue;
+                                }
+                            };
+
+                            match notification {
+                                Notifications::CreateScalers(manifest) => {
+                                    // We don't want to trigger the notification, so just create the scalers and then insert
+                                    let scalers = components_to_scalers(
+                                        &manifest.spec.components,
+                                        &self.state_store,
+                                        &self.lattice_id,
+                                        &manifest.metadata.name,
+                                    );
+                                    let num_scalers = scalers.len();
+                                    self.add_raw_scalers(&manifest.metadata.name, scalers).await;
+                                    trace!(name = %manifest.metadata.name, %num_scalers, "Finished creating scalers for manifest");
+                                }
+                                Notifications::DeleteScalers(name) => {
+                                    trace!(%name, "Removing scalers for manifest");
+                                    match self.remove_scalers_internal(&name).await {
+                                        Some(Ok(_)) => {
+                                            trace!(%name, "Successfully removed scalers for manifest")
+                                        }
+                                        Some(Err(e)) => {
+                                            error!(error = %e, %name, "Error when running cleanup steps for scalers. Nacking notification");
+                                            if let Err(e) = msg.ack_with(AckKind::Nak(None)).await {
+                                                warn!(error = %e, %name, "Unable to nack message");
+                                                // We continue here so we don't fall through to the ack
+                                                continue;
+                                            }
+                                        }
+                                        None => {
+                                            debug!(%name, "Scalers don't exist or were already deleted");
+                                        }
+                                    }
+                                    // NOTE(thomastaylor312): We could find that this strategy actually
+                                    // doesn't tear down everything or leaves something hanging. If that is
+                                    // the case, a new part of the reaper logic should handle it
+                                }
+                                Notifications::BackoffScaler(name) => {
+                                    if let Some(scalers) = self.get_scalers(&name).await {
+                                        trace!(%name, "Handling backoff scaler event");
+                                        futures::future::join_all(
+                                            scalers
+                                                .iter()
+                                                .map(|scaler| scaler.backoff(self.backoff_sender.clone())),
+                                        )
+                                        .await;
+                                    }
+                                }
+                            }
+                            // Always ack if we get here
+                            if let Err(e) = msg.double_ack().await {
+                                warn!(error = %e,"Unable to ack message");
+                            }
+                        }
+                        Some(Err(e)) => {
+                            error!(error = %e, "Error when retrieving message from stream. Will attempt to fetch next message");
+                        }
+                        None => {
+                            // NOTE(thomastaylor312): This could possibly be a fatal error as we won't be able
+                            // to create scalers. We may want to determine how to bubble that all the way back
+                            // up if it is
+                            error!("Notifier for manifests has exited");
+                            anyhow::bail!("Notifier has exited")
+                        }
+                    }
+                }
+                model_name = backoff_receiver.recv() => {
+                    // This is a fatal error and results in a panic since this should never happen
+                    // except in really odd scenarios where we probably should be panicking anyway.
+                    // Essentially it means the Manager's sender data member has dropped
+                    let name = model_name.expect("All backoff senders have closed! Aborting");
+                    let scalers = match self.get_scalers(&name).await {
+                        Some(s) => s,
+                        None => {
+                            continue
+                        }
+                    };
+                    let commands = futures::future::join_all(scalers.iter().map(|scaler| scaler.reconcile())).await
+                    .into_iter()
+                    .collect::<Result<Vec<Vec<Command>>, anyhow::Error>>()
+                    .map(|all| all.into_iter().flatten().collect::<Vec<Command>>())?;
+                    if !commands.is_empty() {
+                        trace!(%name, ?commands, "Additional reconciliation needed after backoff");
+                        if let Err(e) = scalers.backoff().await {
+                            error!(error = %e, "Unable to reenter backoff mode before publishing commands");
+                        }
+                        if let Err(e) = self.publisher.publish_commands(commands).await {
+                            error!(error = %e, "Unable to send reconcile commands after backoff");
+                        }
+                    } else {
+                        trace!(%name, "No reconciliation needed after backoff");
+                    }
+                }
+            }
+        }
+    }
+}
+
+const EMPTY_TRAIT_VEC: Vec<Trait> = Vec::new();
+
+pub(crate) fn components_to_scalers<S: ReadStore + Send + Sync + Clone + 'static>(
+    components: &[Component],
+    store: &S,
+    lattice_id: &str,
+    name: &str,
+) -> ScalerList {
+    let mut scalers: ScalerList = Vec::new();
+    for component in components.iter() {
+        match (&component.component_type, &component.properties) {
+            (ComponentType::Actor, Properties::Actor(props)) => scalers.extend(
+                component
+                    .traits
+                    .as_ref()
+                    .unwrap_or(&EMPTY_TRAIT_VEC)
+                    .iter()
+                    .filter_map(|trt| match (trt.trait_type.as_str(), &trt.properties) {
+                        (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
+                            Some(Box::new(ActorSpreadScaler::new(
+                                store.clone(),
+                                props.image.to_owned(),
+                                lattice_id.to_owned(),
+                                name.to_owned(),
+                                p.to_owned(),
+                            )) as BoxedScaler)
+                        }
+                        _ => None,
+                    }),
+            ),
+            (ComponentType::Actor, _) => {
+                info!(%name, "Manifest has actor type and was parsed with a different property type");
+                continue;
+            }
+            _ => continue,
+        }
+    }
+    scalers
+}

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use tokio::sync::mpsc::Sender;
 
-use crate::{commands::Command, events::Event};
+use crate::{commands::Command, events::Event, model::TraitProperty};
 
+pub mod manager;
 mod simplescaler;
 pub mod spreadscaler;
 
@@ -18,15 +20,37 @@ pub mod spreadscaler;
 /// to determine if actions need to be taken in response to an event
 #[async_trait]
 pub trait Scaler {
-    type Config: Send + Sync;
-
-    /// Provide a scaler with configuration to use internally when computing commands
-    /// This should trigger a reconcile with the new configuration
-    async fn update_config(&mut self, config: Self::Config) -> Result<Vec<Command>>;
+    /// Provide a scaler with configuration to use internally when computing commands This should
+    /// trigger a reconcile with the new configuration.
+    ///
+    /// This config can be anything that can be turned into a
+    /// [`TraitProperty`](crate::model::TraitProperty). Additional configuration outside of what is
+    /// available in a `TraitProperty` can be passed when constructing the scaler
+    async fn update_config(&mut self, config: TraitProperty) -> Result<Vec<Command>>;
 
     /// Compute commands that must be taken given an event that changes the lattice state
     async fn handle_event(&self, event: &Event) -> Result<Vec<Command>>;
 
     /// Compute commands that must be taken to achieve desired state as specified in config
     async fn reconcile(&self) -> Result<Vec<Command>>;
+
+    /// Returns the list of commands needed to cleanup for a scaler
+    ///
+    /// This purposefully does not consume the scaler so that if there is a failure it can be kept
+    /// around
+    async fn cleanup(&self) -> Result<Vec<Command>>;
+
+    /// An optional to implement function that can tell the scaler to enter a backoff period. When
+    /// in backoff, a scaler should always return an empty `Vec<Command>` for all operations. Please
+    /// be careful when calling backoff until you have sent the commands to their intended location
+    /// as otherwise the might not rerun until they are reconciled again.
+    ///
+    /// This function should return as quickly as possible, spawning a task that can switch the
+    /// state back from backoff. The passed in channel is meant to be used to notify the caller that
+    /// the backoff is complete with the name of the model. This name can then be used by the caller
+    /// to run a reconciliation pass to ensure everything is done. This is intended to workaround
+    /// the fact that there is no way to tell when we finished stopping/starting actors
+    ///
+    /// Please note that we'd like this to be temporary in the long term
+    async fn backoff(&self, notifier: Sender<String>);
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -4,6 +4,7 @@ use tracing::{debug, error, instrument, trace};
 
 use crate::{
     model::{internal::StoredManifest, LATEST_VERSION},
+    publisher::Publisher,
     storage::Store,
 };
 
@@ -14,13 +15,13 @@ use super::{
     StatusResponse, StatusResult, StatusType, UndeployModelRequest, VersionInfo, VersionResponse,
 };
 
-pub(crate) struct Handler<S, N> {
+pub(crate) struct Handler<S, P> {
     pub(crate) store: S,
     pub(crate) client: Client,
-    pub(crate) notifier: N,
+    pub(crate) notifier: ManifestNotifier<P>,
 }
 
-impl<S: Store + Send + Sync, N: ManifestNotifier> Handler<S, N> {
+impl<S: Store + Send + Sync, P: Publisher> Handler<S, P> {
     #[instrument(level = "debug", skip(self, msg))]
     pub async fn put_model(&self, msg: Message, lattice_id: &str, name: &str) {
         trace!("Parsing incoming manifest");

--- a/src/storage/reaper.rs
+++ b/src/storage/reaper.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use chrono::{Duration, Utc};
 use tokio::{task::JoinHandle, time};
-use tracing::{debug, error, info, instrument, trace};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use super::{Actor, Host, Provider, Store};
 
@@ -181,7 +181,7 @@ impl<S: Store + Clone + Send + Sync + 'static> Undertaker<S> {
             .store_many(&self.lattice_id, actors_to_update)
             .await
         {
-            error!(error = %e, "Error when storing updated actors. Will retry on next tick");
+            warn!(error = %e, "Error when storing updated actors. Will retry on next tick");
             return;
         }
 
@@ -190,7 +190,7 @@ impl<S: Store + Clone + Send + Sync + 'static> Undertaker<S> {
             .delete_many::<Actor, _, _>(&self.lattice_id, actors_to_remove.keys())
             .await
         {
-            error!(error = %e, "Error when deleting actors from store. Will retry on next tick")
+            warn!(error = %e, "Error when deleting actors from store. Will retry on next tick")
         }
     }
 
@@ -227,7 +227,7 @@ impl<S: Store + Clone + Send + Sync + 'static> Undertaker<S> {
             .store_many(&self.lattice_id, providers_to_update)
             .await
         {
-            error!(error = %e, "Error when storing updated providers. Will retry on next tick");
+            warn!(error = %e, "Error when storing updated providers. Will retry on next tick");
             return;
         }
 
@@ -236,7 +236,7 @@ impl<S: Store + Clone + Send + Sync + 'static> Undertaker<S> {
             .delete_many::<Provider, _, _>(&self.lattice_id, providers_to_remove.keys())
             .await
         {
-            error!(error = %e, "Error when deleting providers from store. Will retry on next tick")
+            warn!(error = %e, "Error when deleting providers from store. Will retry on next tick")
         }
     }
 }

--- a/src/workers/event_helpers.rs
+++ b/src/workers/event_helpers.rs
@@ -1,0 +1,115 @@
+use std::collections::HashMap;
+
+use tracing::{instrument, warn};
+use wasmcloud_control_interface::HostInventory;
+
+use crate::{commands::Command, publisher::Publisher};
+
+/// A subset of needed claims to help populate state
+#[derive(Debug, Clone)]
+pub struct Claims {
+    pub name: String,
+    pub capabilities: Vec<String>,
+    pub issuer: String,
+}
+
+/// A trait for anything that can fetch a set of claims information about actors.
+///
+/// NOTE: This trait right now exists as a convenience for two things: First, testing. Without
+/// something like this we require a network connection to unit test. Second, there is no concrete
+/// claims type returned from the control interface client. This allows us to abstract that away
+/// until such time that we do export one and we'll be able to do so without breaking our API
+#[async_trait::async_trait]
+pub trait ClaimsSource {
+    async fn get_claims(&self) -> anyhow::Result<HashMap<String, Claims>>;
+}
+
+/// NOTE(brooksmtownsend): This trait exists in order to query the hosts inventory
+/// upon receiving a heartbeat since the heartbeat doesn't contain enough
+/// information to properly update the stored data for actors
+#[async_trait::async_trait]
+pub trait InventorySource {
+    async fn get_inventory(&self, host_id: &str) -> anyhow::Result<HostInventory>;
+}
+
+#[async_trait::async_trait]
+impl ClaimsSource for wasmcloud_control_interface::Client {
+    async fn get_claims(&self) -> anyhow::Result<HashMap<String, Claims>> {
+        Ok(self
+            .get_claims()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .claims
+            .into_iter()
+            .filter_map(|mut claim| {
+                // NOTE(thomastaylor312): I'm removing instead of getting since we own the data and I
+                // don't want to clone every time we do this
+
+                // If we don't find a subject, we can't actually get the actor ID, so skip this one
+                Some((
+                    claim.remove("sub")?,
+                    Claims {
+                        name: claim.remove("name").unwrap_or_default(),
+                        capabilities: claim
+                            .remove("caps")
+                            .map(|raw| raw.split(',').map(|s| s.to_owned()).collect())
+                            .unwrap_or_default(),
+                        issuer: claim.remove("iss").unwrap_or_default(),
+                    },
+                ))
+            })
+            .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl InventorySource for wasmcloud_control_interface::Client {
+    async fn get_inventory(&self, host_id: &str) -> anyhow::Result<HostInventory> {
+        Ok(self
+            .get_host_inventory(host_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?)
+    }
+}
+
+/// A struct for publishing commands
+#[derive(Clone)]
+pub struct CommandPublisher<Pub> {
+    publisher: Pub,
+    topic: String,
+}
+
+impl<Pub> CommandPublisher<Pub> {
+    /// Creates an new command publisher configured with the given publisher that will send to the
+    /// specified topic
+    pub fn new(publisher: Pub, topic: &str) -> CommandPublisher<Pub> {
+        CommandPublisher {
+            publisher,
+            topic: topic.to_owned(),
+        }
+    }
+}
+
+impl<Pub: Publisher> CommandPublisher<Pub> {
+    #[instrument(level = "trace", skip(self))]
+    pub async fn publish_commands(&self, commands: Vec<Command>) -> anyhow::Result<()> {
+        futures::future::join_all(
+            commands
+                .into_iter()
+                // Generally commands are purely internal to wadm and so shouldn't have an error serializing. If it does, warn and continue onward
+                .filter_map(|command| {
+                    match serde_json::to_vec(&command) {
+                        Ok(data) => Some(data),
+                        Err(e) => {
+                            warn!(error = %e, ?command, "Got malformed command when trying to serialize. Skipping this command");
+                            None
+                        }
+                    }
+                })
+                .map(|data| self.publisher.publish(data, Some(&self.topic))),
+        )
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<()>>()
+    }
+}

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -4,6 +4,8 @@
 
 mod command;
 mod event;
+mod event_helpers;
 
 pub use command::CommandWorker;
-pub use event::{Claims, ClaimsSource, EventWorker, InventorySource};
+pub use event::EventWorker;
+pub use event_helpers::*;

--- a/test/data/events.json
+++ b/test/data/events.json
@@ -50,7 +50,7 @@
     {
         "data": {
             "annotations": {},
-            "api_version": 1,
+            "api_version": "n/a",
             "claims": {
                 "call_alias": null,
                 "caps": [

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -40,17 +40,20 @@ async fn get_event_consumer(nats_url: String) -> EventConsumer {
         stream
     } else {
         // Create it if it doesn't exist
-        context.create_stream(async_nats::jetstream::stream::Config {
-            name: STREAM_NAME.to_owned(),
-            description: Some("A stream that stores all events coming in on the wasmbus.evt topics in a cluster".to_string()),
-            num_replicas: 1,
-            retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
-            subjects: vec![WASMBUS_EVENT_TOPIC.to_owned()],
-            max_age: wadm::DEFAULT_EXPIRY_TIME,
-            storage: async_nats::jetstream::stream::StorageType::Memory,
-            allow_rollup: false,
-            ..Default::default()
-        }).await.expect("Should be able to create test stream")
+        context
+            .create_stream(async_nats::jetstream::stream::Config {
+                name: STREAM_NAME.to_owned(),
+                description: Some("A stream that stores all events coming in on the wasmbus.evt topics in a cluster".to_string()),
+                num_replicas: 1,
+                retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
+                subjects: vec![WASMBUS_EVENT_TOPIC.to_owned()],
+                max_age: wadm::DEFAULT_EXPIRY_TIME,
+                storage: async_nats::jetstream::stream::StorageType::Memory,
+                allow_rollup: false,
+                ..Default::default()
+            })
+            .await
+            .expect("Should be able to create test stream")
     };
     EventConsumer::new(stream, WASMBUS_EVENT_TOPIC, "default")
         .await

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -246,22 +246,19 @@ impl StreamWrapper {
             stream
         } else {
             context
-            .create_stream(async_nats::jetstream::stream::Config {
-                name: id.to_owned(),
-                description: Some(
-                    "A stream that stores all events coming in on the wasmbus.evt topics in a cluster"
-                        .to_string(),
-                ),
-                num_replicas: 1,
-                retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
-                subjects: vec![topic.clone()],
-                max_age: wadm::DEFAULT_EXPIRY_TIME,
-                storage: async_nats::jetstream::stream::StorageType::Memory,
-                allow_rollup: false,
-                ..Default::default()
-            })
-            .await
-            .expect("Should be able to create test stream")
+                .create_stream(async_nats::jetstream::stream::Config {
+                    name: id.to_owned(),
+                    description: Some("A stream that stores all events coming in on the wasmbus.evt topics in a cluster".to_string()),
+                    num_replicas: 1,
+                    retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
+                    subjects: vec![topic.clone()],
+                    max_age: wadm::DEFAULT_EXPIRY_TIME,
+                    storage: async_nats::jetstream::stream::StorageType::Memory,
+                    allow_rollup: false,
+                    ..Default::default()
+                })
+                .await
+                .expect("Should be able to create test stream")
         };
         let stream = CommandConsumer::new(stream, &topic, "default")
             .await


### PR DESCRIPTION
This is a giant PR because a lot of debugging happened. Most of this stuff is Real Code we will keep around. However, there is one big hacky thing to point out. In order to handle Actor Start/Stop events, we had to introduce the idea of a backoff, similar to what is done in wadm 0.3. This method definitely puts the "eventual" in eventual consistency, particularly with high replica counts, but it does work. This backoff is not needed for linkdef or provider scalers. The reason why this was needed was due to there being no way for identifying "groups" (for lack of a better term) of started and stopped events. We ended up with a stream of events with a non-deterministic end. The real solution here would be to update our actor started/stopped events to just emit a single event when a requested scale is done. So if a command comes in to start 10 actors, then we get all the same stuff we current do with a new `count` field and sans the instance-id field, which I don't think we use anywhere except the host and lattice observer (and I think the observer can do without it). This is also better for state storage as we don't have to read and write for _every_ single actor that starts or stops

Closes #49