### PR TITLE
fix(*): support deleting all versions of manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,42 @@ checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 [[package]]
 name = "async-nats"
 version = "0.30.0"
-source = "git+https://github.com/brooksmtownsend/nats.rs?branch=fix/jetstream-domain-purge#ba8643cf2583a5776d6b2009fc3366cd9a67f48f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e3e851ddf3b62be8a8085e1e453968df9cdbf990a37bbb589b5b4f587c68d7"
+dependencies = [
+ "base64 0.21.2",
+ "bytes",
+ "futures",
+ "http",
+ "itoa",
+ "memchr",
+ "nkeys",
+ "nuid 0.3.2",
+ "once_cell",
+ "rand",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time 0.3.23",
+ "tokio",
+ "tokio-retry",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8257238e2a3629ee5618502a75d1b91f8017c24638c75349fc8d2d80cf1f7c4c"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -2952,7 +2987,7 @@ name = "wadm"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats 0.31.0",
  "async-trait",
  "atty",
  "bytes",
@@ -3131,7 +3166,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da4e25698e9e15af56e9bb510d233495c4ec9c6bbbf13d046205190dd4ab935"
 dependencies = [
- "async-nats",
+ "async-nats 0.30.0",
  "async-trait",
  "atty",
  "base64 0.13.1",
@@ -3164,11 +3199,11 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86693c41af8686e99950450a0dbf2f9a75ee0d133f08209538c46b37514517e"
+checksum = "942b23887d80660323eff38acc580f22fc54340d8022352984d9ce4d0aedb937"
 dependencies = [
- "async-nats",
+ "async-nats 0.31.0",
  "bytes",
  "cloudevents-sdk",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,8 +130,7 @@ checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 [[package]]
 name = "async-nats"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e3e851ddf3b62be8a8085e1e453968df9cdbf990a37bbb589b5b4f587c68d7"
+source = "git+https://github.com/brooksmtownsend/nats.rs?branch=fix/jetstream-domain-purge#ba8643cf2583a5776d6b2009fc3366cd9a67f48f"
 dependencies = [
  "base64 0.21.2",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,6 @@ serial_test = "1"
 name = "wadm"
 path = "bin/main.rs"
 required-features = ["cli"]
+
+[patch.crates-io]
+async-nats = { git = "https://github.com/brooksmtownsend/nats.rs", branch = "fix/jetstream-domain-purge", version = "0.30" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ _e2e_tests = []
 
 [dependencies]
 anyhow = "1"
-async-nats = "0.30"
+async-nats = "0.31"
 async-trait = "0.1"
 atty = { version = "0.2", optional = true }
 bytes = "1"
@@ -60,7 +60,7 @@ tracing-subscriber = { version = "0.3.7", features = [
 ], optional = true }
 uuid = "1"
 wasmbus-rpc = "0.14"
-wasmcloud-control-interface = "0.27"
+wasmcloud-control-interface = "0.28"
 semver = { version = "1.0.16", features = ["serde"] }
 
 [dev-dependencies]
@@ -70,6 +70,3 @@ serial_test = "1"
 name = "wadm"
 path = "bin/main.rs"
 required-features = ["cli"]
-
-[patch.crates-io]
-async-nats = { git = "https://github.com/brooksmtownsend/nats.rs", branch = "fix/jetstream-domain-purge", version = "0.30" }

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -250,6 +250,7 @@ async fn main() -> anyhow::Result<()> {
         permit_pool.clone(),
         event_stream,
         event_worker_creator.clone(),
+        args.multitenant,
     )
     .await;
 
@@ -260,6 +261,7 @@ async fn main() -> anyhow::Result<()> {
         permit_pool.clone(),
         command_stream,
         command_worker_creator.clone(),
+        args.multitenant,
     )
     .await;
 

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -74,7 +74,7 @@ impl ModelStorage {
         let key = model_key(account_id, lattice_id, model.name());
         trace!(%key, "Storing manifest at key");
         let data = serde_json::to_vec(&model).map_err(anyhow::Error::from)?;
-        if let Some(revision) = current_revision {
+        if let Some(revision) = current_revision.filter(|r| r > &0) {
             self.store
                 .update(&key, data.into(), revision)
                 .await

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -1241,6 +1241,8 @@ mod test {
             (
                 host1_id.to_string(),
                 HostInventory {
+                    friendly_name: "my-host-1".to_string(),
+                    issuer: "my-issuer-1".to_string(),
                     actors: vec![
                         ActorDescription {
                             id: actor1.public_key.to_string(),
@@ -1306,6 +1308,8 @@ mod test {
             (
                 host2_id.to_string(),
                 HostInventory {
+                    friendly_name: "my-host-2".to_string(),
+                    issuer: "my-issuer-1".to_string(),
                     actors: vec![
                         ActorDescription {
                             id: actor1.public_key.to_string(),
@@ -1545,6 +1549,8 @@ mod test {
             (
                 host1_id.to_string(),
                 HostInventory {
+                    friendly_name: "my-host-3".to_string(),
+                    issuer: "my-issuer-2".to_string(),
                     actors: vec![ActorDescription {
                         id: actor2.public_key.to_string(),
                         image_ref: None,
@@ -1572,6 +1578,8 @@ mod test {
             (
                 host2_id.to_string(),
                 HostInventory {
+                    friendly_name: "my-host-4".to_string(),
+                    issuer: "my-issuer-2".to_string(),
                     actors: vec![ActorDescription {
                         id: actor2.public_key.to_string(),
                         image_ref: None,
@@ -1757,6 +1765,8 @@ mod test {
         *inventory.write().await = HashMap::from_iter([(
             host_id.to_string(),
             HostInventory {
+                friendly_name: "my-host-5".to_string(),
+                issuer: "my-issuer-3".to_string(),
                 actors: vec![
                     ActorDescription {
                         id: actor1_id.to_string(),
@@ -2021,6 +2031,8 @@ mod test {
         *inventory.write().await = HashMap::from_iter([(
             host_id.to_string(),
             HostInventory {
+                friendly_name: "my-host-6".to_string(),
+                issuer: "my-issuer-4".to_string(),
                 actors: vec![],
                 labels: HashMap::new(),
                 host_id: host_id.to_string(),
@@ -2137,6 +2149,8 @@ mod test {
         *inventory.write().await = HashMap::from_iter([(
             host_id.to_string(),
             HostInventory {
+                friendly_name: "my-host-7".to_string(),
+                issuer: "my-issuer-5".to_string(),
                 actors: vec![ActorDescription {
                     id: "jabba".to_string(),
                     image_ref: None,


### PR DESCRIPTION
## Feature or Problem
This PR fixes two issues
1. As outlined in #129, we had issues with fully deleting all versions of a manifest and then putting that manifest again, this is both fixed by my filter to ensure we only `update` if revision > 0 and adding the jetstream domain to the purge operation
2. For a non-multitenant wadm and multitenant wadm that share the same NATS infrastructure, avoid creating consumers that will automatically fail.

## Related Issues
Fixes #129 
Depends on https://github.com/nats-io/nats.rs/pull/1055

## Release Information
v0.5.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
