### PR TITLE
feat(*) simple devcontainer

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,10 @@
+# wadm devcontainer
+
+A simple devcontainer that has `rust` installed. Try it out with `devcontainer open` at the root of this repository!
+
+As a `postCreateCommand`, we run `cargo install` steps for you to install the proper versions of wash & wadm for experimenting. In the future these will be simplified and much quicker once we release actual artifacts for both projects with support for wadm 0.4.
+
+## Prerequisites
+
+- [devcontainer CLI](https://code.visualstudio.com/docs/devcontainers/devcontainer-cli#_installation)
+- VSCode

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,7 +2,7 @@
 
 A simple devcontainer that has `rust` installed. Try it out with `devcontainer open` at the root of this repository!
 
-As a `postCreateCommand`, we run `cargo install` steps for you to install the proper versions of wash & wadm for experimenting. In the future these will be simplified and much quicker once we release actual artifacts for both projects with support for wadm 0.4.
+As a `postCreateCommand`, we run an install script that grabs an alpha released version of `wadm` for you and installs a compatible (currently unreleased) version of `wash` for you to get started with.
 
 ## Prerequisites
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,9 @@
 			"version": "latest"
 		}
 	},
+  "containerEnv": {
+		"RUST_LOG": "INFO"
+	},
 	"postCreateCommand": "bash ./.devcontainer/install.sh",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/wadm,type=bind,consistency=cached",
 	"workspaceFolder": "/wadm"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,28 @@
 {
 	"name": "wadm",
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"image": "mcr.microsoft.com/devcontainers/rust:latest",
 	"features": {
-		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "latest"
-		}
+		"ghcr.io/devcontainers/features/common-utils:2": {}
 	},
-  "containerEnv": {
+	"containerEnv": {
 		"RUST_LOG": "INFO"
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"files.watcherExclude": {
+					"**/target/**": true
+				},
+				"[rust]": {
+					"editor.formatOnSave": true
+				}
+			},
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml",
+				"serayuzgur.crates"
+			]
+		}
 	},
 	"postCreateCommand": "bash ./.devcontainer/install.sh",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/wadm,type=bind,consistency=cached",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+	"name": "wadm",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest"
+		}
+	},
+	"postCreateCommand": "bash ./.devcontainer/install.sh",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/wadm,type=bind,consistency=cached",
+	"workspaceFolder": "/wadm"
+}

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 
-cargo install wadm --bin wadm --features cli --git https://github.com/wasmcloud/wadm --branch wadm_0.4 --force
+cargo install wadm --bin wadm --features cli --git https://github.com/wasmcloud/wadm --tag v0.4.0-alpha.1 --force

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -13,11 +13,12 @@ if [[ $ARCH == "x86_64" ]]; then
     ARCH="amd64"
 fi
 
-TARBALL=wadm-$VERSION-linux-$ARCH.tar.gz
+TARBALL=wadm-$VERSION-linux-$ARCH
 
-curl -fLO https://github.com/wasmCloud/wadm/releases/download/$VERSION/$TARBALL
+curl -fLO https://github.com/wasmCloud/wadm/releases/download/$VERSION/$TARBALL.tar.gz
 tar -xvf $TARBALL
 mv $TARBALL/wadm /usr/local/bin/wadm
+rm -rf $TARBALL $TARBALL.tar.gz
 
 # INSTALL WASH
 cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
 # INSTALL WADM
-apt update; apt install curl -y
-
 ARCH=$(arch)
 VERSION=v0.4.0-alpha.1
 
-if [[ $ARCH == "arm64" ]]; then
-    ARCH="aarch64"
-fi
 if [[ $ARCH == "x86_64" ]]; then
     ARCH="amd64"
 fi
@@ -16,7 +11,7 @@ fi
 TARBALL=wadm-$VERSION-linux-$ARCH
 
 curl -fLO https://github.com/wasmCloud/wadm/releases/download/$VERSION/$TARBALL.tar.gz
-tar -xvf $TARBALL
+tar -xvf $TARBALL.tar.gz
 mv $TARBALL/wadm /usr/local/bin/wadm
 rm -rf $TARBALL $TARBALL.tar.gz
 

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 
+cargo install wadm --bin wadm --features cli --git https://github.com/wasmcloud/wadm --branch wadm_0.4 --force

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# INSTALL WASH
+cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 
+
 # INSTALL WADM
 ARCH=$(arch)
 VERSION=v0.4.0-alpha.1
@@ -12,8 +15,6 @@ TARBALL=wadm-$VERSION-linux-$ARCH
 
 curl -fLO https://github.com/wasmCloud/wadm/releases/download/$VERSION/$TARBALL.tar.gz
 tar -xvf $TARBALL.tar.gz
-mv $TARBALL/wadm /usr/local/bin/wadm
+chmod +x $TARBALL/wadm
+mv $TARBALL/wadm /usr/local/cargo/bin/wadm
 rm -rf $TARBALL $TARBALL.tar.gz
-
-# INSTALL WASH
-cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
 
+# INSTALL WADM
+apt update; apt install curl -y
+
+ARCH=$(arch)
+VERSION=v0.4.0-alpha.1
+
+if [[ $ARCH == "arm64" ]]; then
+    ARCH="aarch64"
+fi
+if [[ $ARCH == "x86_64" ]]; then
+    ARCH="amd64"
+fi
+
+TARBALL=wadm-$VERSION-linux-$ARCH.tar.gz
+
+curl -fLO https://github.com/wasmCloud/wadm/releases/download/$VERSION/$TARBALL
+tar -xvf $TARBALL
+mv $TARBALL/wadm /usr/local/bin/wadm
+
+# INSTALL WASH
 cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 
-cargo install wadm --bin wadm --features cli --git https://github.com/wasmcloud/wadm --tag v0.4.0-alpha.1 --force

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ issues/missing features to be aware of:
 
 ## Using wadm
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=401352358&machine=standardLinux32gb&location=EastUs)
+
 ### Install
 
 Ensure you have a proper [rust](https://www.rust-lang.org/tools/install) toolchain installed.

--- a/README.md
+++ b/README.md
@@ -28,16 +28,22 @@ issues/missing features to be aware of:
 
 ### Install
 
-Ensure you have a proper [rust](https://www.rust-lang.org/tools/install) toolchain installed.
+You can deploy **wadm** by downloading the binary for your host operating system and architecture, and then running it alongside your wasmCloud host. We recommend using **wash** to run wasmCloud and NATS, and then running **wadm** afterwards connected to the same NATS connection.
+
+Ensure you have a proper [rust](https://www.rust-lang.org/tools/install) toolchain installed to install **wash**, until we release wash v0.18.0.
 
 ```
+# Install wash
 cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force
-cargo install wadm --bin wadm --features cli --git https://github.com/wasmcloud/wadm --version v0.4.0-alpha.1 --force
 ```
 
-You can deploy **wadm** by downloading the binary for your host operating system and architecture,
-and then running it alongside your wasmCloud host. We recommend using **wash** to run wasmCloud and
-NATS, and then running **wadm** afterwards connected to the same NATS connection.
+```
+# Install wadm
+curl -fLO https://github.com/wasmCloud/wadm/releases/download/<version>/wadm-<version>-<os>-<arch>.tar.gz
+tar -xvf wadm-<version>-<os>-<arch>.tar.gz
+cd wadm-<version>-<os>-<arch>
+./wadm
+```
 
 ### Setup
 


### PR DESCRIPTION
This PR adds a simple devcontainer that installs `wash` and `wadm` so that people can run through the example without installing anything locally, if they prefer. Additionally it adds an "Open in Codespaces" badge, which is slick.

We install `wash` directly using `cargo` as we have some commands we need to change + release in wash, but wadm is downloaded from the github release directly