### PR TITLE
feat(*): support non-string spreadscaler requirements

### DIFF
--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -389,12 +389,18 @@ mod test {
             spread: vec![
                 Spread {
                     name: "SimpleOne".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "fake".to_string().into(),
+                    )]),
                     weight: Some(100),
                 },
                 Spread {
                     name: "SimpleTwo".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "real".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "real".to_string().into(),
+                    )]),
                     weight: Some(100),
                 },
             ],
@@ -498,14 +504,17 @@ mod test {
             spread: vec![
                 Spread {
                     name: "ComplexOne".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "fake".to_string().into(),
+                    )]),
                     weight: Some(1),
                 },
                 Spread {
                     name: "ComplexTwo".to_string(),
                     requirements: BTreeMap::from_iter([(
                         "region".to_string(),
-                        "us-yourhouse-1".to_string(),
+                        "us-yourhouse-1".to_string().into(),
                     )]),
                     weight: Some(2),
                 },
@@ -825,12 +834,18 @@ mod test {
             spread: vec![
                 Spread {
                     name: "SimpleOne".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "fake".to_string().into(),
+                    )]),
                     weight: Some(100),
                 },
                 Spread {
                     name: "SimpleTwo".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "real".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "real".to_string().into(),
+                    )]),
                     weight: Some(100),
                 },
             ],
@@ -967,12 +982,18 @@ mod test {
             spread: vec![
                 Spread {
                     name: "SimpleOne".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "fake".to_string().into(),
+                    )]),
                     weight: Some(100),
                 },
                 Spread {
                     name: "SimpleTwo".to_string(),
-                    requirements: BTreeMap::from_iter([("cloud".to_string(), "real".to_string())]),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "real".to_string().into(),
+                    )]),
                     weight: Some(100),
                 },
             ],
@@ -1040,7 +1061,10 @@ mod test {
             replicas: 1,
             spread: vec![Spread {
                 name: "SimpleOne".to_string(),
-                requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                requirements: BTreeMap::from_iter([(
+                    "cloud".to_string(),
+                    "fake".to_string().into(),
+                )]),
                 weight: Some(100),
             }],
         };

--- a/test/data/non-string-requirements.yaml
+++ b/test/data/non-string-requirements.yaml
@@ -1,0 +1,36 @@
+# This manifest is used to test that we can parse requirements as strings
+# no matter the corresponding simple data type. We do not support complex
+# data types like lists or maps on the host, so it's not enforced here.
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: complex
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.8
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 5
+            spread:
+              - name: numba
+                requirements:
+                  number: 5
+              - name: mmmdelicious
+                requirements:
+                  number: 3.14
+              - name: boolin
+                requirements:
+                  boolean: true
+              - name: stringy
+                requirements:
+                  string: sup
+              - name: stringyquote
+                requirements:
+                  string: "sup"


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR allows spreadscaler requirements to be parsed as a string->value map, instead of just string->string. This lets you supply boolean and numeric values for spreadscaler properties and have them parse properly instead of falling under the custom object. Additionally, it modifies the `eligible_hosts` helper function to properly compare the `serde_json::Value` to the host labels that are still string->string hashmaps

## Related Issues
Fixes #131

## Release Information
0.5.0

## Consumer Impact
This may cause previously "custom" scaler objects to be parsed as spreadscaler objects, but I find it unlikely that it would solely be based on this change.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Added 2 unit tests to ensure parsing works properly and that matching based on labels works as intended.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
