### PR TITLE
ref(server): Refactors storage for manifests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 test-e2e::
 ifeq ($(shell nc -czt -w1 127.0.0.1 4222 || echo fail),fail)
 	@$(MAKE) build
-	$(CARGO) test --test e2e_multiple_hosts --features _e2e_tests --  --nocapture 
+	RUST_BACKTRACE=1 $(CARGO) test --test e2e_multiple_hosts --features _e2e_tests --  --nocapture 
 else
 	@echo "WARN: Not running e2e tests. NATS must not be currently running"
 	exit 1

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ production-ready `0.4` version.
 **Heads Up**
 
 Wadm is still in alpha as we continue to tie up a few loose ends. Below is a list of known
-issues/missing features to be aware of:
+issues/missing features to be aware of that we plan on addressing by the time we hit `0.4`:
 
-- Currently the API does not update with the status of each scaler and reconcile action
 - The current scaling algorithm is a bit jittery and puts the "eventual" in eventual consistency. It
   will get to the right number of replicas, but may take a second. We've already identified a fix,
   but it is in the the wasmCloud host, so we'll need to update things there first
@@ -176,6 +175,24 @@ a single lattice. Proceed with caution while we do further testing.
 Interacting with **wadm** is done over NATS on the root topic `wadm.api.{prefix}` where `prefix` is
 the lattice namespace prefix. For more information on this API, please consult the [wadm
 Reference](https://wasmcloud.dev/reference/wadm).
+
+## Known Issues/Missing functionality
+
+As this is a new project there are some things we know are missing or buggy. A non-exhaustive list
+of these can be found below:
+
+- Currently the API does not update with the status of each scaler and reconcile action
+- It is _technically_ possible as things stand right now for a race condition with manifests when a
+  manifest is updated/created and deleted simultaneously. In this case, one of the operations will
+  win and you will end up with a manifest that still exists after you delete it or a manifest that
+  does not exist after you create it. This is a very unlikely scenario as only one person or process
+  is interacting with a specific, but it is possible. If this becomes a problem for you, please let
+  us know and we will consider additional ways of how we can address it.
+- Manifest validation is not yet implemented. Right now wadm will accept the manifest blindly so
+  long as it can parse it. It will not validate that the model name is valid or if you specified
+  entirely invalid properties. This will be added in a future version.
+- Nondestructive (e.g. orphaning resources) undeploys are not currently implemented. You can set the
+  field in the request, but it won't do anything
 
 ## References
 

--- a/bin/observer.rs
+++ b/bin/observer.rs
@@ -12,27 +12,26 @@ use wadm::{
     events::{EventType, HostHeartbeat, HostStarted},
     mirror::Mirror,
     nats_utils::LatticeIdParser,
-    storage::{nats_kv::NatsKvStore, reaper::Reaper, ReadStore, Store},
+    storage::{nats_kv::NatsKvStore, reaper::Reaper, Store},
     DEFAULT_COMMANDS_TOPIC, DEFAULT_WADM_EVENTS_TOPIC,
 };
 
 use super::{CommandWorkerCreator, EventWorkerCreator};
 
-pub(crate) struct Observer<StateStore, ManifestStore> {
+pub(crate) struct Observer<StateStore> {
     pub(crate) parser: LatticeIdParser,
     pub(crate) command_manager: ConsumerManager<CommandConsumer>,
     pub(crate) event_manager: ConsumerManager<EventConsumer>,
     pub(crate) mirror: Mirror,
     pub(crate) client: async_nats::Client,
     pub(crate) reaper: Reaper<NatsKvStore>,
-    pub(crate) event_worker_creator: EventWorkerCreator<StateStore, ManifestStore>,
+    pub(crate) event_worker_creator: EventWorkerCreator<StateStore>,
     pub(crate) command_worker_creator: CommandWorkerCreator,
 }
 
-impl<StateStore, ManifestStore> Observer<StateStore, ManifestStore>
+impl<StateStore> Observer<StateStore>
 where
     StateStore: Store + Send + Sync + Clone + 'static,
-    ManifestStore: ReadStore + Send + Sync + Clone + 'static,
 {
     /// Watches the given topic (with wildcards) for wasmbus events. If it finds a lattice that it
     /// isn't managing, it will start managing it immediately

--- a/src/model/internal.rs
+++ b/src/model/internal.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::Manifest;
 use crate::server::ComponentStatus;
-use crate::storage::StateKind;
 
 use super::LATEST_VERSION;
 
@@ -22,10 +21,6 @@ pub(crate) struct StoredManifest {
     status: Vec<ComponentStatus>,
     // An optional top level status message to help with debugging or status for the whole manifest
     status_message: Option<String>,
-}
-
-impl StateKind for StoredManifest {
-    const KIND: &'static str = "manifest";
 }
 
 impl StoredManifest {
@@ -110,6 +105,11 @@ impl StoredManifest {
             .last()
             .map(|(_, v)| v)
             .expect("A manifest should always exist. This is programmer error")
+    }
+
+    /// Returns the name of the manifest
+    pub fn name(&self) -> &str {
+        &self.get_current().metadata.name
     }
 
     /// Gets a reference to the specified version of the manifest

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -1,0 +1,234 @@
+use std::collections::HashSet;
+
+use anyhow::Result;
+use async_nats::jetstream::kv::{Operation, Store};
+use tracing::{debug, instrument, trace};
+
+use crate::{model::internal::StoredManifest, server::StatusType};
+
+use super::ModelSummary;
+
+// TODO(thomastaylor312): Once async nats has concrete error types for KV, we should switch out
+// anyhow for concrete error types so we can indicate whether a failure was due to something like a
+// CAS failure or a network error
+
+/// Storage for models, with some logic around updating a list of all models in a lattice to make
+/// calls more efficient
+#[derive(Clone)]
+pub(crate) struct ModelStorage {
+    store: Store,
+}
+
+impl ModelStorage {
+    pub fn new(store: Store) -> ModelStorage {
+        Self { store }
+    }
+
+    /// Gets the stored data and its current revision for the given model, returning None if it
+    /// doesn't exist
+    // NOTE(thomastaylor312): The model name is an AsRef purely so we don't have to clone a bunch of
+    // things when fetching in the manager. If we expose this struct outside of the crate, we should
+    // either revert this to be `&str` or make it `AsRef<str>` everywhere
+    #[instrument(level = "debug", skip(self, model_name), fields(model_name = %model_name.as_ref()))]
+    pub async fn get(
+        &self,
+        lattice_id: &str,
+        model_name: impl AsRef<str>,
+    ) -> Result<Option<(StoredManifest, u64)>> {
+        let key = model_key(lattice_id, model_name.as_ref());
+        debug!(%key, "Fetching model from storage");
+        self.store
+            .entry(&key)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?
+            .and_then(|entry| {
+                // Skip any delete or purge operations
+                if matches!(entry.operation, Operation::Delete | Operation::Purge) {
+                    return None;
+                }
+
+                Some(
+                    serde_json::from_slice::<StoredManifest>(&entry.value)
+                        .map_err(anyhow::Error::from)
+                        .map(|m| (m, entry.revision)),
+                )
+            })
+            .transpose()
+    }
+
+    /// Updates the stored data with the given model, overwriting any existing data. The optional
+    /// `current_revision` parameter can be used to compare whether or not you're updating the model
+    /// with the latest revision
+    #[instrument(level = "debug", skip(self, model), fields(model_name = %model.name()))]
+    pub async fn set(
+        &self,
+        lattice_id: &str,
+        model: StoredManifest,
+        current_revision: Option<u64>,
+    ) -> Result<()> {
+        debug!("Storing model in storage");
+        // We need to store the model, then update the set. This is because if we update the set
+        // first and the model fails, it will look like the model exists when it actually doesn't
+        let key = model_key(lattice_id, model.name());
+        trace!(%key, "Storing manifest at key");
+        let data = serde_json::to_vec(&model).map_err(anyhow::Error::from)?;
+        if let Some(revision) = current_revision {
+            self.store.update(&key, data.into(), revision).await
+        } else {
+            self.store.put(&key, data.into()).await
+        }
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+        trace!("Adding model to set");
+        self.retry_model_update(lattice_id, ModelNameOperation::Add(model.name()))
+            .await
+    }
+
+    /// Fetches a summary of all models in the given lattice.
+    #[instrument(level = "debug", skip(self))]
+    pub async fn list(&self, lattice_id: &str) -> Result<Vec<ModelSummary>> {
+        debug!("Fetching list of models from storage");
+        let futs = self
+            .get_model_set(lattice_id)
+            .await?
+            .unwrap_or_default()
+            .0
+            .into_iter()
+            // We can't use filter map with futures, but we can use map and then flatten it below
+            .map(|model_name| {
+                async {
+                    let manifest = match self.get(lattice_id, &model_name).await {
+                        Ok(Some((manifest, _))) => manifest,
+                        Ok(None) => return None,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    Some(Ok(ModelSummary {
+                        name: model_name,
+                        version: manifest.current_version().to_owned(),
+                        description: manifest.get_current().description().map(|s| s.to_owned()),
+                        deployed_version: manifest.get_deployed().map(|m| m.version().to_owned()),
+                        // TODO(thomastaylor312): Actually fetch the status info from the stored
+                        // manifest once we figure it out
+                        status: StatusType::default(),
+                    }))
+                }
+            });
+
+        futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+
+    /// Deletes the given model from storage. This also removes the model from the list of all
+    /// models in the lattice
+    #[instrument(level = "debug", skip(self))]
+    pub async fn delete(&self, lattice_id: &str, model_name: &str) -> Result<()> {
+        debug!("Deleting model from storage");
+        // We need to delete from the set first, then delete the model itself. This is because if we
+        // delete the model but then cannot delete the item from the set, then we end up in a
+        // situation where we say it already exists when creating. If the model doesn't delete it is
+        // fine, because a set operation will overwrite it
+        self.retry_model_update(lattice_id, ModelNameOperation::Delete(model_name))
+            .await?;
+
+        let key = model_key(lattice_id, model_name);
+        trace!("Deleting model from storage");
+        self.store
+            .purge(&key)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))
+    }
+
+    /// Helper function that returns the list of models for the given lattice along with the current
+    /// revision for use in updating
+    async fn get_model_set(&self, lattice_id: &str) -> Result<Option<(HashSet<String>, u64)>> {
+        match self
+            .store
+            .entry(lattice_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?
+        {
+            Some(entry) if !matches!(entry.operation, Operation::Delete | Operation::Purge) => {
+                let models: HashSet<String> =
+                    serde_json::from_slice(&entry.value).map_err(anyhow::Error::from)?;
+                Ok(Some((models, entry.revision)))
+            }
+            Some(_) | None => Ok(None),
+        }
+    }
+
+    /// Convenience wrapper around retrying a key update
+    #[instrument(level = "debug", skip(self))]
+    async fn retry_model_update<'a>(
+        &self,
+        lattice_id: &str,
+        operation: ModelNameOperation<'a>,
+    ) -> Result<()> {
+        // Always retry 3 times for now. We can make this configurable later if we want
+        for i in 0..3 {
+            trace!("Fetching current models from storage");
+            let (mut model_list, current_revision) = match self.get_model_set(lattice_id).await? {
+                Some((models, revision)) => (models, revision),
+                None if matches!(operation, ModelNameOperation::Delete(_)) => {
+                    debug!("No models exist in storage for delete, returning early");
+                    return Ok(());
+                }
+                None => (HashSet::new(), 0),
+            };
+
+            match operation {
+                ModelNameOperation::Add(model_name) => {
+                    if !model_list.insert(model_name.to_owned()) {
+                        debug!("Model was already in list, returning early");
+                        return Ok(());
+                    }
+                }
+                ModelNameOperation::Delete(model_name) => {
+                    if !model_list.remove(model_name) {
+                        debug!("Model was not in list, returning early");
+                        return Ok(());
+                    }
+                }
+            }
+
+            match self
+                .store
+                .update(
+                    lattice_id,
+                    serde_json::to_vec(&model_list)
+                        .map_err(anyhow::Error::from)?
+                        .into(),
+                    current_revision,
+                )
+                .await
+            {
+                Ok(_) => return Ok(()),
+                // NOTE(thomastaylor312): This is brittle but will be replaced once the NATS client
+                // has a concrete error for KV stuff
+                Err(e) if e.to_string().contains("wrong last sequence") => {
+                    debug!(error = %e, attempt = i+1, "Model list update failed due to the underlying data changing, retrying");
+                    continue;
+                }
+                Err(e) => {
+                    // If it wasn't a wrong last sequence error, then we should bail
+                    anyhow::bail!("{e:?}")
+                }
+            }
+        }
+        Err(anyhow::anyhow!(
+            "Model list update failed due to conflicts after multiple retries"
+        ))
+    }
+}
+
+#[derive(Debug)]
+enum ModelNameOperation<'a> {
+    Add(&'a str),
+    Delete(&'a str),
+}
+
+fn model_key(lattice_id: &str, model_name: &str) -> String {
+    format!("{}-{}", lattice_id, model_name)
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -57,7 +57,7 @@ pub struct ModelSummary {
     pub name: String,
     pub version: String,
     pub description: Option<String>,
-    pub deployed: bool,
+    pub deployed_version: Option<String>,
     pub status: StatusType,
 }
 

--- a/test/data/all_hosts.yaml
+++ b/test/data/all_hosts.yaml
@@ -1,0 +1,58 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: echo-all-hosts
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.7
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 5
+          spread:
+            - name: eastcoast
+              requirements:
+                region: us-brooks-east
+              weight: 40
+            - name: westcoast
+              requirements:
+                zone: us-taylor-west
+              weight: 40
+            - name: the-moon
+              requirements:
+                zone: moon
+              weight: 20
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080
+
+    - name: httpserver
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 5
+          spread:
+            - name: eastcoast
+              requirements:
+                region: us-brooks-east
+              weight: 40
+            - name: westcoast
+              requirements:
+                zone: us-taylor-west
+              weight: 40
+            - name: the-moon
+              requirements:
+                zone: moon
+              weight: 20

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -6,7 +6,6 @@ use serde::de::DeserializeOwned;
 use wadm::{
     model::{Manifest, VERSION_ANNOTATION_KEY},
     server::*,
-    storage::nats_kv::NatsKvStore,
 };
 
 mod helpers;
@@ -87,7 +86,7 @@ async fn setup_server(id: String) -> TestServer {
 
     let prefix = format!("testing.{id}");
     let server = Server::new(
-        NatsKvStore::new(store),
+        store,
         client.clone(),
         Some(&id),
         ManifestNotifier::new(&prefix, client.clone()),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "_e2e_tests")]
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},

--- a/tests/e2e_multiple_hosts.rs
+++ b/tests/e2e_multiple_hosts.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "_e2e_tests")]
 use std::path::PathBuf;
 
 use futures::FutureExt;
@@ -33,7 +34,7 @@ async fn run_all_tests() {
     // The futures must be boxed or they're technically different types
     let tests = [
         test_no_requirements(&client_info).boxed(),
-        test_spread_all_hosts(&client_info).boxed(),
+        // test_spread_all_hosts(&client_info).boxed(),
     ];
     futures::future::join_all(tests).await;
 }
@@ -123,160 +124,160 @@ async fn test_no_requirements(client_info: &ClientInfo) {
     .await;
 }
 
-async fn test_spread_all_hosts(client_info: &ClientInfo) {
-    let resp = client_info
-        .put_manifest_from_file("all_hosts.yaml", None)
-        .await;
+// async fn test_spread_all_hosts(client_info: &ClientInfo) {
+//     let resp = client_info
+//         .put_manifest_from_file("all_hosts.yaml", None)
+//         .await;
 
-    assert_ne!(
-        resp.result,
-        PutResult::Error,
-        "Shouldn't have errored when creating manifest: {resp:?}"
-    );
+//     assert_ne!(
+//         resp.result,
+//         PutResult::Error,
+//         "Shouldn't have errored when creating manifest: {resp:?}"
+//     );
 
-    // Deploy manifest
-    let resp = client_info
-        .deploy_manifest("echo-all-hosts", None, None)
-        .await;
-    assert_ne!(
-        resp.result,
-        DeployResult::Error,
-        "Shouldn't have errored when deploying manifest: {resp:?}"
-    );
+//     // Deploy manifest
+//     let resp = client_info
+//         .deploy_manifest("echo-all-hosts", None, None)
+//         .await;
+//     assert_ne!(
+//         resp.result,
+//         DeployResult::Error,
+//         "Shouldn't have errored when deploying manifest: {resp:?}"
+//     );
 
-    assert_status(None, Some(5), || async {
-        let inventory = client_info.get_all_inventory().await;
+//     assert_status(None, Some(5), || async {
+//         let inventory = client_info.get_all_inventory().await?;
 
-        let all_echo_actors = inventory
-            .values()
-            .flat_map(|inv| &inv.actors)
-            .filter_map(|actor| {
-                (actor.image_ref.as_deref().unwrap_or_default()
-                    == "wasmcloud.azurecr.io/echo:0.3.7")
-                    .then_some(&actor.instances)
-            })
-            .flatten();
-        let actor_count = all_echo_actors
-            .filter(|actor| {
-                actor
-                    .annotations
-                    .as_ref()
-                    .and_then(|annotations| {
-                        annotations
-                            .get(APP_SPEC_ANNOTATION)
-                            .map(|val| val == "echo-all-hosts")
-                    })
-                    .unwrap_or(false)
-            })
-            .count();
-        if actor_count != 5 {
-            anyhow::bail!(
-                "Should have had 5 actors managed by wadm running, only found {actor_count}"
-            )
-        }
+//         let all_echo_actors = inventory
+//             .values()
+//             .flat_map(|inv| &inv.actors)
+//             .filter_map(|actor| {
+//                 (actor.image_ref.as_deref().unwrap_or_default()
+//                     == "wasmcloud.azurecr.io/echo:0.3.7")
+//                     .then_some(&actor.instances)
+//             })
+//             .flatten();
+//         let actor_count = all_echo_actors
+//             .filter(|actor| {
+//                 actor
+//                     .annotations
+//                     .as_ref()
+//                     .and_then(|annotations| {
+//                         annotations
+//                             .get(APP_SPEC_ANNOTATION)
+//                             .map(|val| val == "echo-all-hosts")
+//                     })
+//                     .unwrap_or(false)
+//             })
+//             .count();
+//         if actor_count != 5 {
+//             anyhow::bail!(
+//                 "Should have had 5 actors managed by wadm running, only found {actor_count}"
+//             )
+//         }
 
-        // Get count of providers matching annotation
-        let provider_count = inventory
-            .values()
-            .flat_map(|inv| &inv.providers)
-            .filter(|provider| {
-                // You can only have 1 provider per host and that could be created by any manifest,
-                // so we can just check the image ref and that it is managed by wadm
-                provider
-                    .image_ref
-                    .as_deref()
-                    .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
-                    .unwrap_or(false)
-                    && provider
-                        .annotations
-                        .as_ref()
-                        .and_then(|annotations| {
-                            annotations
-                                .get(MANAGED_BY_ANNOTATION)
-                                .map(|val| val == MANAGED_BY_IDENTIFIER)
-                        })
-                        .unwrap_or(false)
-            })
-            .count();
+//         // Get count of providers matching annotation
+//         let provider_count = inventory
+//             .values()
+//             .flat_map(|inv| &inv.providers)
+//             .filter(|provider| {
+//                 // You can only have 1 provider per host and that could be created by any manifest,
+//                 // so we can just check the image ref and that it is managed by wadm
+//                 provider
+//                     .image_ref
+//                     .as_deref()
+//                     .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
+//                     .unwrap_or(false)
+//                     && provider
+//                         .annotations
+//                         .as_ref()
+//                         .and_then(|annotations| {
+//                             annotations
+//                                 .get(MANAGED_BY_ANNOTATION)
+//                                 .map(|val| val == MANAGED_BY_IDENTIFIER)
+//                         })
+//                         .unwrap_or(false)
+//             })
+//             .count();
 
-        if provider_count != 5 {
-            anyhow::bail!(
-                "Should have had 5 providers managed by wadm running, found {provider_count}"
-            )
-        }
-        Ok(())
-    })
-    .await;
+//         if provider_count != 5 {
+//             anyhow::bail!(
+//                 "Should have had 5 providers managed by wadm running, found {provider_count}"
+//             )
+//         }
+//         Ok(())
+//     })
+//     .await;
 
-    // Undeploy manifest
-    let resp = client_info.undeploy_manifest("echo-all-hosts", None).await;
+//     // Undeploy manifest
+//     let resp = client_info.undeploy_manifest("echo-all-hosts", None).await;
 
-    assert_ne!(
-        resp.result,
-        DeployResult::Error,
-        "Shouldn't have errored when undeploying manifest: {resp:?}"
-    );
+//     assert_ne!(
+//         resp.result,
+//         DeployResult::Error,
+//         "Shouldn't have errored when undeploying manifest: {resp:?}"
+//     );
 
-    // assert that no actors or providers with annotations exist
-    assert_status(None, None, || async {
-        let inventory = client_info.get_all_inventory().await;
+//     // assert that no actors or providers with annotations exist
+//     assert_status(None, None, || async {
+//         let inventory = client_info.get_all_inventory().await?;
 
-        let all_echo_actors = inventory
-            .values()
-            .flat_map(|inv| &inv.actors)
-            .filter_map(|actor| {
-                (actor.image_ref.as_deref().unwrap_or_default()
-                    == "wasmcloud.azurecr.io/echo:0.3.7")
-                    .then_some(&actor.instances)
-            })
-            .flatten();
-        let actor_count = all_echo_actors
-            .filter(|actor| {
-                actor
-                    .annotations
-                    .as_ref()
-                    .and_then(|annotations| {
-                        annotations
-                            .get(APP_SPEC_ANNOTATION)
-                            .map(|val| val == "echo-all-hosts")
-                    })
-                    .unwrap_or(false)
-            })
-            .count();
-        if actor_count != 0 {
-            anyhow::bail!(
-                "Should have no actors belonging to this model running, found {actor_count}"
-            )
-        }
+//         let all_echo_actors = inventory
+//             .values()
+//             .flat_map(|inv| &inv.actors)
+//             .filter_map(|actor| {
+//                 (actor.image_ref.as_deref().unwrap_or_default()
+//                     == "wasmcloud.azurecr.io/echo:0.3.7")
+//                     .then_some(&actor.instances)
+//             })
+//             .flatten();
+//         let actor_count = all_echo_actors
+//             .filter(|actor| {
+//                 actor
+//                     .annotations
+//                     .as_ref()
+//                     .and_then(|annotations| {
+//                         annotations
+//                             .get(APP_SPEC_ANNOTATION)
+//                             .map(|val| val == "echo-all-hosts")
+//                     })
+//                     .unwrap_or(false)
+//             })
+//             .count();
+//         if actor_count != 0 {
+//             anyhow::bail!(
+//                 "Should have no actors belonging to this model running, found {actor_count}"
+//             )
+//         }
 
-        // Get count of providers matching annotation
-        let provider_count = inventory
-            .values()
-            .flat_map(|inv| &inv.providers)
-            .filter(|provider| {
-                provider
-                    .image_ref
-                    .as_deref()
-                    .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
-                    .unwrap_or(false)
-                    && provider
-                        .annotations
-                        .as_ref()
-                        .and_then(|annotations| {
-                            annotations
-                                .get(APP_SPEC_ANNOTATION)
-                                .map(|val| val == "echo-all-hosts")
-                        })
-                        .unwrap_or(false)
-            })
-            .count();
+//         // Get count of providers matching annotation
+//         let provider_count = inventory
+//             .values()
+//             .flat_map(|inv| &inv.providers)
+//             .filter(|provider| {
+//                 provider
+//                     .image_ref
+//                     .as_deref()
+//                     .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
+//                     .unwrap_or(false)
+//                     && provider
+//                         .annotations
+//                         .as_ref()
+//                         .and_then(|annotations| {
+//                             annotations
+//                                 .get(APP_SPEC_ANNOTATION)
+//                                 .map(|val| val == "echo-all-hosts")
+//                         })
+//                         .unwrap_or(false)
+//             })
+//             .count();
 
-        if provider_count != 0 {
-            anyhow::bail!(
-                "Should have no provider belonging to this model running, found {provider_count}"
-            )
-        }
-        Ok(())
-    })
-    .await;
-}
+//         if provider_count != 0 {
+//             anyhow::bail!(
+//                 "Should have no provider belonging to this model running, found {provider_count}"
+//             )
+//         }
+//         Ok(())
+//     })
+//     .await;
+// }

--- a/tests/e2e_multiple_hosts.rs
+++ b/tests/e2e_multiple_hosts.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
+use futures::FutureExt;
 use wadm::server::{DeployResult, PutResult};
-use wadm::APP_SPEC_ANNOTATION;
+use wadm::{APP_SPEC_ANNOTATION, MANAGED_BY_ANNOTATION, MANAGED_BY_IDENTIFIER};
 
 mod e2e;
 
@@ -29,7 +30,11 @@ async fn run_all_tests() {
     // about which test failed. Another issue is that only the first panic will be returned, so
     // capturing the backtraces and then printing them nicely would probably be good
 
-    let tests = [test_no_requirements(&client_info)];
+    // The futures must be boxed or they're technically different types
+    let tests = [
+        test_no_requirements(&client_info).boxed(),
+        test_spread_all_hosts(&client_info).boxed(),
+    ];
     futures::future::join_all(tests).await;
 }
 
@@ -41,14 +46,14 @@ async fn test_no_requirements(client_info: &ClientInfo) {
     assert_ne!(
         resp.result,
         PutResult::Error,
-        "Shouldn't have errored when creating manifest"
+        "Shouldn't have errored when creating manifest: {resp:?}"
     );
 
     let resp = client_info.deploy_manifest("echo-simple", None, None).await;
     assert_ne!(
         resp.result,
         DeployResult::Error,
-        "Shouldn't have errored when deploying manifest"
+        "Shouldn't have errored when deploying manifest: {resp:?}"
     );
 
     // NOTE: This runs for a while, but it's because we're waiting for the provider to download,
@@ -89,23 +94,186 @@ async fn test_no_requirements(client_info: &ClientInfo) {
             .values()
             .flat_map(|inv| &inv.providers)
             .filter(|provider| {
-                provider.image_ref.as_deref().unwrap_or_default()
-                    == "wasmcloud.azurecr.io/httpserver:0.17.0"
+                // You can only have 1 provider per host and that could be created by any manifest,
+                // so we can just check the image ref and that it is managed by wadm
+                provider
+                    .image_ref
+                    .as_deref()
+                    .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
+                    .unwrap_or(false)
+                    && provider
+                        .annotations
+                        .as_ref()
+                        .and_then(|annotations| {
+                            annotations
+                                .get(MANAGED_BY_ANNOTATION)
+                                .map(|val| val == MANAGED_BY_IDENTIFIER)
+                        })
+                        .unwrap_or(false)
+            })
+            .count();
+
+        if provider_count < 1 {
+            anyhow::bail!(
+                "Should have had at least 1 provider managed by wadm running, found {provider_count}"
+            )
+        }
+        Ok(())
+    })
+    .await;
+}
+
+async fn test_spread_all_hosts(client_info: &ClientInfo) {
+    let resp = client_info
+        .put_manifest_from_file("all_hosts.yaml", None)
+        .await;
+
+    assert_ne!(
+        resp.result,
+        PutResult::Error,
+        "Shouldn't have errored when creating manifest: {resp:?}"
+    );
+
+    // Deploy manifest
+    let resp = client_info
+        .deploy_manifest("echo-all-hosts", None, None)
+        .await;
+    assert_ne!(
+        resp.result,
+        DeployResult::Error,
+        "Shouldn't have errored when deploying manifest: {resp:?}"
+    );
+
+    assert_status(None, Some(5), || async {
+        let inventory = client_info.get_all_inventory().await;
+
+        let all_echo_actors = inventory
+            .values()
+            .flat_map(|inv| &inv.actors)
+            .filter_map(|actor| {
+                (actor.image_ref.as_deref().unwrap_or_default()
+                    == "wasmcloud.azurecr.io/echo:0.3.7")
+                    .then_some(&actor.instances)
+            })
+            .flatten();
+        let actor_count = all_echo_actors
+            .filter(|actor| {
+                actor
+                    .annotations
+                    .as_ref()
+                    .and_then(|annotations| {
+                        annotations
+                            .get(APP_SPEC_ANNOTATION)
+                            .map(|val| val == "echo-all-hosts")
+                    })
+                    .unwrap_or(false)
+            })
+            .count();
+        if actor_count != 5 {
+            anyhow::bail!(
+                "Should have had 5 actors managed by wadm running, only found {actor_count}"
+            )
+        }
+
+        // Get count of providers matching annotation
+        let provider_count = inventory
+            .values()
+            .flat_map(|inv| &inv.providers)
+            .filter(|provider| {
+                // You can only have 1 provider per host and that could be created by any manifest,
+                // so we can just check the image ref and that it is managed by wadm
+                provider
+                    .image_ref
+                    .as_deref()
+                    .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
+                    .unwrap_or(false)
+                    && provider
+                        .annotations
+                        .as_ref()
+                        .and_then(|annotations| {
+                            annotations
+                                .get(MANAGED_BY_ANNOTATION)
+                                .map(|val| val == MANAGED_BY_IDENTIFIER)
+                        })
+                        .unwrap_or(false)
+            })
+            .count();
+
+        if provider_count != 5 {
+            anyhow::bail!(
+                "Should have had 5 providers managed by wadm running, found {provider_count}"
+            )
+        }
+        Ok(())
+    })
+    .await;
+
+    // Undeploy manifest
+    let resp = client_info.undeploy_manifest("echo-all-hosts", None).await;
+
+    assert_ne!(
+        resp.result,
+        DeployResult::Error,
+        "Shouldn't have errored when undeploying manifest: {resp:?}"
+    );
+
+    // assert that no actors or providers with annotations exist
+    assert_status(None, None, || async {
+        let inventory = client_info.get_all_inventory().await;
+
+        let all_echo_actors = inventory
+            .values()
+            .flat_map(|inv| &inv.actors)
+            .filter_map(|actor| {
+                (actor.image_ref.as_deref().unwrap_or_default()
+                    == "wasmcloud.azurecr.io/echo:0.3.7")
+                    .then_some(&actor.instances)
+            })
+            .flatten();
+        let actor_count = all_echo_actors
+            .filter(|actor| {
+                actor
+                    .annotations
+                    .as_ref()
+                    .and_then(|annotations| {
+                        annotations
+                            .get(APP_SPEC_ANNOTATION)
+                            .map(|val| val == "echo-all-hosts")
+                    })
+                    .unwrap_or(false)
+            })
+            .count();
+        if actor_count != 0 {
+            anyhow::bail!(
+                "Should have no actors belonging to this model running, found {actor_count}"
+            )
+        }
+
+        // Get count of providers matching annotation
+        let provider_count = inventory
+            .values()
+            .flat_map(|inv| &inv.providers)
+            .filter(|provider| {
+                provider
+                    .image_ref
+                    .as_deref()
+                    .map(|image| image == "wasmcloud.azurecr.io/httpserver:0.17.0")
+                    .unwrap_or(false)
                     && provider
                         .annotations
                         .as_ref()
                         .and_then(|annotations| {
                             annotations
                                 .get(APP_SPEC_ANNOTATION)
-                                .map(|val| val == "echo-simple")
+                                .map(|val| val == "echo-all-hosts")
                         })
                         .unwrap_or(false)
             })
             .count();
 
-        if provider_count != 1 {
+        if provider_count != 0 {
             anyhow::bail!(
-                "Should have had 1 provider managed by wadm running, found {provider_count}"
+                "Should have no provider belonging to this model running, found {provider_count}"
             )
         }
         Ok(())

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -248,7 +248,7 @@ impl StreamWrapper {
             context
                 .create_stream(async_nats::jetstream::stream::Config {
                     name: id.to_owned(),
-                    description: Some("A stream that stores all events coming in on the wasmbus.evt topics in a cluster".to_string()),
+                    description: Some("A stream that stores all commands".to_string()),
                     num_replicas: 1,
                     retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
                     subjects: vec![topic.clone()],


### PR DESCRIPTION
This solved the problem where you could really only update one manifest at a time per lattice. Please note that this has some added e2e tests, but those are currently commented out as they are waiting on some of our other work for removing jitter from starting actors (which is landing in the new host version and in wadm fairly soon)