### PR TITLE
fix(canary): include context and binaries for canary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    tags: 
+    tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_dispatch: # Allow manual creation of artifacts without a release
 
@@ -62,7 +62,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         shell: bash
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
-  
+
       - name: Output Version
         id: version_output
         run: echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
@@ -125,7 +125,7 @@ jobs:
           if-no-files-found: error
           path: |
             ${{ matrix.config.targetPath }}wadm${{ matrix.config.extension }}
-      
+
   publish:
     name: publish release assets
     runs-on: ubuntu-20.04
@@ -134,32 +134,31 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.build.outputs.version_output }}
     steps:
-        - name: download release assets
-          uses: actions/download-artifact@v3
-        - name: Generate Checksums
-          run: |
-            for dir in */; do
-              cd "$dir" || continue 
-              sum=$(sha256sum * | awk '{ print $1 }')
-              echo "$dir:$sum" >> checksums-${{ env.RELEASE_VERSION }}.txt
-              cd ..
-            done
-        - name: Package Binaries
-          run:
-            for dir in */; do tar -czvf "${dir%/}.tar.gz" "$dir"; done
-        - name: Publish to GHCR
-          uses: softprops/action-gh-release@v1
-          with:
-            token: ${{ secrets.WADM_GITHUB_TOKEN }}
-            prerelease: false
-            draft: false
-            files: |
-              checksums-${{ env.RELEASE_VERSION }}.txt
-              wadm-${{ env.RELEASE_VERSION }}-linux-aarch64.tar.gz
-              wadm-${{ env.RELEASE_VERSION }}-linux-amd64.tar.gz
-              wadm-${{ env.RELEASE_VERSION }}-macos-aarch64.tar.gz
-              wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
-              wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
+      - name: download release assets
+        uses: actions/download-artifact@v3
+      - name: Generate Checksums
+        run: |
+          for dir in */; do
+            cd "$dir" || continue 
+            sum=$(sha256sum * | awk '{ print $1 }')
+            echo "$dir:$sum" >> checksums-${{ env.RELEASE_VERSION }}.txt
+            cd ..
+          done
+      - name: Package Binaries
+        run: for dir in */; do tar -czvf "${dir%/}.tar.gz" "$dir"; done
+      - name: Publish to GHCR
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.WADM_GITHUB_TOKEN }}
+          prerelease: false
+          draft: false
+          files: |
+            checksums-${{ env.RELEASE_VERSION }}.txt
+            wadm-${{ env.RELEASE_VERSION }}-linux-aarch64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-linux-amd64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-macos-aarch64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
 
   crate:
     name: Publish crate
@@ -200,7 +199,7 @@ jobs:
           name: wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
           path: ./artifacts
       - run: mv ./artifacts/wadm ./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64 && chmod +x ./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
-          
+
       - uses: actions/download-artifact@v3
         with:
           name: wadm-${{ env.RELEASE_VERSION }}-linux-amd64
@@ -213,7 +212,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.WADM_GITHUB_TOKEN }}
-      
+
       - name: lowercase repository owner
         run: |
           echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>$GITHUB_ENV
@@ -235,4 +234,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
+          context: ./
+          build-args: |
+            BIN_ARM64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
+            BIN_AMD64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
           tags: ghcr.io/${{ env.OWNER }}/wadm:canary


### PR DESCRIPTION
## Feature or Problem
This PR fixes the canary release image not including the wadm binaries, due to missing configuration in the release action.

## Related Issues
N/A

## Release Information
`canary`