### PR TITLE
feat(scaler): Accounts for other providers running the lattice

### DIFF
--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -821,15 +821,16 @@ where
                         .get(APP_SPEC_ANNOTATION)
                         .map(|s| s.as_str())
                 }),
+            // NOTE(thomastaylor312): Provider stopped events need to be handled by all scalers as
+            // it they could need to adjust their provider count based on the number of providers
+            // available throughout the whole lattice (e.g. if a provider managed by another
+            // manifest is removed, but this manifest still needs one). Ideally we should have a way
+            // to have a "global" list of required providers in a lattice so we never shut one down
+            // just to spin it back up, but for now we'll just deal with this as is
             Event::ProviderStopped(provider) => self
                 .handle_provider_stopped(&message.lattice_id, provider)
                 .await
-                .map(|_| {
-                    provider
-                        .annotations
-                        .get(APP_SPEC_ANNOTATION)
-                        .map(|s| s.as_str())
-                }),
+                .map(|_| None),
             Event::ProviderHealthCheckPassed(ProviderHealthCheckPassed { data, host_id }) => self
                 .handle_provider_health_check(&message.lattice_id, host_id, data, false)
                 .await

--- a/test/data/all_hosts.yaml
+++ b/test/data/all_hosts.yaml
@@ -15,19 +15,19 @@ spec:
         - type: spreadscaler
           properties:
             replicas: 5
-          spread:
-            - name: eastcoast
-              requirements:
-                region: us-brooks-east
-              weight: 40
-            - name: westcoast
-              requirements:
-                zone: us-taylor-west
-              weight: 40
-            - name: the-moon
-              requirements:
-                zone: moon
-              weight: 20
+            spread:
+              - name: eastcoast
+                requirements:
+                  region: us-brooks-east
+                weight: 40
+              - name: westcoast
+                requirements:
+                  region: us-taylor-west
+                weight: 40
+              - name: the-moon
+                requirements:
+                  region: moon
+                weight: 20
         - type: linkdef
           properties:
             target: httpserver
@@ -43,16 +43,16 @@ spec:
         - type: spreadscaler
           properties:
             replicas: 5
-          spread:
-            - name: eastcoast
-              requirements:
-                region: us-brooks-east
-              weight: 40
-            - name: westcoast
-              requirements:
-                zone: us-taylor-west
-              weight: 40
-            - name: the-moon
-              requirements:
-                zone: moon
-              weight: 20
+            spread:
+              - name: eastcoast
+                requirements:
+                  region: us-brooks-east
+                weight: 40
+              - name: westcoast
+                requirements:
+                  region: us-taylor-west
+                weight: 40
+              - name: the-moon
+                requirements:
+                  region: moon
+                weight: 20

--- a/test/docker-compose-e2e.yaml
+++ b/test/docker-compose-e2e.yaml
@@ -37,8 +37,6 @@ services:
     image: wasmcloud/wasmcloud_host:0.63.1
     depends_on: 
       - nats
-    ports:
-     - 4000:4000
     deploy:
       replicas: 1
     environment:


### PR DESCRIPTION
This PR contains a couple small changes I discovered while manually testing, but the large change is around the scaler algorithm for providers. Now a provider scaler will consider its job done if _any_ provider matching what it is expecting to be running.

Closes #106