### PR TITLE
Allow more optional manifest things

### DIFF
--- a/oam/simple2.yaml
+++ b/oam/simple2.yaml
@@ -27,8 +27,6 @@ spec:
         - type: linkdef
           properties:
             target: webcap
-            values:
-              port: "8080"
 
     - name: webcap
       type: capability

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -183,8 +183,8 @@ pub struct LinkdefProperty {
     /// The target this linkdef applies to. This should be the name of an actor component
     pub target: String,
     /// Values to use for this linkdef
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub values: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<HashMap<String, String>>,
 }
 
 /// Properties for spread scalers
@@ -324,6 +324,12 @@ mod test {
             matches!(traits[1].properties, TraitProperty::Linkdef(_)),
             "Should have linkdef properties"
         );
+        if let TraitProperty::Linkdef(ld) = &traits[1].properties {
+            assert_eq!(ld.values, None);
+            assert_eq!(ld.target, "webcap".to_string());
+        } else {
+            panic!("trait property was not a link definition");
+        }
     }
 
     #[test]
@@ -350,7 +356,7 @@ mod test {
         trait_vec.push(trait_item);
         let linkdefprop = LinkdefProperty {
             target: "webcap".to_string(),
-            values: HashMap::from([("port".to_string(), "4000".to_string())]),
+            values: Some(HashMap::from([("port".to_string(), "4000".to_string())])),
         };
         let trait_item = Trait::new_linkdef(linkdefprop);
         trait_vec.push(trait_item);

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -138,7 +138,7 @@ impl<S: ReadStore + Send + Sync> LinkScaler<S> {
         provider_link_name: Option<String>,
         lattice_id: String,
         model_name: String,
-        values: HashMap<String, String>,
+        values: Option<HashMap<String, String>>,
     ) -> Self {
         Self {
             store,
@@ -152,7 +152,7 @@ impl<S: ReadStore + Send + Sync> LinkScaler<S> {
                     .unwrap_or_else(|| DEFAULT_LINK_NAME.to_string()),
                 lattice_id,
                 model_name,
-                values,
+                values: values.unwrap_or_default(),
             },
         }
     }


### PR DESCRIPTION
## Feature or Problem
This PR allows two more things in the wadm manifest to be replaced by default values.
1. Linkdef values (as you do not need values to create a linkdef)
2. Provider spreadscaler properties (as it's just a little verbose)

The first is desired behavior, but the second is a preference and worth discussion. I like it because it can reduce this:
```yaml
 - name: httpclient
      type: capability
      properties:
        image: wasmcloud.azurecr.io/httpclient:0.5.3
        contract: wasmcloud:httpclient
      traits:
        - type: spreadscaler
          properties:
            replicas: 1
    - name: blobstore
      type: capability
      properties:
        image: wasmcloud.azurecr.io/blobstore_fs:0.1.0
        contract: wasmcloud:blobstore
      traits:
        - type: spreadscaler
          properties:
            replicas: 1
    - name: messaging
      type: capability
      properties:
        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
        contract: wasmcloud:messaging
      traits:
        - type: spreadscaler
          properties:
            replicas: 1

```

Into this:
```yaml
    - name: httpclient
      type: capability
      properties:
        image: wasmcloud.azurecr.io/httpclient:0.5.3
        contract: wasmcloud:httpclient
    - name: blobstore
      type: capability
      properties:
        image: wasmcloud.azurecr.io/blobstore_fs:0.1.0
        contract: wasmcloud:blobstore
    - name: messaging
      type: capability
      properties:
        image: wasmcloud.azurecr.io/nats_messaging:0.16.3
        contract: wasmcloud:messaging
```

## Related Issues
#96 

## Release Information
`v0.4.0-alpha.2`

## Consumer Impact
Consumers won't notice any changes, this just allows manifests to be simpler for the most common use cases.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Modified model tests to adopt to linkdef changes. Worth noting that my changes did not work with the previous `HashMap::is_empty` test, and I had to make the linkdef property an Option<HashMap<_>>

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Validating :spinner:
