### PR TITLE
feat(*) support provider config json

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -223,9 +223,10 @@ pub struct StartProvider {
     pub link_name: Option<String>,
     /// The name of the model/manifest that generated this command
     pub model_name: String,
-    // TODO: Do we need to support config_json paths?
     /// Additional annotations to attach on this command
     pub annotations: HashMap<String, String>,
+    /// Optional provider configuration to pass to the provider
+    pub config_json: Option<String>,
 }
 
 from_impl!(StartProvider);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -117,6 +117,9 @@ pub struct CapabilityProperties {
     /// An optional link name to use for this capability
     #[serde(skip_serializing_if = "Option::is_none")]
     pub link_name: Option<String>,
+    /// Optional configuration for this capability provider
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -378,6 +381,7 @@ mod test {
                     image: "wasmcloud.azurecr.io/httpserver:0.13.1".to_string(),
                     contract: "wasmcloud:httpserver".to_string(),
                     link_name: Some("default".to_string()),
+                    config: None,
                 },
             },
             traits: None,
@@ -405,6 +409,7 @@ mod test {
                     image: "wasmcloud.azurecr.io/ledblinky:0.0.1".to_string(),
                     contract: "wasmcloud:blinkenlights".to_string(),
                     link_name: Some(crate::DEFAULT_LINK_NAME.to_owned()),
+                    config: None,
                 },
             },
             traits: Some(trait_vec),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -119,7 +119,7 @@ pub struct CapabilityProperties {
     pub link_name: Option<String>,
     /// Optional configuration for this capability provider
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub config: Option<HashMap<String, String>>,
+    pub config: Option<HashMap<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -540,6 +540,7 @@ pub(crate) fn components_to_scalers<S: ReadStore + Send + Sync + Clone + 'static
                                         props.image.to_owned(),
                                         props.contract.to_owned(),
                                         props.link_name.to_owned(),
+                                        props.config.to_owned(),
                                         lattice_id.to_owned(),
                                         name.to_owned(),
                                         p.to_owned(),
@@ -557,6 +558,7 @@ pub(crate) fn components_to_scalers<S: ReadStore + Send + Sync + Clone + 'static
                             props.image.to_owned(),
                             props.contract.to_owned(),
                             props.link_name.to_owned(),
+                            props.config.to_owned(),
                             lattice_id.to_owned(),
                             name.to_owned(),
                             SpreadScalerProperty {

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -29,7 +29,7 @@ pub struct ProviderSpreadConfig {
     /// Contract ID the provider implements
     provider_contract_id: String,
     /// Provider config, to be serialized as a JSON string
-    provider_config: Option<HashMap<String, String>>,
+    provider_config: Option<HashMap<String, serde_json::Value>>,
     /// The name of the wadm model this SpreadScaler is under
     model_name: String,
     /// Configuration for this SpreadScaler
@@ -186,7 +186,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
                             })
                             .map(|host| {
                                 let config_json =
-                                    self.config.provider_config.as_ref().map(|c| serde_json::to_string(c).ok()).flatten();
+                                    self.config.provider_config.as_ref().and_then(|c| serde_json::to_string(c).ok());
                                 Command::StartProvider(StartProvider {
                                     reference: provider_ref.to_owned(),
                                     host_id: host.id.to_string(),
@@ -223,12 +223,13 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
 
 impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
     /// Construct a new ProviderSpreadScaler with specified configuration values
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         store: S,
         provider_reference: String,
         provider_contract_id: String,
         provider_link_name: Option<String>,
-        provider_config: Option<HashMap<String, String>>,
+        provider_config: Option<HashMap<String, serde_json::Value>>,
         lattice_id: String,
         model_name: String,
         spread_config: SpreadScalerProperty,

--- a/src/workers/command.rs
+++ b/src/workers/command.rs
@@ -63,7 +63,7 @@ impl Worker for CommandWorker {
                         &prov.reference,
                         prov.link_name.clone(),
                         Some(annotations),
-                        None,
+                        prov.config_json.clone(),
                     )
                     .await
             }


### PR DESCRIPTION
Still draft as it should be merged after #112. Can always break it out into its own PR if needed but I wanted to test this in tandem with the other change. 

## Feature or Problem
This PR adds support for a `config` block in the provider yaml. For example, you can change the default URL of the wasmCloud redis provider like this so you don't have to specify a URL in the linkdef
```yaml
    - name: redis
      type: capability
      properties:
        image: wasmcloud.azurecr.io/kvredis:0.19.0
        contract: wasmcloud:keyvalue
        config:
          url: redis://127.0.0.1:6380
```

I started with the implementation of this as a `HashMap<String, String>` even though it could technically be better represented as a `String, serde_json::Value`, just to keep it simple. It all ends up being serialized into a String anyways, but I pushed an additional commit with that change so if you specified a port like `8080`, it actually gets serialized more accurately as a number. Need to consider if this is better or more complicated, from my testing it should deserialize properly when users expect certain types.

## Related Issues
Fixes #102 

## Release Information
next alpha

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Updated unit tests to set config to be `None`

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I ran this manually with the kvcounter yaml snippet above, which properly made it to the provider
