### PR TITLE
Investigate WADM Integration Tests Failing

### DIFF
--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -18,6 +18,7 @@ const HTTP_SERVER_PROVIDER_ID: &str = "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5
 async fn test_commands() {
     let config = TestWashConfig::random().await.unwrap();
     let _guard = setup_test_wash(&config).await;
+    println!("PORT:{:?}", config.nats_port);
 
     let mut wrapper = StreamWrapper::new("commands_integration".into(), config.nats_port).await;
 

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -117,6 +117,7 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     // Build the cleanup guard that will be returned
     let guard = CleanupGuard {
         child: None,
+        // should this be set to true?
         already_running: false,
     };
 
@@ -133,8 +134,11 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
 }
 
 async fn stop_wash_instance() -> Result<CleanupGuard> {
-    let mut command = tokio::process::Command::new("wash");
-    command.arg("down");
+    let mut cmd = tokio::process::Command::new("wash");
+    cmd.arg("down");
+
+    let output = cmd.status().await.expect("Unable to stop detached wash up");
+    assert!(output.success(), "Error trying to stop host",);
 
     // Give the host time to totally end
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -111,13 +111,16 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     cmd.args(&args)
         .env("WASMCLOUD_PORT", &wasmcloud_port)
         .env("WASMCLOUD_DASHBOARD_PORT", &wasmcloud_port)
-        .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null());
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped());
 
-    let child = cmd.spawn().expect("wash command failed to start");
     println!("{:?}", cmd);
 
+    let child = cmd.spawn().expect("wash command failed to start");
+    println!("{:?}", child);
+
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
     // Build the cleanup guard that will be returned
     let guard = CleanupGuard {
         child: None,

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -132,6 +132,22 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     Ok(guard)
 }
 
+async fn stop_wash_instance() -> Result<CleanupGuard> {
+    let mut command = tokio::process::Command::new("wash");
+    command.arg("down");
+
+    // Give the host time to totally end
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Build the cleanup guard that will be returned
+    let guard = CleanupGuard {
+        child: None,
+        already_running: false,
+    };
+
+    Ok(guard)
+}
+
 /// Set up and run a wash instance that can be used for a test
 pub async fn setup_test_wash(cfg: &TestWashConfig) -> CleanupGuard {
     match tokio::net::TcpStream::connect(cfg.washboard_url()).await {

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -133,25 +133,6 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     Ok(guard)
 }
 
-async fn stop_wash_instance() -> Result<CleanupGuard> {
-    let mut cmd = tokio::process::Command::new("wash");
-    cmd.arg("down");
-
-    let output = cmd.status().await.expect("Unable to stop detached wash up");
-    assert!(output.success(), "Error trying to stop host",);
-
-    // Give the host time to totally end
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-    // Build the cleanup guard that will be returned
-    let guard = CleanupGuard {
-        child: None,
-        already_running: false,
-    };
-
-    Ok(guard)
-}
-
 /// Set up and run a wash instance that can be used for a test
 pub async fn setup_test_wash(cfg: &TestWashConfig) -> CleanupGuard {
     match tokio::net::TcpStream::connect(cfg.washboard_url()).await {

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -112,7 +112,14 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
         .env("WASMCLOUD_PORT", &wasmcloud_port)
         .env("WASMCLOUD_DASHBOARD_PORT", &wasmcloud_port)
         .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null());
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("wash command failed to start")
+        .wait_with_output()
+        .await
+        .expect("wash command failed to run");
+
+    println!("{:?}", cmd);
 
     // Build the cleanup guard that will be returned
     let guard = CleanupGuard {
@@ -120,8 +127,9 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
         already_running: false,
     };
 
-    let output = cmd.status().await.expect("Unable to run detached wash up");
-    assert!(output.success(), "Error trying to start host",);
+    // let output = cmd.status().await.expect("Unable to run detached wash up");
+    // println!("{:?}", output);
+    // assert!(output.success(), "Error trying to start host",);
 
     // Make sure we can connect to washboard
     wait_for_server(&cfg.washboard_url()).await;

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -112,23 +112,24 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
         .env("WASMCLOUD_PORT", &wasmcloud_port)
         .env("WASMCLOUD_DASHBOARD_PORT", &wasmcloud_port)
         .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .spawn()
-        .expect("wash command failed to start")
-        .wait_with_output()
-        .await
-        .expect("wash command failed to run");
+        .stdout(std::process::Stdio::null());
 
+    let child = cmd.spawn().expect("wash command failed to start");
     println!("{:?}", cmd);
 
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     // Build the cleanup guard that will be returned
     let guard = CleanupGuard {
         child: None,
         already_running: false,
     };
 
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("wash command failed to run");
     // let output = cmd.status().await.expect("Unable to run detached wash up");
-    // println!("{:?}", output);
+    println!("{:?}", output);
     // assert!(output.success(), "Error trying to start host",);
 
     // Make sure we can connect to washboard

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -117,7 +117,6 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     // Build the cleanup guard that will be returned
     let guard = CleanupGuard {
         child: None,
-        // should this be set to true?
         already_running: false,
     };
 


### PR DESCRIPTION
## Feature or Problem
Some tests that require wasmCloud Host can't run. 

4 Related Tests that use Wash Host and Commands:
 - event_consumer_integration.rs
    - test_nack_and_rereceive (passing)
    - test_event_stream (missing in log - maybe didn't run, but in same file as above test)
- command_worker_integration.rs
    - test_annotation_stop (failing)
    - test_commands (failing)
 
 Example Error: 
 ```
 running 1 test
thread 'test_commands' panicked at 'Unable to run detached wash up: Os { code: 2, kind: NotFound, message: "No such file or directory" }', tests/helpers.rs:124:37
```
