### PR TITLE
fix(*): acquire permit for work after receive msg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-nats 0.31.0",
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-control-interface"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b23887d80660323eff38acc580f22fc54340d8022352984d9ce4d0aedb937"
+checksum = "37be05dfc4e1c528be5b9bdf7d0934182abe4a25424fcca0ba7afdb3f2b432e7"
 dependencies = [
  "async-nats 0.31.0",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]
@@ -60,7 +60,7 @@ tracing-subscriber = { version = "0.3.7", features = [
 ], optional = true }
 uuid = "1"
 wasmbus-rpc = "0.14"
-wasmcloud-control-interface = "0.28"
+wasmcloud-control-interface = "0.28.1"
 semver = { version = "1.0.16", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
The problem with the current implementation is that consumers acquire permits _before_ knowing that work needs to be done. This PR is a simple refactor that ensures that all consumers are awaiting their next message on the stream, and then once they receive the next message they attempt to acquire the permit.

This PR also updates the control interface to 0.28.1, which includes a small bug fix for querying claims when a version field may be null.

## Related Issues
N/A

## Release Information
v0.5.0-alpha.2

## Consumer Impact
This simply makes wadm operate as intended.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I made sure this works with the default values with more than 256 consumers.
