### PR TITLE
feat(*) Remove jitter with plural events and expected events

### DIFF
--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
 # INSTALL WASH
-cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force 
-
-# INSTALL WADM
-ARCH=$(arch)
-VERSION=v0.4.0-alpha.1
-
-if [[ $ARCH == "x86_64" ]]; then
-    ARCH="amd64"
-fi
-
-TARBALL=wadm-$VERSION-linux-$ARCH
-
-curl -fLO https://github.com/wasmCloud/wadm/releases/download/$VERSION/$TARBALL.tar.gz
-tar -xvf $TARBALL.tar.gz
-chmod +x $TARBALL/wadm
-mv $TARBALL/wadm /usr/local/cargo/bin/wadm
-rm -rf $TARBALL $TARBALL.tar.gz
+curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.deb.sh | sudo bash
+sudo apt install wash openssl -y

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "wasmbus-rpc",
  "wasmcloud-control-interface",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { version = "0.3.7", features = [
     "json",
 ], optional = true }
 uuid = "1"
+wasmbus-rpc = "*"
 wasmcloud-control-interface = "0.25"
 semver = { version = "1.0.16", features = ["serde"] }
 

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,17 @@ MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 MAKEFLAGS += -S
 
-.DEFAULT: all
+.DEFAULT: help
 
 CARGO ?= cargo
 CARGO_CLIPPY ?= cargo-clippy
 DOCKER ?= docker
 NATS ?= nats
 
-all: build test
-
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_\-.*]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+all: build test
 
 ###########
 # Tooling #

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ issues/missing features to be aware of that we plan on addressing by the time we
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=401352358&machine=standardLinux32gb&location=EastUs)
 
-### Install
+### Install & Run
 
-You can deploy **wadm** by downloading the binary for your host operating system and architecture, and then running it alongside your wasmCloud host. We recommend using **wash** to run wasmCloud and NATS, and then running **wadm** afterwards connected to the same NATS connection.
-
-Ensure you have a proper [rust](https://www.rust-lang.org/tools/install) toolchain installed to install **wash**, until we release wash v0.18.0.
+You can easily run **wadm** by downloading [wash](https://wasmcloud.com/docs/installation) and launching it alongside NATS and wasmCloud. Then, you can use the `wash app` command to query, create, and deploy applications.
 
 ```
-# Install wash
-cargo install wash-cli --git https://github.com/wasmcloud/wash --branch feat/wadm_0.4_support --force
+wash up -d    # Start NATS, wasmCloud, and wadm in the background
+wash app list # Query the list of applications
 ```
+
+If you prefer to run **wadm** separately and/or connect to running wasmCloud hosts, you can instead opt for using the latest GitHub release artifact and executing the binary. Simply replace the latest version, your operating system, and architecture below.
 
 ```
 # Install wadm
@@ -42,13 +42,6 @@ curl -fLO https://github.com/wasmCloud/wadm/releases/download/<version>/wadm-<ve
 tar -xvf wadm-<version>-<os>-<arch>.tar.gz
 cd wadm-<version>-<os>-<arch>
 ./wadm
-```
-
-### Setup
-
-```
-wash up -d   # Start NATS and wasmCloud in the background
-wadm         # Start wadm
 ```
 
 ### Deploying an application

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ of these can be found below:
   entirely invalid properties. This will be added in a future version.
 - Nondestructive (e.g. orphaning resources) undeploys are not currently implemented. You can set the
   field in the request, but it won't do anything
+- If wadm discovers a provider in the lattice that isn't already started via a manifest, the
+  manifest won't be able to reconcile until another start provider event is received. This will
+  require a feature add to the ctl client to fix
 
 ## References
 

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -348,6 +348,7 @@ where
                     self.state_store.clone(),
                     self.manifest_store.clone(),
                     publisher.clone(),
+                    client.clone(),
                 )
                 .await?;
                 Ok(EventWorker::new(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,7 +7,14 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::CapabilityConfig;
+use crate::{
+    events::{
+        ActorClaims, ActorsStartFailed, ActorsStarted, Event, Linkdef, LinkdefSet, ProviderClaims,
+        ProviderStartFailed, ProviderStarted,
+    },
+    model::CapabilityConfig,
+    workers::insert_managed_annotations,
+};
 
 macro_rules! from_impl {
     ($t:ident) => {
@@ -28,6 +35,106 @@ pub enum Command {
     StopProvider(StopProvider),
     PutLinkdef(PutLinkdef),
     DeleteLinkdef(DeleteLinkdef),
+}
+
+impl Command {
+    /// Generates the corresponding event for a [Command](Command) in the form of a two-tuple ([Event](Event), Option<Event>)
+    ///
+    /// # Arguments
+    /// `model_name` - The model name that the command satisfies, needed to compute the proper annotations
+    ///
+    /// # Return
+    /// - The first element in the tuple corresponds to the "success" event a host would output after completing this command
+    /// - The second element in the tuple corresponds to an optional "failure" event that a host could output if processing fails
+    pub fn corresponding_event(&self, model_name: &str) -> (Event, Option<Event>) {
+        match self {
+            Command::StartActor(StartActor {
+                annotations,
+                reference,
+                host_id,
+                count,
+                ..
+            }) => {
+                let mut annotations = annotations.to_owned();
+                insert_managed_annotations(&mut annotations, model_name);
+                (
+                    Event::ActorsStarted(ActorsStarted {
+                        annotations: annotations.to_owned(),
+                        image_ref: reference.to_owned(),
+                        host_id: host_id.to_owned(),
+                        count: *count,
+                        // We do not know the public key or claims from the command
+                        public_key: String::with_capacity(0),
+                        claims: ActorClaims::default(),
+                    }),
+                    Some(Event::ActorsStartFailed(ActorsStartFailed {
+                        annotations,
+                        image_ref: reference.to_owned(),
+                        host_id: host_id.to_owned(),
+                        error: String::with_capacity(0),
+                        // We do not know the public key from the command
+                        public_key: String::with_capacity(0),
+                    })),
+                )
+            }
+            Command::StartProvider(StartProvider {
+                annotations,
+                reference,
+                host_id,
+                link_name,
+                ..
+            }) => {
+                let mut annotations = annotations.to_owned();
+                insert_managed_annotations(&mut annotations, model_name);
+                (
+                    Event::ProviderStarted(ProviderStarted {
+                        annotations: annotations.to_owned(),
+                        claims: ProviderClaims::default(),
+                        image_ref: reference.to_owned(),
+                        link_name: link_name
+                            .to_owned()
+                            .unwrap_or_else(|| "default".to_string()),
+                        host_id: host_id.to_owned(),
+                        // We don't know these fields from the command
+                        contract_id: String::with_capacity(0),
+                        instance_id: String::with_capacity(0),
+                        public_key: String::with_capacity(0),
+                    }),
+                    Some(Event::ProviderStartFailed(ProviderStartFailed {
+                        provider_ref: reference.to_owned(),
+                        link_name: link_name
+                            .to_owned()
+                            .unwrap_or_else(|| "default".to_string()),
+                        host_id: host_id.to_owned(),
+                        // We don't know this field from the command
+                        error: String::with_capacity(0),
+                    })),
+                )
+            }
+            Command::PutLinkdef(PutLinkdef {
+                actor_id,
+                provider_id,
+                link_name,
+                contract_id,
+                values,
+                ..
+            }) => (
+                Event::LinkdefSet(LinkdefSet {
+                    linkdef: Linkdef {
+                        actor_id: actor_id.to_owned(),
+                        contract_id: contract_id.to_owned(),
+                        link_name: link_name.to_owned(),
+                        provider_id: provider_id.to_owned(),
+                        values: values.to_owned(),
+                        // We don't know the linkdef ID from the command
+                        id: String::with_capacity(0),
+                    },
+                }),
+                None,
+            ),
+            _ => todo!(),
+        }
+    }
 }
 
 /// Struct for the StartActor command

--- a/src/events/data.rs
+++ b/src/events/data.rs
@@ -33,7 +33,7 @@ impl Hash for ProviderInfo {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct ProviderClaims {
     pub expires_human: String,
     // TODO: Should we actually parse the nkey?
@@ -48,7 +48,7 @@ pub struct ProviderClaims {
     pub version: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct ProviderHealthCheckInfo {
     pub link_name: String,
     // TODO: Should we make this a parsed nkey?
@@ -56,7 +56,7 @@ pub struct ProviderHealthCheckInfo {
     pub contract_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct ActorClaims {
     pub call_alias: Option<String>,
     #[serde(rename = "caps")]

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -83,7 +83,7 @@ pub trait EventType {
 }
 
 /// A lattice event
-#[derive(Debug)]
+#[derive(Debug, Clone, Deserialize)]
 pub enum Event {
     ActorStarted(ActorStarted),
     ActorsStarted(ActorsStarted),
@@ -113,7 +113,12 @@ impl TryFrom<CloudEvent> for Event {
     fn try_from(value: CloudEvent) -> Result<Self, Self::Error> {
         match value.ty() {
             ActorStarted::TYPE => ActorStarted::try_from(value).map(Event::ActorStarted),
+            ActorsStarted::TYPE => ActorsStarted::try_from(value).map(Event::ActorsStarted),
+            ActorsStartFailed::TYPE => {
+                ActorsStartFailed::try_from(value).map(Event::ActorsStartFailed)
+            }
             ActorStopped::TYPE => ActorStopped::try_from(value).map(Event::ActorStopped),
+            ActorsStopped::TYPE => ActorsStopped::try_from(value).map(Event::ActorsStopped),
             ProviderStarted::TYPE => ProviderStarted::try_from(value).map(Event::ProviderStarted),
             ProviderStopped::TYPE => ProviderStopped::try_from(value).map(Event::ProviderStopped),
             ProviderStartFailed::TYPE => {

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -86,7 +86,10 @@ pub trait EventType {
 #[derive(Debug)]
 pub enum Event {
     ActorStarted(ActorStarted),
+    ActorsStarted(ActorsStarted),
+    ActorsStartFailed(ActorsStartFailed),
     ActorStopped(ActorStopped),
+    ActorsStopped(ActorsStopped),
     ProviderStarted(ProviderStarted),
     ProviderStopped(ProviderStopped),
     ProviderStartFailed(ProviderStartFailed),
@@ -149,7 +152,10 @@ impl Serialize for Event {
     {
         match self {
             Event::ActorStarted(evt) => evt.serialize(serializer),
+            Event::ActorsStarted(evt) => evt.serialize(serializer),
+            Event::ActorsStartFailed(evt) => evt.serialize(serializer),
             Event::ActorStopped(evt) => evt.serialize(serializer),
+            Event::ActorsStopped(evt) => evt.serialize(serializer),
             Event::ProviderStarted(evt) => evt.serialize(serializer),
             Event::ProviderStopped(evt) => evt.serialize(serializer),
             Event::ProviderStartFailed(evt) => evt.serialize(serializer),
@@ -177,7 +183,10 @@ impl Event {
     pub fn raw_type(&self) -> &str {
         match self {
             Event::ActorStarted(_) => ActorStarted::TYPE,
+            Event::ActorsStarted(_) => ActorsStarted::TYPE,
+            Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
             Event::ActorStopped(_) => ActorStopped::TYPE,
+            Event::ActorsStopped(_) => ActorsStopped::TYPE,
             Event::ProviderStarted(_) => ProviderStarted::TYPE,
             Event::ProviderStopped(_) => ProviderStopped::TYPE,
             Event::ProviderStartFailed(_) => ProviderStopped::TYPE,
@@ -238,6 +247,45 @@ event_impl!(
 );
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ActorsStarted {
+    pub annotations: HashMap<String, String>,
+    // Commented out for now because the host broken it and we actually don't use this right now
+    // pub api_version: usize,
+    pub claims: ActorClaims,
+    pub image_ref: String,
+    pub count: usize,
+    // TODO: Parse as nkey?
+    pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
+}
+
+event_impl!(
+    ActorsStarted,
+    "com.wasmcloud.lattice.actors_started",
+    source,
+    host_id
+);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ActorsStartFailed {
+    pub annotations: HashMap<String, String>,
+    pub image_ref: String,
+    // TODO: Parse as nkey?
+    pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
+    pub error: String,
+}
+
+event_impl!(
+    ActorsStartFailed,
+    "com.wasmcloud.lattice.actors_start_failed",
+    source,
+    host_id
+);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActorStopped {
     #[serde(default)]
     pub annotations: HashMap<String, String>,
@@ -251,6 +299,27 @@ pub struct ActorStopped {
 event_impl!(
     ActorStopped,
     "com.wasmcloud.lattice.actor_stopped",
+    source,
+    host_id
+);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ActorsStopped {
+    #[serde(default)]
+    pub annotations: HashMap<String, String>,
+    // TODO: Parse as nkey?
+    pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
+    /// Number of actors stopped from this command
+    pub count: usize,
+    /// Remaining number of this actor running on the host
+    pub remaining: usize,
+}
+
+event_impl!(
+    ActorsStopped,
+    "com.wasmcloud.lattice.actors_stopped",
     source,
     host_id
 );

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -83,6 +83,7 @@ pub trait EventType {
 }
 
 /// A lattice event
+// TODO:  this `Deserialize` impl _compiles_ but doesn't let you deserialize an event because of our custom Serialize
 #[derive(Debug, Clone, Deserialize)]
 pub enum Event {
     ActorStarted(ActorStarted),

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -86,8 +86,7 @@ pub trait EventType {
 }
 
 /// A lattice event
-// TODO:  this `Deserialize` impl _compiles_ but doesn't let you deserialize an event because of our custom Serialize
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum Event {
     ActorStarted(ActorStarted),
     ActorsStarted(ActorsStarted),
@@ -269,7 +268,7 @@ pub enum ConversionError {
 // EVENTS START HERE
 //
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorStarted {
     pub annotations: HashMap<String, String>,
     // Commented out for now because the host broken it and we actually don't use this right now
@@ -291,7 +290,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorsStarted {
     pub annotations: HashMap<String, String>,
     // Commented out for now because the host broken it and we actually don't use this right now
@@ -312,7 +311,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorsStartFailed {
     pub annotations: HashMap<String, String>,
     pub image_ref: String,
@@ -330,7 +329,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorStopped {
     #[serde(default)]
     pub annotations: HashMap<String, String>,
@@ -348,7 +347,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorsStopped {
     #[serde(default)]
     pub annotations: HashMap<String, String>,
@@ -369,7 +368,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderStarted {
     pub annotations: HashMap<String, String>,
     pub claims: ProviderClaims,
@@ -391,7 +390,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderStartFailed {
     pub error: String,
     pub link_name: String,
@@ -407,7 +406,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderStopped {
     #[serde(default)]
     // TODO(thomastaylor312): Yep, there was a spelling bug in the host is 0.62.1. Revert this once
@@ -433,7 +432,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderHealthCheckPassed {
     #[serde(flatten)]
     pub data: ProviderHealthCheckInfo,
@@ -448,7 +447,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderHealthCheckFailed {
     #[serde(flatten)]
     pub data: ProviderHealthCheckInfo,
@@ -463,7 +462,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderHealthCheckStatus {
     #[serde(flatten)]
     pub data: ProviderHealthCheckInfo,
@@ -478,7 +477,7 @@ event_impl!(
     host_id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LinkdefSet {
     #[serde(flatten)]
     pub linkdef: Linkdef,
@@ -486,7 +485,7 @@ pub struct LinkdefSet {
 
 event_impl!(LinkdefSet, "com.wasmcloud.lattice.linkdef_set");
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LinkdefDeleted {
     #[serde(flatten)]
     pub linkdef: Linkdef,
@@ -494,7 +493,7 @@ pub struct LinkdefDeleted {
 
 event_impl!(LinkdefDeleted, "com.wasmcloud.lattice.linkdef_deleted");
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HostStarted {
     pub labels: HashMap<String, String>,
     pub friendly_name: String,
@@ -510,7 +509,7 @@ event_impl!(
     id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HostStopped {
     pub labels: HashMap<String, String>,
     // TODO: Parse as nkey?
@@ -525,7 +524,7 @@ event_impl!(
     id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HostHeartbeat {
     pub actors: HashMap<String, usize>,
     pub friendly_name: String,
@@ -548,7 +547,7 @@ event_impl!(
     id
 );
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ManifestPublished {
     #[serde(flatten)]
     pub manifest: Manifest,
@@ -556,7 +555,7 @@ pub struct ManifestPublished {
 
 event_impl!(ManifestPublished, "com.wadm.manifest_published");
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ManifestUnpublished {
     pub name: String,
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -31,7 +31,7 @@ pub const LINKDEF_TRAIT: &str = "linkdef";
 pub const LATEST_VERSION: &str = "latest";
 
 /// An OAM manifest
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Manifest {
     /// The OAM version of the manifest
     #[serde(rename = "apiVersion")]
@@ -64,7 +64,7 @@ impl Manifest {
 }
 
 /// The metadata describing the manifest
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Metadata {
     /// The name of the manifest. This should be unique
     pub name: String,
@@ -74,14 +74,14 @@ pub struct Metadata {
 }
 
 /// A representation of an OAM specification
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Specification {
     /// The list of components for describing an application
     pub components: Vec<Component>,
 }
 
 /// A component definition
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Component {
     /// The name of this component
     pub name: String,
@@ -97,7 +97,7 @@ pub struct Component {
 }
 
 /// Properties that can be defined for a component
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub enum Properties {
     #[serde(rename = "actor")]
@@ -106,13 +106,13 @@ pub enum Properties {
     Capability { properties: CapabilityProperties },
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorProperties {
     /// The image reference to use
     pub image: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct CapabilityProperties {
     /// The image reference to use
     pub image: String,
@@ -181,7 +181,7 @@ impl Serialize for CapabilityConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Trait {
     /// The type of trait specified. This should be a unique string for the type of scaler. As we
     /// plan on supporting custom scalers, these traits are not enumerated
@@ -210,7 +210,7 @@ impl Trait {
 }
 
 /// Properties for defining traits
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum TraitProperty {
     Linkdef(LinkdefProperty),
@@ -240,7 +240,7 @@ impl From<serde_json::Value> for TraitProperty {
 }
 
 /// Properties for linkdefs
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LinkdefProperty {
     /// The target this linkdef applies to. This should be the name of an actor component
     pub target: String,
@@ -250,7 +250,7 @@ pub struct LinkdefProperty {
 }
 
 /// Properties for spread scalers
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct SpreadScalerProperty {
     /// Number of replicas to scale
     pub replicas: usize,
@@ -260,7 +260,7 @@ pub struct SpreadScalerProperty {
 }
 
 /// Configuration for various spreading requirements
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Spread {
     /// The name of this spread requirement
     pub name: String,

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -98,20 +98,6 @@ where
 
         Ok(futures::future::join_all(self.scalers.iter().map(|scaler| scaler.reconcile())).await)
     }
-
-    /// Ensures that each Scaler for a manifest removes this event from its expected events list
-    pub async fn remove_expected_event(&self, event: &Event) -> Result<()> {
-        let manifest_name = self.name;
-
-        let data = serde_json::to_vec(&Notifications::RemoveExpectedEvent {
-            name: manifest_name.to_owned(),
-            event: event.clone(),
-        })?;
-
-        self.publisher.publish(data, Some(self.subject)).await?;
-
-        Ok(())
-    }
 }
 
 /// A wrapper type returned when getting all scalers.
@@ -377,7 +363,6 @@ where
                 res = messages.next() => {
                     match res {
                         Some(Ok(msg)) => {
-                            println!("msg: {:?}", msg);
                             let notification: Notifications = match serde_json::from_slice(&msg.payload) {
                                 Ok(n) => n,
                                 Err(e) => {

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -120,9 +120,7 @@ where
     }
 }
 
-/// A wrapper type returned when getting all scalers. Implements a backoff operation that can be
-/// called to tell all returned scalers to back off and notifiying with a message so other consumers
-/// can backoff as well
+/// A wrapper type returned when getting all scalers.
 pub struct AllScalers {
     pub scalers: OwnedRwLockReadGuard<HashMap<String, ScalerList>>,
 }

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -48,7 +48,6 @@ pub const WADM_NOTIFY_PREFIX: &str = "wadm.notify";
 pub enum Notifications {
     CreateScalers(Manifest),
     DeleteScalers(String),
-
     /// Register expected events for a manifest. Should only be used when a full reconcile
     /// is being done (like on first deploy), rather than just handling a single event
     RegisterExpectedEvents(String),

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -33,35 +33,16 @@ use crate::{
     DEFAULT_LINK_NAME,
 };
 
-use super::spreadscaler::{
-    link::LinkScaler,
-    provider::{ProviderSpreadConfig, ProviderSpreadScaler},
+use super::{
+    spreadscaler::{
+        link::LinkScaler,
+        provider::{ProviderSpreadConfig, ProviderSpreadScaler},
+    },
+    BackoffAwareScaler,
 };
 
 pub type BoxedScaler = Box<dyn Scaler + Send + Sync + 'static>;
-pub type ScalerList = Vec<ScalerWithEvents>;
-
-pub struct ScalerWithEvents {
-    scaler: BoxedScaler,
-    pub(crate) backoff_events: Arc<RwLock<Vec<(Event, Option<Event>)>>>,
-}
-
-impl Deref for ScalerWithEvents {
-    type Target = BoxedScaler;
-
-    fn deref(&self) -> &Self::Target {
-        &self.scaler
-    }
-}
-
-impl From<BoxedScaler> for ScalerWithEvents {
-    fn from(scaler: BoxedScaler) -> Self {
-        Self {
-            scaler,
-            backoff_events: Arc::new(RwLock::new(vec![])),
-        }
-    }
-}
+pub type ScalerList = Vec<BackoffAwareScaler>;
 
 pub const WADM_NOTIFY_PREFIX: &str = "wadm.notify";
 // The backoff channel buffer size. This is an arbitrary number, but we want to make sure we cap it
@@ -73,6 +54,14 @@ const CHANNEL_BUFFER_SIZE: usize = 250;
 pub enum Notifications {
     CreateScalers(Manifest),
     DeleteScalers(String),
+
+    /// Register expected events for a manifest. Should only be used when a full reconcile
+    /// is being done (like on first deploy), rather than just handling a single event
+    RegisterExpectedEvents(String),
+    /// Remove an event from the expected list for a manifest scaler
+    RemoveExpectedEvent((String, Event)),
+    /// Clear all expected events for a manifest
+    ClearExpectedEvents(String),
 }
 
 /// A wrapper type returned when getting a list of scalers. Implements a backoff operation that can
@@ -91,6 +80,51 @@ impl<'a, P> Deref for Scalers<'a, P> {
 
     fn deref(&self) -> &Self::Target {
         self.scalers.deref()
+    }
+}
+
+impl<'a, P> Scalers<'a, P>
+where
+    P: Publisher,
+{
+    pub async fn reconcile_and_register(&self) -> Result<Vec<Result<Vec<Command>>>> {
+        let manifest_name = self.name;
+
+        // Publish the message first because otherwise we could get scalers that don't go to backoff
+        // mode
+        let data = serde_json::to_vec(&Notifications::RegisterExpectedEvents(
+            manifest_name.to_owned(),
+        ))?;
+        self.publisher.publish(data, Some(self.subject)).await?;
+
+        Ok(self
+            .reconcile_and_register_expected_events(manifest_name)
+            .await)
+    }
+
+    /// Computes commands and registers expected events for each scaler.
+    /// Should only be called when you plan to publish all of the commands,
+    /// as this function will register expected events for each scaler.
+    pub async fn reconcile_and_register_expected_events(
+        &self,
+        manifest_name: &str,
+    ) -> Vec<Result<Vec<Command>>> {
+        futures::future::join_all(self.scalers.iter().map(|scaler| async move {
+            match scaler.reconcile().await {
+                // "Backoff" scalers with expected corresponding events
+                Ok(commands) => scaler
+                    .add_events(
+                        commands
+                            .iter()
+                            .filter_map(|command| command.corresponding_event(manifest_name)),
+                        true,
+                    )
+                    .await
+                    .map(|_| commands),
+                Err(e) => Err(e),
+            }
+        }))
+        .await
     }
 }
 
@@ -416,6 +450,36 @@ where
                                     // NOTE(thomastaylor312): We could find that this strategy actually
                                     // doesn't tear down everything or leaves something hanging. If that is
                                     // the case, a new part of the reaper logic should handle it
+                                },
+                                Notifications::RegisterExpectedEvents(name) => {
+                                    trace!(%name, "Computing and registering expected events for manifest");
+                                    if let Some(scalers) = self.get_scalers(&name).await {
+                                        scalers.reconcile_and_register_expected_events(&name).await;
+                                    } else {
+                                        debug!(%name, "Received request to register events for non-existent scalers, ignoring");
+                                    }
+                                },
+                                Notifications::RemoveExpectedEvent((name, event)) => {
+                                    trace!(%name, "Removing expected event for manifest");
+                                    if let Some(scalers) = self.get_scalers(&name).await {
+                                        futures::future::join_all(scalers.iter().map(|scaler| async {
+                                            scaler.remove_event(&event).await
+                                        }
+                                        )).await;
+                                    } else {
+                                        debug!(%name, "Received request to remove event for non-existent scalers, ignoring");
+                                    }
+                                }
+                                Notifications::ClearExpectedEvents(name) => {
+                                    trace!(%name, "Clearing expected events for all scalers for manifest");
+                                    if let Some(scalers) = self.get_scalers(&name).await {
+                                        futures::future::join_all(scalers.iter().map(|scaler| async {
+                                            scaler.set_events(vec![]).await
+                                        }
+                                        )).await;
+                                    } else {
+                                        debug!(%name, "Received request to clear events for non-existent scalers, ignoring");
+                                    }
                                 }
                             }
                             // Always ack if we get here
@@ -442,6 +506,13 @@ where
 
 const EMPTY_TRAIT_VEC: Vec<Trait> = Vec::new();
 
+/// Converts a list of components into a list of scalers
+///
+/// # Arguments
+/// * `components` - The list of components to convert
+/// * `store` - The store to use when creating the scalers so they can access lattice state
+/// * `lattice_id` - The lattice id the scalers operate on
+/// * `name` - The name of the manifest that the scalers are being created for
 pub(crate) fn components_to_scalers<S: ReadStore + Send + Sync + Clone + 'static>(
     components: &[Component],
     store: &S,
@@ -489,39 +560,41 @@ pub(crate) fn components_to_scalers<S: ReadStore + Send + Sync + Clone + 'static
                                 }),
                             _ => None,
                         })
-                        .map(|boxed| boxed.into()),
+                        .map(|boxed| BackoffAwareScaler::new(boxed, name)),
                 )
             }
             Properties::Capability { properties: props } => {
                 if let Some(traits) = traits {
-                    scalers.extend(traits.iter().filter_map(|trt| {
-                        match (trt.trait_type.as_str(), &trt.properties) {
-                            (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                                Some(Box::new(ProviderSpreadScaler::new(
-                                    store.clone(),
-                                    ProviderSpreadConfig {
-                                        lattice_id: lattice_id.to_owned(),
-                                        provider_reference: props.image.to_owned(),
-                                        spread_config: p.to_owned(),
-                                        provider_contract_id: props.contract.to_owned(),
-                                        provider_link_name: props
-                                            .link_name
-                                            .as_deref()
-                                            .unwrap_or(DEFAULT_LINK_NAME)
-                                            .to_owned(),
-                                        model_name: name.to_owned(),
-                                        provider_config: props.config.to_owned(),
-                                    },
-                                )) as BoxedScaler)
-                                .map(|boxed| boxed.into())
-                            }
-                            _ => None,
-                        }
-                    }))
+                    scalers.extend(
+                        traits
+                            .iter()
+                            .filter_map(|trt| match (trt.trait_type.as_str(), &trt.properties) {
+                                (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
+                                    Some(Box::new(ProviderSpreadScaler::new(
+                                        store.clone(),
+                                        ProviderSpreadConfig {
+                                            lattice_id: lattice_id.to_owned(),
+                                            provider_reference: props.image.to_owned(),
+                                            spread_config: p.to_owned(),
+                                            provider_contract_id: props.contract.to_owned(),
+                                            provider_link_name: props
+                                                .link_name
+                                                .as_deref()
+                                                .unwrap_or(DEFAULT_LINK_NAME)
+                                                .to_owned(),
+                                            model_name: name.to_owned(),
+                                            provider_config: props.config.to_owned(),
+                                        },
+                                    )) as BoxedScaler)
+                                }
+                                _ => None,
+                            })
+                            .map(|boxed| BackoffAwareScaler::new(boxed, name)),
+                    )
                 } else {
                     // Allow providers to omit the scaler entirely for simplicity
-                    scalers.push(
-                        (Box::new(ProviderSpreadScaler::new(
+                    scalers.push(BackoffAwareScaler::new(
+                        Box::new(ProviderSpreadScaler::new(
                             store.clone(),
                             ProviderSpreadConfig {
                                 lattice_id: lattice_id.to_owned(),
@@ -539,9 +612,9 @@ pub(crate) fn components_to_scalers<S: ReadStore + Send + Sync + Clone + 'static
                                 model_name: name.to_owned(),
                                 provider_config: props.config.to_owned(),
                             },
-                        )) as BoxedScaler)
-                            .into(),
-                    )
+                        )),
+                        name,
+                    ))
                 }
             }
         }

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -57,6 +57,7 @@ pub struct BackoffAwareScaler {
     scaler: Box<dyn Scaler + Send + Sync>,
     pub model_name: String,
     /// A list of (success, Option<failure>) events that the scaler is expecting
+    #[allow(clippy::type_complexity)]
     expected_events: Arc<RwLock<Vec<(Event, Option<Event>)>>>,
 }
 

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -39,18 +39,4 @@ pub trait Scaler {
     /// This purposefully does not consume the scaler so that if there is a failure it can be kept
     /// around
     async fn cleanup(&self) -> Result<Vec<Command>>;
-
-    /// An optional to implement function that can tell the scaler to enter a backoff period. When
-    /// in backoff, a scaler should always return an empty `Vec<Command>` for all operations. Please
-    /// be careful when calling backoff until you have sent the commands to their intended location
-    /// as otherwise the might not rerun until they are reconciled again.
-    ///
-    /// This function should return as quickly as possible, spawning a task that can switch the
-    /// state back from backoff. The passed in channel is meant to be used to notify the caller that
-    /// the backoff is complete with the name of the model. This name can then be used by the caller
-    /// to run a reconciliation pass to ensure everything is done. This is intended to workaround
-    /// the fact that there is no way to tell when we finished stopping/starting actors
-    ///
-    /// Please note that we'd like this to be temporary in the long term
-    async fn backoff(&self, notifier: Sender<String>);
 }

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -1,8 +1,16 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use tokio::sync::mpsc::Sender;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
-use crate::{commands::Command, events::Event, model::TraitProperty};
+use crate::{
+    commands::Command,
+    events::{
+        ActorsStartFailed, ActorsStarted, ActorsStopped, Event, Linkdef, LinkdefSet,
+        ProviderStartFailed, ProviderStarted,
+    },
+    model::TraitProperty,
+};
 
 pub mod manager;
 mod simplescaler;
@@ -39,4 +47,226 @@ pub trait Scaler {
     /// This purposefully does not consume the scaler so that if there is a failure it can be kept
     /// around
     async fn cleanup(&self) -> Result<Vec<Command>>;
+}
+
+/// A Scaler wrapper struct that can compute a proper backoff for a scaler based
+/// on its commands and avoids delivering events to the scaler that would cause
+/// it to issue duplicate commands
+//TODO(brooksmtownsend): Consider if this should be pub or pub(crate). Gut feeling says that this shouldn't be a type that external crate users are exposed to, they should just be using the Scaler trait. However changing this would mark a lot of different type as pub(crate)
+pub struct BackoffAwareScaler {
+    scaler: Box<dyn Scaler + Send + Sync>,
+    pub model_name: String,
+    /// A list of (success, Option<failure>) events that the scaler is expecting
+    expected_events: Arc<RwLock<Vec<(Event, Option<Event>)>>>,
+}
+
+impl std::ops::Deref for BackoffAwareScaler {
+    type Target = Box<dyn Scaler + Send + Sync>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.scaler
+    }
+}
+
+impl BackoffAwareScaler {
+    pub fn new(scaler: Box<dyn Scaler + Send + Sync>, model_name: &str) -> Self {
+        Self {
+            scaler,
+            model_name: model_name.to_string(),
+            expected_events: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+    pub async fn event_count(&self) -> usize {
+        self.expected_events.read().await.len()
+    }
+
+    pub async fn get_events(&self) -> Vec<(Event, Option<Event>)> {
+        //TODO: see if I can ref this instead of clone
+        self.expected_events.read().await.clone()
+    }
+
+    /// Returns true if the given event is expected by the scaler either as a successful event
+    /// or a failure event
+    pub async fn expecting_event(&self, event: &Event) -> bool {
+        let expected_events = self.expected_events.read().await;
+        expected_events.iter().any(|(success, fail)| {
+            evt_matches_expected(success, event)
+                || fail
+                    .as_ref()
+                    .map(|f| evt_matches_expected(f, event))
+                    .unwrap_or(false)
+        })
+    }
+
+    /// Adds events to the expected events list
+    ///
+    /// # Arguments
+    /// `events` - A list of (success, failure) events to add to the expected events list
+    /// `clear_previous` - If true, clears the previous expected events list before adding the new events
+    pub async fn add_events<I>(&self, events: I, clear_previous: bool) -> Result<()>
+    where
+        I: IntoIterator<Item = (Event, Option<Event>)>,
+    {
+        let mut expected_events = self.expected_events.write().await;
+        if clear_previous {
+            expected_events.clear();
+        }
+        expected_events.extend(events);
+        Ok(())
+    }
+
+    /// Removes an event pair from the expected events list if one matches the given event
+    /// Returns true if the event was removed, false otherwise
+    pub async fn remove_event(&self, event: &Event) -> Result<bool> {
+        let mut expected_events = self.expected_events.write().await;
+        let before_count = expected_events.len();
+        expected_events.retain(|(success, fail)| {
+            !evt_matches_expected(success, event)
+                && !fail
+                    .as_ref()
+                    .map(|f| evt_matches_expected(f, event))
+                    .unwrap_or(false)
+        });
+        Ok(expected_events.len() != before_count)
+    }
+
+    /// Sets the expected events list to the given events
+    pub async fn set_events(&self, events: Vec<Event>) -> Result<()> {
+        let mut expected_events = self.expected_events.write().await;
+        expected_events.clear();
+        expected_events.extend(events.into_iter().map(|e| (e, None)));
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Scaler for BackoffAwareScaler {
+    async fn update_config(&mut self, config: TraitProperty) -> Result<Vec<Command>> {
+        self.scaler.update_config(config).await
+    }
+
+    async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
+        self.scaler.handle_event(event).await
+    }
+
+    async fn reconcile(&self) -> Result<Vec<Command>> {
+        self.scaler.reconcile().await
+    }
+
+    async fn cleanup(&self) -> Result<Vec<Command>> {
+        self.scaler.cleanup().await
+    }
+}
+
+/// A specialized function that compares an incoming lattice event to an "expected" event
+/// stored alongside a [Scaler](Scaler).
+///
+/// This is not a PartialEq or Eq implementation because there are strict assumptions that do not always hold.
+/// For example, an incoming and expected event are equal even if their claims are not equal, because we cannot
+/// compute that information from a [Command](Command). However, this is not a valid comparison if actually
+/// comparing two events for equality.
+fn evt_matches_expected(incoming: &Event, expected: &Event) -> bool {
+    match (incoming, expected) {
+        (
+            Event::ActorsStarted(ActorsStarted {
+                annotations: a1,
+                image_ref: i1,
+                count: c1,
+                host_id: h1,
+                ..
+            }),
+            Event::ActorsStarted(ActorsStarted {
+                annotations: a2,
+                image_ref: i2,
+                count: c2,
+                host_id: h2,
+                ..
+            }),
+        ) => a1 == a2 && i1 == i2 && c1 == c2 && h1 == h2,
+        (
+            Event::ActorsStartFailed(ActorsStartFailed {
+                annotations: a1,
+                image_ref: i1,
+                host_id: h1,
+                ..
+            }),
+            Event::ActorsStartFailed(ActorsStartFailed {
+                annotations: a2,
+                image_ref: i2,
+                host_id: h2,
+                ..
+            }),
+        ) => a1 == a2 && i1 == i2 && h1 == h2,
+        (
+            Event::ActorsStopped(ActorsStopped {
+                annotations: a1,
+                public_key: p1,
+                count: c1,
+                host_id: h1,
+                ..
+            }),
+            Event::ActorsStopped(ActorsStopped {
+                annotations: a2,
+                public_key: p2,
+                count: c2,
+                host_id: h2,
+                ..
+            }),
+        ) => a1 == a2 && p1 == p2 && c1 == c2 && h1 == h2,
+        (
+            Event::ProviderStarted(ProviderStarted {
+                annotations: a1,
+                image_ref: i1,
+                link_name: l1,
+                host_id: h1,
+                ..
+            }),
+            Event::ProviderStarted(ProviderStarted {
+                annotations: a2,
+                image_ref: i2,
+                link_name: l2,
+                host_id: h2,
+                ..
+            }),
+        ) => a1 == a2 && i1 == i2 && l1 == l2 && h1 == h2,
+        // NOTE(brooksmtownsend): This is a little less information than we really need here.
+        // Image reference + annotations would be nice
+        (
+            Event::ProviderStartFailed(ProviderStartFailed {
+                link_name: l1,
+                host_id: h1,
+                ..
+            }),
+            Event::ProviderStartFailed(ProviderStartFailed {
+                link_name: l2,
+                host_id: h2,
+                ..
+            }),
+        ) => l1 == l2 && h1 == h2,
+        (
+            Event::LinkdefSet(LinkdefSet {
+                linkdef:
+                    Linkdef {
+                        actor_id: a1,
+                        contract_id: c1,
+                        link_name: l1,
+                        provider_id: p1,
+                        values: v1,
+                        ..
+                    },
+            }),
+            Event::LinkdefSet(LinkdefSet {
+                linkdef:
+                    Linkdef {
+                        actor_id: a2,
+                        contract_id: c2,
+                        link_name: l2,
+                        provider_id: p2,
+                        values: v2,
+                        ..
+                    },
+            }),
+        ) => a1 == a2 && c1 == c2 && l1 == l2 && p1 == p2 && v1 == v2,
+        _ => false,
+    }
 }

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -213,8 +213,6 @@ impl<S: ReadStore + Send + Sync> SimpleActorScaler<S> {
 mod test {
     use std::{collections::HashMap, sync::Arc};
 
-    use tokio::sync::RwLock;
-
     use crate::{
         commands::{Command, StartActor},
         consumers::{manager::Worker, ScopedMessage},
@@ -259,17 +257,20 @@ mod test {
         // Lattice State: One empty host
 
         let store = Arc::new(TestStore::default());
-        let lattice_source = TestLatticeSource {
-            claims: HashMap::default(),
-            inventory: Arc::new(RwLock::new(HashMap::default())),
-        };
+        let lattice_source = TestLatticeSource::default();
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
-            lattice_source,
+            lattice_source.clone(),
             command_publisher.clone(),
-            ScalerManager::test_new(NoopPublisher, lattice_id, store.clone(), command_publisher)
-                .await,
+            ScalerManager::test_new(
+                NoopPublisher,
+                lattice_id,
+                store.clone(),
+                command_publisher,
+                lattice_source,
+            )
+            .await,
         );
 
         let host_id = "NASDASDIAMAREALHOST".to_string();
@@ -327,17 +328,20 @@ mod test {
         let replicas = 2;
 
         let store = Arc::new(TestStore::default());
-        let lattice_source = TestLatticeSource {
-            claims: HashMap::default(),
-            inventory: Arc::new(RwLock::new(HashMap::default())),
-        };
+        let lattice_source = TestLatticeSource::default();
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
-            lattice_source,
+            lattice_source.clone(),
             command_publisher.clone(),
-            ScalerManager::test_new(NoopPublisher, lattice_id, store.clone(), command_publisher)
-                .await,
+            ScalerManager::test_new(
+                NoopPublisher,
+                lattice_id,
+                store.clone(),
+                command_publisher,
+                lattice_source,
+            )
+            .await,
         );
 
         // *** STATE SETUP BEGIN ***

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -76,10 +76,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for SimpleActorScaler<S> {
 
         cleanerupper.compute_actor_commands(&self.store).await
     }
-
-    async fn backoff(&self, notifier: Sender<String>) {
-        let _ = notifier.send(String::with_capacity(0)).await;
-    }
 }
 
 impl<S: ReadStore + Send + Sync> SimpleActorScaler<S> {

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tokio::sync::mpsc::Sender;
 
 use crate::{
     commands::{Command, StartActor, StopActor},

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -11,6 +11,7 @@ use crate::{
     model::TraitProperty,
     scaler::Scaler,
     storage::{Actor, Provider, ReadStore},
+    workers::LinkSource,
     DEFAULT_LINK_NAME,
 };
 
@@ -35,18 +36,23 @@ pub struct LinkScalerConfig {
 }
 
 /// The LinkSpreadScaler ensures that link configuration exists on a specified lattice.
-pub struct LinkScaler<S: ReadStore + Send + Sync> {
+pub struct LinkScaler<S, L> {
     pub config: LinkScalerConfig,
     store: S,
     /// Actor ID, stored in a OnceCell to facilitate more efficient fetches
     actor_id: OnceCell<String>,
     /// Provider ID, stored in a OnceCell to facilitate more efficient fetches
     provider_id: OnceCell<String>,
+    ctl_client: L,
     id: String,
 }
 
 #[async_trait]
-impl<S: ReadStore + Send + Sync> Scaler for LinkScaler<S> {
+impl<S, L> Scaler for LinkScaler<S, L>
+where
+    S: ReadStore + Send + Sync,
+    L: LinkSource + Send + Sync,
+{
     fn id(&self) -> &str {
         &self.id
     }
@@ -99,15 +105,47 @@ impl<S: ReadStore + Send + Sync> Scaler for LinkScaler<S> {
     #[instrument(level = "trace", skip_all, fields(actor_ref = %self.config.actor_reference, provider_ref = %self.config.provider_reference, link_name = %self.config.provider_link_name, scaler_id = %self.id))]
     async fn reconcile(&self) -> Result<Vec<Command>> {
         if let (Ok(actor_id), Ok(provider_id)) = (self.actor_id().await, self.provider_id().await) {
-            // TODO: check to see if linkdef exists. Might need to be deleted first if values differ
-            Ok(vec![Command::PutLinkdef(PutLinkdef {
-                actor_id: actor_id.to_owned(),
-                provider_id: provider_id.to_owned(),
-                link_name: self.config.provider_link_name.to_owned(),
-                contract_id: self.config.provider_contract_id.to_owned(),
-                values: self.config.values.to_owned(),
-                model_name: self.config.model_name.to_owned(),
-            })])
+            let linkdefs = self.ctl_client.get_links().await?;
+            let (exists, values_different) = linkdefs
+                .into_iter()
+                .find(|linkdef| {
+                    linkdef.actor_id == actor_id
+                        && linkdef.provider_id == provider_id
+                        && linkdef.link_name == self.config.provider_link_name
+                        && linkdef.contract_id == self.config.provider_contract_id
+                })
+                .map(|linkdef| (true, linkdef.values != self.config.values))
+                .unwrap_or((false, false));
+
+            // If it already exists, but values are different, we need to have a delete event first
+            // and recreate it with the correct values second
+            let mut commands = values_different
+                .then(|| {
+                    trace!("Linkdef exists, but values are different, deleting and recreating");
+                    vec![Command::DeleteLinkdef(DeleteLinkdef {
+                        actor_id: actor_id.to_owned(),
+                        provider_id: provider_id.to_owned(),
+                        contract_id: self.config.provider_contract_id.to_owned(),
+                        link_name: self.config.provider_link_name.to_owned(),
+                        model_name: self.config.model_name.to_owned(),
+                    })]
+                })
+                .unwrap_or_default();
+
+            if exists && !values_different {
+                trace!("Linkdef already exists, skipping");
+            } else if !exists || values_different {
+                trace!("Linkdef does not exist or needs to be recreated");
+                commands.push(Command::PutLinkdef(PutLinkdef {
+                    actor_id: actor_id.to_owned(),
+                    provider_id: provider_id.to_owned(),
+                    link_name: self.config.provider_link_name.to_owned(),
+                    contract_id: self.config.provider_contract_id.to_owned(),
+                    values: self.config.values.to_owned(),
+                    model_name: self.config.model_name.to_owned(),
+                }))
+            };
+            Ok(commands)
         } else {
             trace!("Actor ID and provider ID are not initialized, skipping linkdef creation");
             Ok(Vec::new())
@@ -131,7 +169,7 @@ impl<S: ReadStore + Send + Sync> Scaler for LinkScaler<S> {
     }
 }
 
-impl<S: ReadStore + Send + Sync> LinkScaler<S> {
+impl<S: ReadStore + Send + Sync, L: LinkSource> LinkScaler<S, L> {
     /// Construct a new LinkScaler with specified configuration values
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -143,6 +181,7 @@ impl<S: ReadStore + Send + Sync> LinkScaler<S> {
         lattice_id: String,
         model_name: String,
         values: Option<HashMap<String, String>>,
+        ctl_client: L,
     ) -> Self {
         let provider_link_name =
             provider_link_name.unwrap_or_else(|| DEFAULT_LINK_NAME.to_string());
@@ -162,6 +201,7 @@ impl<S: ReadStore + Send + Sync> LinkScaler<S> {
                 model_name,
                 values: values.unwrap_or_default(),
             },
+            ctl_client,
             id,
         }
     }
@@ -209,5 +249,143 @@ impl<S: ReadStore + Send + Sync> LinkScaler<S> {
             })
             .await
             .map(|id| id.as_str())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use wasmbus_rpc::core::LinkDefinition;
+
+    use super::*;
+
+    use crate::{
+        storage::Store,
+        test_util::{TestLatticeSource, TestStore},
+    };
+
+    async fn create_store(lattice_id: &str, actor_ref: &str, provider_ref: &str) -> TestStore {
+        let store = TestStore::default();
+        store
+            .store(
+                lattice_id,
+                "actor".to_string(),
+                Actor {
+                    id: "actor".to_string(),
+                    reference: actor_ref.to_owned(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("Couldn't store actor");
+        store
+            .store(
+                lattice_id,
+                "provider".to_string(),
+                Provider {
+                    id: "provider".to_string(),
+                    reference: provider_ref.to_owned(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("Couldn't store actor");
+        store
+    }
+
+    #[tokio::test]
+    async fn test_no_linkdef() {
+        let lattice_id = "no-linkdef".to_string();
+        let actor_ref = "actor_ref".to_string();
+        let provider_ref = "provider_ref".to_string();
+
+        let scaler = LinkScaler::new(
+            create_store(&lattice_id, &actor_ref, &provider_ref).await,
+            actor_ref,
+            provider_ref,
+            "contract".to_string(),
+            None,
+            lattice_id.clone(),
+            "model".to_string(),
+            None,
+            TestLatticeSource::default(),
+        );
+
+        // Run a reconcile and make sure it returns a single put linkdef command
+        let commands = scaler.reconcile().await.expect("Couldn't reconcile");
+        assert_eq!(commands.len(), 1, "Expected 1 command, got {commands:?}");
+        assert!(matches!(commands[0], Command::PutLinkdef(_)));
+    }
+
+    #[tokio::test]
+    async fn test_different_values() {
+        let lattice_id = "different-values".to_string();
+        let actor_ref = "actor_ref".to_string();
+        let provider_ref = "provider_ref".to_string();
+
+        let values = HashMap::from([("foo".to_string(), "bar".to_string())]);
+
+        let mut linkdef = LinkDefinition::default();
+        linkdef.actor_id = "actor".to_string();
+        linkdef.provider_id = "provider".to_string();
+        linkdef.contract_id = "contract".to_string();
+        linkdef.link_name = "default".to_string();
+        linkdef.values = [("foo".to_string(), "nope".to_string())].into();
+
+        let scaler = LinkScaler::new(
+            create_store(&lattice_id, &actor_ref, &provider_ref).await,
+            actor_ref,
+            provider_ref,
+            "contract".to_string(),
+            None,
+            lattice_id.clone(),
+            "model".to_string(),
+            Some(values),
+            TestLatticeSource {
+                links: vec![linkdef],
+                ..Default::default()
+            },
+        );
+
+        let commands = scaler.reconcile().await.expect("Couldn't reconcile");
+        assert_eq!(commands.len(), 2);
+        assert!(matches!(commands[0], Command::DeleteLinkdef(_)));
+        assert!(matches!(commands[1], Command::PutLinkdef(_)));
+    }
+
+    #[tokio::test]
+    async fn test_existing_linkdef() {
+        let lattice_id = "existing-linkdef".to_string();
+        let actor_ref = "actor_ref".to_string();
+        let provider_ref = "provider_ref".to_string();
+
+        let values = HashMap::from([("foo".to_string(), "bar".to_string())]);
+        let mut linkdef = LinkDefinition::default();
+        linkdef.actor_id = "actor".to_string();
+        linkdef.provider_id = "provider".to_string();
+        linkdef.contract_id = "contract".to_string();
+        linkdef.link_name = "default".to_string();
+        linkdef.values = values.clone();
+
+        let scaler = LinkScaler::new(
+            create_store(&lattice_id, &actor_ref, &provider_ref).await,
+            actor_ref,
+            provider_ref,
+            "contract".to_string(),
+            None,
+            lattice_id.clone(),
+            "model".to_string(),
+            Some(values),
+            TestLatticeSource {
+                links: vec![linkdef],
+                ..Default::default()
+            },
+        );
+
+        let commands = scaler.reconcile().await.expect("Couldn't reconcile");
+        assert_eq!(
+            commands.len(),
+            0,
+            "Scaler shouldn't have returned any commands"
+        );
     }
 }

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -121,10 +121,6 @@ impl<S: ReadStore + Send + Sync> Scaler for LinkScaler<S> {
             Ok(Vec::new())
         }
     }
-
-    async fn backoff(&self, notifier: Sender<String>) {
-        let _ = notifier.send(String::with_capacity(0)).await;
-    }
 }
 
 impl<S: ReadStore + Send + Sync> LinkScaler<S> {

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tokio::sync::{mpsc::Sender, OnceCell};
+use tokio::sync::OnceCell;
 use tracing::{instrument, trace};
 
 use crate::{

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -54,7 +54,7 @@ impl<S: ReadStore + Send + Sync> Scaler for LinkScaler<S> {
         match event {
             // We can only publish links once we know actor and provider IDs,
             // so we should pay attention to the Started events if we don't know them yet
-            Event::ActorStarted(actor_started)
+            Event::ActorsStarted(actor_started)
                 if !self.actor_id.initialized()
                     && actor_started.image_ref == self.config.actor_reference =>
             {

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -61,7 +61,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
 
     #[instrument(level = "trace", skip(self))]
     async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
-        //TODO: race condition, first actorstarted can come in before the rwlock updated?
         // NOTE(brooksmtownsend): We could be more efficient here and instead of running
         // the entire reconcile, smart compute exactly what needs to change, but it just
         // requires more code branches and would be fine as a future improvement

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -352,7 +352,6 @@ mod test {
         collections::{BTreeMap, HashMap, HashSet},
         sync::Arc,
     };
-    use tokio::sync::RwLock;
 
     use crate::{
         commands::{Command, StartActor},
@@ -1034,17 +1033,20 @@ mod test {
 
         let store = Arc::new(TestStore::default());
 
-        let lattice_source = TestLatticeSource {
-            claims: HashMap::default(),
-            inventory: Arc::new(RwLock::new(HashMap::default())),
-        };
+        let lattice_source = TestLatticeSource::default();
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
-            lattice_source,
+            lattice_source.clone(),
             command_publisher.clone(),
-            ScalerManager::test_new(NoopPublisher, lattice_id, store.clone(), command_publisher)
-                .await,
+            ScalerManager::test_new(
+                NoopPublisher,
+                lattice_id,
+                store.clone(),
+                command_publisher,
+                lattice_source,
+            )
+            .await,
         );
         let blobby_spread_property = SpreadScalerProperty {
             replicas: 9,

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -1,13 +1,9 @@
-use std::{cmp::Ordering, collections::HashMap, sync::Arc, time::Duration};
+use std::{cmp::Ordering, collections::HashMap};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
-use tokio::sync::mpsc::Sender;
-use tokio::sync::{OnceCell, RwLock};
-use tokio::time::Instant;
-use tracing::{debug, error, instrument, trace, warn, Instrument};
+use tokio::sync::OnceCell;
+use tracing::{instrument, trace, warn};
 
 use crate::events::HostHeartbeat;
 use crate::{
@@ -25,7 +21,6 @@ pub mod provider;
 // Annotation constants
 const SCALER_VALUE: &str = "spreadscaler";
 const SPREAD_KEY: &str = "wasmcloud.dev/spread_name";
-const BACKOFF_TIME: Duration = Duration::from_secs(30);
 
 /// Config for an ActorSpreadScaler
 #[derive(Clone)]

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -216,11 +216,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
 
         cleanerupper.reconcile().await
     }
-
-    #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name))]
-    async fn backoff(&self, notifier: Sender<std::string::String>) {
-        let _ = notifier.send(String::with_capacity(0)).await;
-    }
 }
 
 impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::HashMap};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tokio::sync::{mpsc::Sender, OnceCell};
+use tokio::sync::OnceCell;
 use tracing::{instrument, trace};
 
 use crate::{

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -16,6 +16,8 @@ use crate::{
     storage::{Host, Provider, ReadStore},
 };
 
+pub const PROVIDER_SPREAD_SCALER_TYPE: &str = "providerspreadscaler";
+
 /// Config for a ProviderSpreadConfig
 #[derive(Clone)]
 pub struct ProviderSpreadConfig {
@@ -47,11 +49,16 @@ pub struct ProviderSpreadScaler<S: ReadStore + Send + Sync> {
     spread_requirements: Vec<(Spread, usize)>,
     /// Provider ID, stored in a OnceCell to facilitate more efficient fetches
     provider_id: OnceCell<String>,
+    id: String,
 }
 
 #[async_trait]
 impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
-    #[instrument(level = "debug", skip_all)]
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    #[instrument(level = "debug", skip_all, fields(scaler_id = %self.id))]
     async fn update_config(&mut self, config: TraitProperty) -> Result<Vec<Command>> {
         let spread_config = match config {
             TraitProperty::SpreadScaler(prop) => prop,
@@ -62,7 +69,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
         self.reconcile().await
     }
 
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "debug", skip_all, fields(scaler_id = %self.id))]
     async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
         // NOTE(brooksmtownsend): We could be more efficient here and instead of running
         // the entire reconcile, smart compute exactly what needs to change, but it just
@@ -100,7 +107,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
         }
     }
 
-    #[instrument(level = "debug", skip_all, fields(provider_ref = %self.config.provider_reference, link_name = %self.config.provider_link_name))]
+    #[instrument(level = "debug", skip_all, fields(provider_ref = %self.config.provider_reference, link_name = %self.config.provider_link_name, scaler_id = %self.id))]
     async fn reconcile(&self) -> Result<Vec<Command>> {
         let hosts = self.store.list::<Host>(&self.config.lattice_id).await?;
         // Defaulting to empty String is ok here, since it's only going to happen if this provider has never
@@ -127,7 +134,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
                                 annotations: HashMap::default(),
                             })
                             .map(|provider| {
-                                spreadscaler_annotations(&spread.name).iter().all(|(k, v)| {
+                                spreadscaler_annotations(&spread.name, &self.id).iter().all(|(k, v)| {
                                     let has_annotation = provider
                                         .annotations
                                         .get(k)
@@ -159,7 +166,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
                                     link_name: Some(self.config.provider_link_name.to_owned()),
                                     contract_id: self.config.provider_contract_id.to_owned(),
                                     model_name: self.config.model_name.to_owned(),
-                                    annotations: spreadscaler_annotations(&spread.name),
+                                    annotations: spreadscaler_annotations(&spread.name, &self.id),
                                 })
                             })
                             .take(num_to_stop)
@@ -189,7 +196,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
                                     host_id: host.id.to_string(),
                                     link_name: Some(link_name.to_owned()),
                                     model_name: self.config.model_name.to_owned(),
-                                    annotations: spreadscaler_annotations(&spread.name),
+                                    annotations: spreadscaler_annotations(&spread.name, &self.id),
                                     config: self.config.provider_config.clone(),
                                 })
                             })
@@ -212,6 +219,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
             config: config_clone,
             spread_requirements,
             provider_id: self.provider_id.clone(),
+            id: self.id.clone(),
         };
 
         cleanerupper.reconcile().await
@@ -220,12 +228,17 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
 
 impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
     /// Construct a new ProviderSpreadScaler with specified configuration values
-    pub fn new(store: S, config: ProviderSpreadConfig) -> Self {
+    pub fn new(store: S, config: ProviderSpreadConfig, component_name: &str) -> Self {
+        let id = format!(
+            "{PROVIDER_SPREAD_SCALER_TYPE}-{}-{component_name}-{}-{}",
+            config.model_name, config.provider_link_name, config.provider_reference
+        );
         Self {
             store,
             spread_requirements: compute_spread(&config.spread_config),
             provider_id: OnceCell::new(),
             config,
+            id,
         }
     }
 
@@ -382,6 +395,7 @@ mod test {
                 model_name: MODEL_NAME.to_string(),
                 provider_config: Some(CapabilityConfig::Opaque("foobar".to_string())),
             },
+            "fake_component",
         );
 
         let commands = spreadscaler.reconcile().await?;
@@ -398,13 +412,16 @@ mod test {
                         host_id: host_id_one.to_string(),
                         link_name: Some(DEFAULT_LINK_NAME.to_string()),
                         model_name: MODEL_NAME.to_string(),
-                        annotations: spreadscaler_annotations("SimpleOne"),
+                        annotations: spreadscaler_annotations("SimpleOne", spreadscaler.id()),
                         config: Some(CapabilityConfig::Opaque("foobar".to_string())),
                     }
                 );
                 // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
                 // correct ones
-                assert_eq!(start.annotations, spreadscaler_annotations("SimpleOne"))
+                assert_eq!(
+                    start.annotations,
+                    spreadscaler_annotations("SimpleOne", spreadscaler.id())
+                )
             }
             Some(_other) => panic!("command should have been a start provider"),
         }
@@ -420,13 +437,16 @@ mod test {
                         host_id: host_id_two.to_string(),
                         link_name: Some(DEFAULT_LINK_NAME.to_string()),
                         model_name: MODEL_NAME.to_string(),
-                        annotations: spreadscaler_annotations("SimpleTwo"),
+                        annotations: spreadscaler_annotations("SimpleTwo", spreadscaler.id()),
                         config: Some(CapabilityConfig::Opaque("foobar".to_string())),
                     }
                 );
                 // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
                 // correct ones
-                assert_eq!(start.annotations, spreadscaler_annotations("SimpleTwo"))
+                assert_eq!(
+                    start.annotations,
+                    spreadscaler_annotations("SimpleTwo", spreadscaler.id())
+                )
             }
             Some(_other) => panic!("command should have been a start provider"),
         }
@@ -487,6 +507,7 @@ mod test {
                 model_name: MODEL_NAME.to_string(),
                 provider_config: None,
             },
+            "fake_component",
         );
 
         store
@@ -505,7 +526,7 @@ mod test {
                         contract_id: "prov:ider".to_string(),
                         link_name: DEFAULT_LINK_NAME.to_string(),
                         public_key: provider_id.to_string(),
-                        annotations: spreadscaler_annotations("ComplexOne"),
+                        annotations: spreadscaler_annotations("ComplexOne", spreadscaler.id()),
                     }]),
                     uptime_seconds: 123,
                     version: None,
@@ -571,7 +592,7 @@ mod test {
                         contract_id: "prov:ider".to_string(),
                         link_name: DEFAULT_LINK_NAME.to_string(),
                         public_key: provider_id.to_string(),
-                        annotations: spreadscaler_annotations("ComplexOne"),
+                        annotations: spreadscaler_annotations("ComplexOne", spreadscaler.id()),
                     }]),
                     uptime_seconds: 123,
                     version: None,
@@ -630,7 +651,7 @@ mod test {
                         link_name: Some(DEFAULT_LINK_NAME.to_string()),
                         contract_id: "prov:ider".to_string(),
                         model_name: MODEL_NAME.to_string(),
-                        annotations: spreadscaler_annotations("ComplexOne")
+                        annotations: spreadscaler_annotations("ComplexOne", spreadscaler.id())
                     }
                 );
             }
@@ -643,12 +664,15 @@ mod test {
                         link_name: Some(DEFAULT_LINK_NAME.to_string()),
                         contract_id: "prov:ider".to_string(),
                         model_name: MODEL_NAME.to_string(),
-                        annotations: spreadscaler_annotations("ComplexOne")
+                        annotations: spreadscaler_annotations("ComplexOne", spreadscaler.id())
                     }
                 );
                 // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
                 // correct ones
-                assert_eq!(stop.annotations, spreadscaler_annotations("ComplexOne"))
+                assert_eq!(
+                    stop.annotations,
+                    spreadscaler_annotations("ComplexOne", spreadscaler.id())
+                )
             }
             (_, _) => panic!("command should have been a stop provider"),
         }
@@ -663,13 +687,16 @@ mod test {
                         host_id: host_id_two.to_string(),
                         link_name: Some(DEFAULT_LINK_NAME.to_string()),
                         model_name: MODEL_NAME.to_string(),
-                        annotations: spreadscaler_annotations("ComplexTwo"),
+                        annotations: spreadscaler_annotations("ComplexTwo", spreadscaler.id()),
                         config: None,
                     }
                 );
                 // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
                 // correct ones
-                assert_eq!(start.annotations, spreadscaler_annotations("ComplexTwo"))
+                assert_eq!(
+                    start.annotations,
+                    spreadscaler_annotations("ComplexTwo", spreadscaler.id())
+                )
             }
             Some(_other) => panic!("command should have been a start provider"),
         }
@@ -684,13 +711,16 @@ mod test {
                         host_id: host_id_three.to_string(),
                         link_name: Some(DEFAULT_LINK_NAME.to_string()),
                         model_name: MODEL_NAME.to_string(),
-                        annotations: spreadscaler_annotations("ComplexTwo"),
+                        annotations: spreadscaler_annotations("ComplexTwo", spreadscaler.id()),
                         config: None,
                     }
                 );
                 // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
                 // correct ones
-                assert_eq!(start.annotations, spreadscaler_annotations("ComplexTwo"))
+                assert_eq!(
+                    start.annotations,
+                    spreadscaler_annotations("ComplexTwo", spreadscaler.id())
+                )
             }
             Some(_other) => panic!("command should have been a start provider"),
         }

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -8,7 +8,9 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use super::StateKind;
-use crate::events::{ActorStarted, HostHeartbeat, HostStarted, ProviderInfo, ProviderStarted};
+use crate::events::{
+    ActorStarted, ActorsStarted, HostHeartbeat, HostStarted, ProviderInfo, ProviderStarted,
+};
 
 /// A wasmCloud Capability provider
 // NOTE: We probably aren't going to use this _right now_ so we've kept it pretty minimal. But it is
@@ -194,6 +196,34 @@ impl From<ActorStarted> for Actor {
 
 impl From<&ActorStarted> for Actor {
     fn from(value: &ActorStarted) -> Self {
+        Actor {
+            id: value.public_key.clone(),
+            name: value.claims.name.clone(),
+            capabilities: value.claims.capabilites.clone(),
+            issuer: value.claims.issuer.clone(),
+            call_alias: value.claims.call_alias.clone(),
+            reference: value.image_ref.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<ActorsStarted> for Actor {
+    fn from(value: ActorsStarted) -> Self {
+        Actor {
+            id: value.public_key,
+            name: value.claims.name,
+            capabilities: value.claims.capabilites,
+            issuer: value.claims.issuer,
+            call_alias: value.claims.call_alias,
+            reference: value.image_ref,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<&ActorsStarted> for Actor {
+    fn from(value: &ActorsStarted) -> Self {
         Actor {
             id: value.public_key.clone(),
             name: value.claims.name.clone(),

--- a/src/workers/command.rs
+++ b/src/workers/command.rs
@@ -10,13 +10,6 @@ use crate::{
     APP_SPEC_ANNOTATION,
 };
 
-lazy_static::lazy_static! {
-    static ref MANAGED_BY_ANNOTATIONS: HashMap<String, String> =
-        HashMap::from(
-            [(crate::MANAGED_BY_ANNOTATION.to_owned(), crate::MANAGED_BY_IDENTIFIER.to_owned())]
-        );
-}
-
 /// A worker implementation for handling incoming commands
 #[derive(Clone)]
 pub struct CommandWorker {
@@ -39,8 +32,7 @@ impl Worker for CommandWorker {
             Command::StartActor(actor) => {
                 // Order here is intentional to prevent scalers from overwriting managed annotations
                 let mut annotations = actor.annotations.clone();
-                annotations.extend(MANAGED_BY_ANNOTATIONS.clone());
-                annotations.insert(APP_SPEC_ANNOTATION.to_owned(), actor.model_name.clone());
+                insert_managed_annotations(&mut annotations, &actor.model_name);
                 self.client
                     .start_actor(
                         &actor.host_id,
@@ -53,8 +45,7 @@ impl Worker for CommandWorker {
             Command::StopActor(actor) => {
                 // Order here is intentional to prevent scalers from overwriting managed annotations
                 let mut annotations = actor.annotations.clone();
-                annotations.extend(MANAGED_BY_ANNOTATIONS.clone());
-                annotations.insert(APP_SPEC_ANNOTATION.to_owned(), actor.model_name.clone());
+                insert_managed_annotations(&mut annotations, &actor.model_name);
                 self.client
                     .stop_actor(
                         &actor.host_id,
@@ -67,8 +58,7 @@ impl Worker for CommandWorker {
             Command::StartProvider(prov) => {
                 // Order here is intentional to prevent scalers from overwriting managed annotations
                 let mut annotations = prov.annotations.clone();
-                annotations.extend(MANAGED_BY_ANNOTATIONS.clone());
-                annotations.insert(APP_SPEC_ANNOTATION.to_owned(), prov.model_name.clone());
+                insert_managed_annotations(&mut annotations, &prov.model_name);
                 let config = prov.config.clone().map(|conf| match conf {
                     // NOTE: We validate the serialization when we store the model so this should be
                     // safe to unwrap
@@ -90,8 +80,7 @@ impl Worker for CommandWorker {
             Command::StopProvider(prov) => {
                 // Order here is intentional to prevent scalers from overwriting managed annotations
                 let mut annotations = prov.annotations.clone();
-                annotations.extend(MANAGED_BY_ANNOTATIONS.clone());
-                annotations.insert(APP_SPEC_ANNOTATION.to_owned(), prov.model_name.clone());
+                insert_managed_annotations(&mut annotations, &prov.model_name);
                 self.client
                     .stop_provider(
                         &prov.host_id,
@@ -131,4 +120,15 @@ impl Worker for CommandWorker {
         }
         message.ack().await.map_err(WorkError::from)
     }
+}
+
+/// Inserts managed annotations to the given `annotations` HashMap.
+pub fn insert_managed_annotations(annotations: &mut HashMap<String, String>, model_name: &str) {
+    annotations.extend([
+        (
+            crate::MANAGED_BY_ANNOTATION.to_owned(),
+            crate::MANAGED_BY_IDENTIFIER.to_owned(),
+        ),
+        (APP_SPEC_ANNOTATION.to_owned(), model_name.to_owned()),
+    ])
 }

--- a/src/workers/command.rs
+++ b/src/workers/command.rs
@@ -5,7 +5,6 @@ use crate::{
         ScopedMessage,
     },
     model::CapabilityConfig,
-    APP_SPEC_ANNOTATION,
 };
 
 use super::insert_managed_annotations;

--- a/src/workers/command.rs
+++ b/src/workers/command.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{
     commands::*,
     consumers::{
@@ -9,6 +7,8 @@ use crate::{
     model::CapabilityConfig,
     APP_SPEC_ANNOTATION,
 };
+
+use super::insert_managed_annotations;
 
 /// A worker implementation for handling incoming commands
 #[derive(Clone)]
@@ -120,15 +120,4 @@ impl Worker for CommandWorker {
         }
         message.ack().await.map_err(WorkError::from)
     }
-}
-
-/// Inserts managed annotations to the given `annotations` HashMap.
-pub fn insert_managed_annotations(annotations: &mut HashMap<String, String>, model_name: &str) {
-    annotations.extend([
-        (
-            crate::MANAGED_BY_ANNOTATION.to_owned(),
-            crate::MANAGED_BY_IDENTIFIER.to_owned(),
-        ),
-        (APP_SPEC_ANNOTATION.to_owned(), model_name.to_owned()),
-    ])
 }

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -687,8 +687,6 @@ where
             .collect::<Result<Vec<Vec<Command>>, anyhow::Error>>()
             .map(|all| all.into_iter().flatten().collect::<Vec<Command>>())?;
 
-        println!("Commands: {:?}", commands);
-
         trace!(?commands, "Handling commands");
 
         // Now handle the result from reconciliation
@@ -755,7 +753,6 @@ where
     #[instrument(level = "debug", skip(self))]
     async fn do_work(&self, mut message: ScopedMessage<Self::Message>) -> WorkResult<()> {
         // Everything in this block returns a name hint for the success case and an error otherwise
-        println!("Message: {:?}", message);
         let res = match message.as_ref() {
             // NOTE(brooksmtownsend): For now, the plural events trigger scaler runs but do
             // not modify state. Ideally we'd use this to update the state of the lattice instead of the

--- a/src/workers/event_helpers.rs
+++ b/src/workers/event_helpers.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use tracing::{instrument, warn};
+use wasmbus_rpc::core::LinkDefinition;
 use wasmcloud_control_interface::HostInventory;
 
 use crate::{commands::Command, publisher::Publisher, APP_SPEC_ANNOTATION};
@@ -30,6 +31,15 @@ pub trait ClaimsSource {
 #[async_trait::async_trait]
 pub trait InventorySource {
     async fn get_inventory(&self, host_id: &str) -> anyhow::Result<HostInventory>;
+}
+
+/// A trait for anything that can fetch the links in a lattice
+///
+/// NOTE: This trait right now exists as a convenience for testing. It isn't ideal to have this just
+/// due to testing, but it does allow us to abstract away the concrete type of the client
+#[async_trait::async_trait]
+pub trait LinkSource {
+    async fn get_links(&self) -> anyhow::Result<Vec<LinkDefinition>>;
 }
 
 #[async_trait::async_trait]
@@ -69,6 +79,20 @@ impl InventorySource for wasmcloud_control_interface::Client {
             .get_host_inventory(host_id)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?)
+    }
+}
+
+// NOTE(thomastaylor312): A future improvement here that would make things more efficient is if this
+// was just a cache of the links. On startup, it could fetch once, and then it could subscribe to
+// the KV store for updates. This would allow us to not have to fetch every time we need to get
+// links
+#[async_trait::async_trait]
+impl LinkSource for wasmcloud_control_interface::Client {
+    async fn get_links(&self) -> anyhow::Result<Vec<LinkDefinition>> {
+        self.query_links()
+            .await
+            .map(|resp| resp.links)
+            .map_err(|e| anyhow::anyhow!("{e:?}"))
     }
 }
 

--- a/src/workers/event_helpers.rs
+++ b/src/workers/event_helpers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use tracing::{instrument, warn};
 use wasmcloud_control_interface::HostInventory;
 
-use crate::{commands::Command, publisher::Publisher};
+use crate::{commands::Command, publisher::Publisher, APP_SPEC_ANNOTATION};
 
 /// A subset of needed claims to help populate state
 #[derive(Debug, Clone)]
@@ -112,4 +112,15 @@ impl<Pub: Publisher> CommandPublisher<Pub> {
         .into_iter()
         .collect::<anyhow::Result<()>>()
     }
+}
+
+/// Inserts managed annotations to the given `annotations` HashMap.
+pub fn insert_managed_annotations(annotations: &mut HashMap<String, String>, model_name: &str) {
+    annotations.extend([
+        (
+            crate::MANAGED_BY_ANNOTATION.to_owned(),
+            crate::MANAGED_BY_IDENTIFIER.to_owned(),
+        ),
+        (APP_SPEC_ANNOTATION.to_owned(), model_name.to_owned()),
+    ])
 }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -6,6 +6,6 @@ mod command;
 mod event;
 mod event_helpers;
 
-pub use command::CommandWorker;
+pub use command::{insert_managed_annotations, CommandWorker};
 pub use event::EventWorker;
 pub use event_helpers::*;

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -6,6 +6,6 @@ mod command;
 mod event;
 mod event_helpers;
 
-pub use command::{insert_managed_annotations, CommandWorker};
+pub use command::CommandWorker;
 pub use event::EventWorker;
 pub use event_helpers::*;

--- a/test/docker-compose-e2e.yaml
+++ b/test/docker-compose-e2e.yaml
@@ -6,7 +6,7 @@ services:
      - 4222:4222
   # Have hosts in 3 different "regions"
   wasmcloud_east:
-    image: wasmcloud/wasmcloud_host:0.62.1
+    image: wasmcloud/wasmcloud_host:0.63.1
     depends_on: 
       - nats
     deploy:
@@ -20,7 +20,7 @@ services:
       WASMCLOUD_CLUSTER_SEED: SCAOGJWX53TGI4233T6GAXWYWBIB5ZDGPTCO6ODJQYELS52YCQCBQSRPA4
       HOST_region: us-brooks-east
   wasmcloud_west:
-    image: wasmcloud/wasmcloud_host:0.62.1
+    image: wasmcloud/wasmcloud_host:0.63.1
     depends_on: 
       - nats
     deploy:
@@ -34,7 +34,7 @@ services:
       WASMCLOUD_CLUSTER_SEED: SCAOGJWX53TGI4233T6GAXWYWBIB5ZDGPTCO6ODJQYELS52YCQCBQSRPA4
       HOST_region: us-taylor-west
   wasmcloud_moon:
-    image: wasmcloud/wasmcloud_host:0.62.1
+    image: wasmcloud/wasmcloud_host:0.63.1
     depends_on: 
       - nats
     deploy:

--- a/test/docker-compose-e2e.yaml
+++ b/test/docker-compose-e2e.yaml
@@ -37,6 +37,8 @@ services:
     image: wasmcloud/wasmcloud_host:0.63.1
     depends_on: 
       - nats
+    ports:
+     - 4000:4000
     deploy:
       replicas: 1
     environment:

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -57,8 +57,39 @@ impl ClientInfo {
         if !status.success() {
             panic!("Docker compose up didn't exit successfully")
         }
+
         let repo_root =
             PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Unable to find repo root"));
+        // Create the logging directory
+        let log_dir = repo_root.join(LOG_DIR);
+        tokio::fs::create_dir_all(&log_dir)
+            .await
+            .expect("Unable to create log dir");
+
+        let mut commands = Vec::with_capacity(4);
+
+        // Start a process for capturing docker logs
+        let log_path = log_dir.join("docker-compose");
+        let file = tokio::fs::File::create(log_path)
+            .await
+            .expect("Unable to create log file")
+            .into_std()
+            .await;
+        let child = Command::new("docker")
+            .args([
+                "compose",
+                "-f",
+                compose_file.as_ref().to_str().unwrap(),
+                "logs",
+                "--follow",
+            ])
+            .stdout(file)
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("Unable to spawn wadm binary");
+        commands.push(child);
+
         // Wait for hosts to start
         let client = async_nats::connect("127.0.0.1:4222")
             .await
@@ -105,12 +136,6 @@ impl ClientInfo {
             )
         }
 
-        // Create the logging directory
-        let log_dir = repo_root.join(LOG_DIR);
-        tokio::fs::create_dir_all(&log_dir)
-            .await
-            .expect("Unable to create log dir");
-        let mut commands = Vec::with_capacity(3);
         for i in 0..3 {
             let log_path = log_dir.join(format!("wadm-{i}"));
             let file = tokio::fs::File::create(log_path)

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -122,7 +122,10 @@ impl ClientInfo {
                 .stderr(file)
                 .stdout(Stdio::null())
                 .kill_on_drop(true)
-                .env("RUST_LOG", "info,wadm=debug,wadm::scaler=trace")
+                .env(
+                    "RUST_LOG",
+                    "info,wadm=debug,wadm::scaler=trace,wadm::workers::event=trace",
+                )
                 .spawn()
                 .expect("Unable to spawn wadm binary");
             commands.push(child);


### PR DESCRIPTION
There's one or two more TODOs that I've outlined below, but I'm marking as ready for review to get some input around the rest of the methodology. 

This PR:
- [x] Adds support for ActorsStarted / ActorsStopped and their failure events
- [x] Implicitly requires `wadm` to work with v0.63+ versions of the host because of the above
- [x] Removes the notion of a backoff, replacing it with logic to make Scalers compute "expected events" for each command that they send. For example, if a scaler wants to start 5 of an actor, it won't take any action until it either receives an event where 5 of that actor started, or if that command failed to complete. Scaler implementers do not need to care about this, it's all on the `wadm` side.
- [x] TODO: Make the expected events list clear after a certain time frame to account for missed events or strange edge cases.

## Feature or Problem
Currently, Scalers (particularly the ActorSpreadScaler) are prone to jitter and difficulty actually converging on proper state when you run many (10+) copies of an actor. They are handling each event as it comes in, and we added a very coarse backoff mechanism to account for this but it still creates difficulties.

## Related Issues
Will file issue soon to make state only update on plural events.

## Release Information
next alpha release

## Consumer Impact
Consumers will notice that wadm feels more responsive at reconciling

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
This feature is large enough that it probably warrants some tests to verify behavior around expected events.

- [ ] TODO: Tests

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I've applied applications and messed with them in many ways to confirm that this works great with 1 running wadm.
