### PR TITLE
chore: add CODEOWNERS for reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# wasmCloud team members
+* @autodidaddict @brooksmtownsend @thomastaylor312 @connorsmith256


### PR DESCRIPTION
Added CODEOWNERS files so we automatically tag reviewers on PRs.

