### PR TITLE
feat(*): Adds support for provider config

### DIFF
--- a/oam/provider_config.yaml
+++ b/oam/provider_config.yaml
@@ -1,0 +1,36 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: provider-config-example
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: webcap
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+        link_name: default
+        # You can pass any config data you'd like sent to your provider as a string. This can be any
+        # format you desire. Here it is encoded JSON
+        config: '{"raw": "json", "data": {}}'
+
+    - name: ledblinky
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/ledblinky:0.0.1
+        contract: wasmcloud:blinkenlights
+        # You can also pass in any structured data that can be represented in JSON. This example is YAML
+        config:
+          some: config
+          number: 1
+
+    - name: bot
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/bot:0.0.1
+        contract: wasmcloud:bot
+        # One more example using JSON
+        config: { "some": "config", "number": 1 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use crate::model::CapabilityConfig;
+
 macro_rules! from_impl {
     ($t:ident) => {
         impl From<$t> for Command {
@@ -94,7 +96,9 @@ pub struct StartProvider {
     pub link_name: Option<String>,
     /// The name of the model/manifest that generated this command
     pub model_name: String,
-    // TODO: Do we need to support config_json paths?
+    /// Optional config to pass to the provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<CapabilityConfig>,
     /// Additional annotations to attach on this command
     pub annotations: HashMap<String, String>,
 }

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -552,6 +552,16 @@ async fn test_manifest_parsing() {
         .await;
 
     assert_put_response(resp, PutResult::NewVersion, "v0.0.2", 2);
+
+    // Smoke test to make sure the server can handle the various provider config options
+    let raw = tokio::fs::read("./oam/provider_config.yaml")
+        .await
+        .expect("Unable to load file");
+    let resp: PutModelResponse = test_server
+        .get_response("default.model.put", raw, None)
+        .await;
+
+    assert_put_response(resp, PutResult::Created, "v0.0.1", 1);
 }
 
 #[tokio::test]

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use futures::StreamExt;
 use serial_test::serial;
 
-use wadm::{commands::*, consumers::manager::Worker, workers::CommandWorker};
+use wadm::{
+    commands::*, consumers::manager::Worker, model::CapabilityConfig, workers::CommandWorker,
+};
 
 mod helpers;
 use helpers::{setup_test_wash, StreamWrapper, TestWashConfig};
@@ -117,6 +119,9 @@ async fn test_commands() {
             link_name: None,
             model_name: "fake".into(),
             annotations: HashMap::new(),
+            config: Some(CapabilityConfig::Opaque(
+                "{\"address\":\"0.0.0.0:8080\"}".to_string(),
+            )),
         })
         .await;
 


### PR DESCRIPTION
Adds support for passing a string encoded config or an optional json encoded config through to a provider. This includes an additional example manifest and tests

Closes #102