### PR TITLE
feat(multitenant)! Account prefixed API topics and manifest storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,8 @@ dependencies = [
 [[package]]
 name = "wasmbus-macros"
 version = "0.1.11"
-source = "git+https://github.com/vados-cosmonic/weld?branch=chore/update-nkeys-and-related-deps#993028a2574e1053b1a169556c3474d1b9b014e8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29134584a9233fe941de00a84ef60006954c48f0b80fca29db54fbb799ac817"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -3127,8 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.13.0"
-source = "git+https://github.com/vados-cosmonic/weld?branch=chore/update-nkeys-and-related-deps#993028a2574e1053b1a169556c3474d1b9b014e8"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da4e25698e9e15af56e9bb510d233495c4ec9c6bbbf13d046205190dd4ab935"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -3226,7 +3228,8 @@ dependencies = [
 [[package]]
 name = "weld-codegen"
 version = "0.7.0"
-source = "git+https://github.com/vados-cosmonic/weld?branch=chore/update-nkeys-and-related-deps#993028a2574e1053b1a169556c3474d1b9b014e8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66385fd8affabb09b678d2f826c78d995789cdb2fbb2dd02e6010dffe298797e"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -291,6 +291,7 @@ async fn main() -> anyhow::Result<()> {
         manifest_storage,
         client,
         Some(&args.api_prefix),
+        args.multitenant,
         ManifestNotifier::new(wadm_event_prefix, context),
     )
     .await?;
@@ -363,6 +364,7 @@ where
                     self.publisher.clone(),
                     self.notify_stream.clone(),
                     lattice_id,
+                    multitenant_prefix,
                     self.state_store.clone(),
                     self.manifest_store.clone(),
                     publisher.clone(),

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -139,6 +139,7 @@ where
         client: P,
         stream: JsStream,
         lattice_id: &str,
+        multitenant_prefix: Option<&str>,
         state_store: StateStore,
         manifest_store: KvStore,
         publisher: CommandPublisher<P>,
@@ -171,10 +172,10 @@ where
         // Get current scalers set up
         let manifest_store = crate::server::ModelStorage::new(manifest_store);
         let futs = manifest_store
-            .list(lattice_id)
+            .list(multitenant_prefix, lattice_id)
             .await?
             .into_iter()
-            .map(|summary| manifest_store.get(lattice_id, summary.name));
+            .map(|summary| manifest_store.get(multitenant_prefix, lattice_id, summary.name));
         let all_manifests = futures::future::join_all(futs)
             .await
             .into_iter()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -90,7 +90,7 @@ impl<P: Publisher> Server<P> {
     #[instrument(level = "info", skip_all)]
     pub async fn serve(mut self) -> anyhow::Result<()> {
         while let Some(msg) = self.subscriber.next().await {
-            if !msg.subject.starts_with(&self.prefix) {
+            if !msg.subject.starts_with(&self.prefix) && !self.multitenant {
                 warn!(subject = %msg.subject, "Received message on an invalid subject");
                 continue;
             }
@@ -250,7 +250,7 @@ impl<P: Publisher> Server<P> {
             anyhow::bail!("Found extra components of subject")
         }
         Ok(ParsedSubject {
-            account_id: account_id,
+            account_id,
             lattice_id,
             category,
             operation,

--- a/test/docker-compose-e2e-multitenant.yaml
+++ b/test/docker-compose-e2e-multitenant.yaml
@@ -21,6 +21,8 @@ services:
     depends_on:
       - nats-core
     image: nats:2.9.16-alpine
+    ports:
+      - "127.0.0.1:4223:4222"
     command: ["-js", "-a", "0.0.0.0", "-c", "/nats/config/nats-leaf-a.conf"]
     volumes:
       - ./nats/:/nats/config
@@ -28,6 +30,8 @@ services:
     depends_on:
       - nats-core
     image: nats:2.9.16-alpine
+    ports:
+      - "127.0.0.1:4224:4222"
     command: ["-js", "-a", "0.0.0.0", "-c", "/nats/config/nats-leaf-b.conf"]
     volumes:
       - ./nats/:/nats/config

--- a/test/nats/nats-test.conf
+++ b/test/nats/nats-test.conf
@@ -23,13 +23,14 @@ accounts: {
         users: [
             {user: wadm, password: wadm}
         ]
+        exports: [
+            {service: *.wadm.api.>, accounts: [A, B]}
+        ]
         # Listen to wasmbus.evt events and wadm API commands from account A and B
         # Lattice IDs are unique, so we don't need to add account prefixes for them
         imports: [
             {stream: {account: A, subject: wasmbus.evt.*}, prefix: Axxx}
-            {stream: {account: A, subject: wadm.api.>}}
             {stream: {account: B, subject: wasmbus.evt.*}, prefix: Ayyy}
-            {stream: {account: B, subject: wadm.api.>}}
             {service: {account: A, subject: wasmbus.ctl.>}, to: Axxx.wasmbus.ctl.>}
             {service: {account: B, subject: wasmbus.ctl.>}, to: Ayyy.wasmbus.ctl.>}
         ]
@@ -38,8 +39,10 @@ accounts: {
         users: [
             {user: a, password: a}
         ]
+        imports: [
+            {service: {account: WADM, subject: Axxx.wadm.api.>}, to: wadm.api.>}
+        ]
         exports: [
-            {stream: wadm.api.>, accounts: [WADM]}
             {stream: wasmbus.evt.*, accounts: [WADM]}
             {service: wasmbus.ctl.>, accounts: [WADM], response_type: stream}
         ]
@@ -48,8 +51,10 @@ accounts: {
         users: [
             {user: b, password: b}
         ]
+        imports: [
+            {service: {account: WADM, subject: Ayyy.wadm.api.>}, to: wadm.api.>}
+        ]
         exports: [
-            {stream: wadm.api.>, accounts: [WADM]}
             {stream: wasmbus.evt.*, accounts: [WADM]}
             {service: wasmbus.ctl.>, accounts: [WADM], response_type: stream}
         ]

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -89,6 +89,7 @@ async fn setup_server(id: String) -> TestServer {
         store,
         client.clone(),
         Some(&id),
+        false,
         ManifestNotifier::new(&prefix, client.clone()),
     )
     .await

--- a/tests/e2e_multiple_hosts.rs
+++ b/tests/e2e_multiple_hosts.rs
@@ -84,7 +84,7 @@ async fn run_multiple_host_tests() {
 // other tests run
 async fn test_no_requirements(client_info: &ClientInfo) {
     let resp = client_info
-        .put_manifest_from_file("simple.yaml", None)
+        .put_manifest_from_file("simple.yaml", None, None)
         .await;
 
     assert_ne!(
@@ -93,7 +93,9 @@ async fn test_no_requirements(client_info: &ClientInfo) {
         "Shouldn't have errored when creating manifest: {resp:?}"
     );
 
-    let resp = client_info.deploy_manifest("echo-simple", None, None).await;
+    let resp = client_info
+        .deploy_manifest("echo-simple", None, None, None)
+        .await;
     assert_ne!(
         resp.result,
         DeployResult::Error,
@@ -138,7 +140,9 @@ async fn test_no_requirements(client_info: &ClientInfo) {
     .await;
 
     // Undeploy manifest
-    let resp = client_info.undeploy_manifest("echo-simple", None).await;
+    let resp = client_info
+        .undeploy_manifest("echo-simple", None, None)
+        .await;
 
     assert_ne!(
         resp.result,
@@ -214,7 +218,7 @@ async fn test_no_requirements(client_info: &ClientInfo) {
 
 async fn test_spread_all_hosts(client_info: &ClientInfo) {
     let resp = client_info
-        .put_manifest_from_file("all_hosts.yaml", None)
+        .put_manifest_from_file("all_hosts.yaml", None, None)
         .await;
 
     assert_ne!(
@@ -225,7 +229,7 @@ async fn test_spread_all_hosts(client_info: &ClientInfo) {
 
     // Deploy manifest
     let resp = client_info
-        .deploy_manifest("echo-all-hosts", None, None)
+        .deploy_manifest("echo-all-hosts", None, None, None)
         .await;
     assert_ne!(
         resp.result,
@@ -255,7 +259,7 @@ async fn test_spread_all_hosts(client_info: &ClientInfo) {
 
 async fn test_complex_app(client_info: &ClientInfo) {
     let resp = client_info
-        .put_manifest_from_file("complex.yaml", None)
+        .put_manifest_from_file("complex.yaml", None, None)
         .await;
 
     assert_ne!(
@@ -265,7 +269,9 @@ async fn test_complex_app(client_info: &ClientInfo) {
     );
 
     // Deploy manifest
-    let resp = client_info.deploy_manifest("complex", None, None).await;
+    let resp = client_info
+        .deploy_manifest("complex", None, None, None)
+        .await;
     assert_ne!(
         resp.result,
         DeployResult::Error,
@@ -359,7 +365,7 @@ async fn test_complex_app(client_info: &ClientInfo) {
 // This test should be run after other tests have finished since we are stopping one of the hosts
 async fn test_stop_host_rebalance(client_info: &ClientInfo) {
     let resp = client_info
-        .put_manifest_from_file("host_stop.yaml", None)
+        .put_manifest_from_file("host_stop.yaml", None, None)
         .await;
 
     assert_ne!(
@@ -369,7 +375,9 @@ async fn test_stop_host_rebalance(client_info: &ClientInfo) {
     );
 
     // Deploy manifest
-    let resp = client_info.deploy_manifest("host-stop", None, None).await;
+    let resp = client_info
+        .deploy_manifest("host-stop", None, None, None)
+        .await;
     assert_ne!(
         resp.result,
         DeployResult::Error,

--- a/tests/e2e_multitenant.rs
+++ b/tests/e2e_multitenant.rs
@@ -14,6 +14,8 @@ const DOCKER_COMPOSE_FILE: &str = "test/docker-compose-e2e-multitenant.yaml";
 
 const MESSAGE_PUB_ACTOR_ID: &str = "MC3QONHYH3FY4KYFCOSVJWIDJG4WA2PVD6FHKR7FFT457GVUTZJYR2TJ";
 const NATS_PROVIDER_ID: &str = "VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7";
+const ACCOUNT_EAST: &str = "Axxx";
+const ACCOUNT_WEST: &str = "Ayyy";
 const LATTICE_EAST: &str = "wasmcloud-east";
 const LATTICE_WEST: &str = "wasmcloud-west";
 
@@ -52,7 +54,7 @@ async fn run_multitenant_tests() {
 
 async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     let resp = client_info
-        .put_manifest_from_file("simple.yaml", Some(LATTICE_EAST))
+        .put_manifest_from_file("simple.yaml", Some(ACCOUNT_EAST), Some(LATTICE_EAST))
         .await;
     assert_ne!(
         resp.result,
@@ -61,7 +63,7 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     );
 
     let resp = client_info
-        .put_manifest_from_file("simple2.yaml", Some(LATTICE_WEST))
+        .put_manifest_from_file("simple2.yaml", Some(ACCOUNT_WEST), Some(LATTICE_WEST))
         .await;
     assert_ne!(
         resp.result,
@@ -72,7 +74,7 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     eprintln!("Deploying manifests to east and west");
 
     let resp = client_info
-        .deploy_manifest("echo-simple", Some(LATTICE_EAST), None)
+        .deploy_manifest("echo-simple", Some(ACCOUNT_EAST), Some(LATTICE_EAST), None)
         .await;
     assert_ne!(
         resp.result,
@@ -81,7 +83,12 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     );
 
     let resp = client_info
-        .deploy_manifest("messaging-simple", Some(LATTICE_WEST), None)
+        .deploy_manifest(
+            "messaging-simple",
+            Some(ACCOUNT_WEST),
+            Some(LATTICE_WEST),
+            None,
+        )
         .await;
     assert_ne!(
         resp.result,
@@ -250,7 +257,7 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     // Undeploy manifests
     eprintln!("Undeploying manifest from east and west");
     let resp = client_info
-        .undeploy_manifest("echo-simple", Some(LATTICE_EAST))
+        .undeploy_manifest("echo-simple", Some(ACCOUNT_EAST), Some(LATTICE_EAST))
         .await;
     assert_ne!(
         resp.result,
@@ -259,7 +266,7 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     );
 
     let resp = client_info
-        .undeploy_manifest("messaging-simple", Some(LATTICE_WEST))
+        .undeploy_manifest("messaging-simple", Some(ACCOUNT_WEST), Some(LATTICE_WEST))
         .await;
     assert_ne!(
         resp.result,

--- a/tests/e2e_multitenant.rs
+++ b/tests/e2e_multitenant.rs
@@ -277,7 +277,9 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
     // assert that no actors or providers with annotations exist
     assert_status(None, None, || async {
         let east_inventory = client_info.get_all_inventory(LATTICE_EAST).await?;
+        println!("east inventory: {:?}", east_inventory);
         let west_inventory = client_info.get_all_inventory(LATTICE_WEST).await?;
+        println!("west inventory: {:?}", west_inventory);
 
         eprintln!("Ensuring resources stopped in east");
         check_actors(

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -91,7 +91,7 @@ async fn test_event_stream() -> Result<()> {
     // NOTE: the first heartbeat doesn't come for 30s so we are ignoring it for now
 
     // Start an actor
-    helpers::run_wash_command(["ctl", "start", "actor", ECHO_REFERENCE]).await;
+    helpers::run_wash_command(["start", "actor", ECHO_REFERENCE]).await;
 
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
     if let Event::ActorStarted(actor) = evt.as_ref() {
@@ -106,7 +106,7 @@ async fn test_event_stream() -> Result<()> {
     evt.ack().await.expect("Should be able to ack event");
 
     // Start a provider
-    helpers::run_wash_command(["ctl", "start", "provider", HTTP_SERVER_REFERENCE]).await;
+    helpers::run_wash_command(["start", "provider", HTTP_SERVER_REFERENCE]).await;
 
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
     if let Event::ProviderStarted(provider) = evt.as_ref() {
@@ -253,7 +253,7 @@ async fn test_nack_and_rereceive() -> Result<()> {
     let mut stream = get_event_consumer(config.nats_url()).await;
 
     // Start an actor
-    helpers::run_wash_command(["ctl", "start", "actor", ECHO_REFERENCE]).await;
+    helpers::run_wash_command(["start", "actor", ECHO_REFERENCE]).await;
 
     // Get the event and then nack it
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;


### PR DESCRIPTION
## Feature or Problem
This PR ensures we are storing and querying manifests based on an account prefix if running in multitenant mode. This ensures that accounts can only access and modify manifests that are specifically bound to that account, rather than simply using a global lattice ID.

Due to possible edge cases, it's still recommended to keep lattice prefixes globally unique between accounts, as there are not e2e tests at this time to verify that functionality works without issues. This PR at least implements the portion of that that constrains manifests from conflicting between accounts.

## Related Issues
#132

## Release Information
v0.5.0

## Consumer Impact
Multitenancy hasn't released yet so this shouldn't affect consumers, however they will need to examine the account prefixed topic if manually looking up manifests in NATS.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Modified a few unit tests that were hitting deprecation warnings

### Acceptance or Integration
Will have to modify the e2e tests to properly import/export account prefixes

### Manual Verification
Using the multitenant docker compose, I was able to verify that if I put a manifest using one account, I cannot query that manifest in another account even if I use the correct lattice prefix 😄 
