### PR TITLE
feat(*) wash support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ CARGO ?= cargo
 CARGO_WATCH ?= cargo-watch
 CARGO_CLIPPY ?= cargo-clippy
 DOCKER ?= docker
+NATS ?= nats
 
 all: build test
 
@@ -85,4 +86,16 @@ test-int-watch: ## Run integration tests (continuously)
 test-int-all:: ## Run all integration tests
 	$(MAKE) test-int CARGO_TEST_TARGET='*'
 
-.PHONY: check-cargo-watch check-cargo-clippy lint build build-watch test test-watch test-int test-int-all test-int-watch
+###########
+# Cleanup #
+###########
+
+stream-cleanup: ## Purges all streams that wadm creates
+	$(NATS) stream purge wadm_commands --force
+	$(NATS) stream purge wadm_events --force
+	$(NATS) stream purge wadm_notify --force
+	$(NATS) stream purge wadm_mirror --force
+	$(NATS) stream purge KV_wadm_state --force
+	$(NATS) stream purge KV_wadm_manifests --force
+
+.PHONY: check-cargo-watch check-cargo-clippy lint build build-watch test test-watch test-int test-int-all test-int-watch stream-cleanup

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -116,8 +116,8 @@ impl<S: Store + Send + Sync, P: Publisher> Server<S, P> {
                     lattice_id,
                     category: "model",
                     operation: "put",
-                    object_name: Some(name),
-                } => self.handler.put_model(msg, lattice_id, name).await,
+                    object_name: None,
+                } => self.handler.put_model(msg, lattice_id).await,
                 ParsedSubject {
                     lattice_id,
                     category: "model",

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -38,6 +38,8 @@ pub struct PutModelResponse {
     pub current_version: String,
     #[serde(default)]
     pub message: String,
+    #[serde(default)]
+    pub name: String,
 }
 
 /// Possible outcomes of a put request

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -117,7 +117,7 @@ async fn test_crud_operations() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -130,7 +130,7 @@ async fn test_crud_operations() {
         serde_yaml::from_slice(&raw).expect("Should be able to parse as manifest");
 
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.my-example-app", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
 
@@ -169,7 +169,7 @@ async fn test_crud_operations() {
         .insert(VERSION_ANNOTATION_KEY.to_owned(), "v0.0.2".to_owned());
     let resp: PutModelResponse = test_server
         .get_response(
-            "default.model.put.my-example-app",
+            "default.model.put",
             serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
@@ -182,7 +182,7 @@ async fn test_crud_operations() {
         .insert(VERSION_ANNOTATION_KEY.to_owned(), "v0.0.3".to_owned());
     let resp: PutModelResponse = test_server
         .get_response(
-            "default.model.put.my-example-app",
+            "default.model.put",
             serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
@@ -342,7 +342,7 @@ async fn test_bad_requests() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -352,7 +352,7 @@ async fn test_bad_requests() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert!(
@@ -371,7 +371,7 @@ async fn test_bad_requests() {
         .annotations
         .insert(VERSION_ANNOTATION_KEY.to_owned(), "latest".to_owned());
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert!(
@@ -385,7 +385,7 @@ async fn test_bad_requests() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.foobar", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert!(
@@ -422,7 +422,7 @@ async fn test_delete_noop() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -455,7 +455,7 @@ async fn test_invalid_topics() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -519,7 +519,7 @@ async fn test_manifest_parsing() {
         .expect("Unable to load file");
     let mut manifest: Manifest = serde_json::from_slice(&raw).unwrap();
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.my-example-app", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -530,7 +530,7 @@ async fn test_manifest_parsing() {
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
         .get_response(
-            "default.model.put.petclinic",
+            "default.model.put",
             raw,
             Some(("Content-Type", "application/yaml")),
         )
@@ -546,7 +546,7 @@ async fn test_manifest_parsing() {
     let raw = serde_json::to_vec(&manifest).unwrap();
     let resp: PutModelResponse = test_server
         .get_response(
-            "default.model.put.my-example-app",
+            "default.model.put",
             raw,
             Some(("Content-Type", "application/json")),
         )
@@ -565,7 +565,7 @@ async fn test_deploy() {
         .expect("Unable to load file");
     let mut manifest: Manifest = serde_yaml::from_slice(&raw).unwrap();
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -575,7 +575,7 @@ async fn test_deploy() {
         .insert(VERSION_ANNOTATION_KEY.to_owned(), "v0.0.2".to_string());
     let resp: PutModelResponse = test_server
         .get_response(
-            "default.model.put.petclinic",
+            "default.model.put",
             serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
@@ -709,7 +709,7 @@ async fn test_delete_deploy() {
         .expect("Unable to load file");
     let mut manifest: Manifest = serde_yaml::from_slice(&raw).unwrap();
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
 
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
@@ -719,7 +719,7 @@ async fn test_delete_deploy() {
         .insert(VERSION_ANNOTATION_KEY.to_owned(), "v0.0.2".to_string());
     let resp: PutModelResponse = test_server
         .get_response(
-            "default.model.put.petclinic",
+            "default.model.put",
             serde_yaml::to_string(&manifest).unwrap().into_bytes(),
             None,
         )
@@ -793,7 +793,7 @@ async fn test_status() {
         .await
         .expect("Unable to load file");
     let resp: PutModelResponse = test_server
-        .get_response("default.model.put.petclinic", raw, None)
+        .get_response("default.model.put", raw, None)
         .await;
     assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
 


### PR DESCRIPTION
## Feature or Problem
This PR makes a few changes to the wadm API, along with a forthcoming PR in `wash`, to ensure you can use `wash` 

## Related Issues
(pr) https://github.com/wasmCloud/wash/pull/520

## Release Information
v0.4.0

## Consumer Impact
Consumers can use `wash` to interact with wadm 0.4

## Testing

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually ran the happy paths through the API interactions, but I haven't tested them all yet so leaving as draft until I can validate all of the commands through successful and failure paths.