### PR TITLE
feat(status): implement status for applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 test/e2e_log/
+
+*.dump

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "async-nats 0.31.0",
  "async-trait",
  "atty",
+ "base64 0.21.2",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,13 +1903,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.6",
  "regex-syntax 0.7.4",
 ]
 
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3003,6 +3003,7 @@ dependencies = [
  "opentelemetry-otlp",
  "prometheus",
  "rand",
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,7 @@ repository = "https://github.com/wasmcloud/wadm"
 
 [features]
 default = []
-cli = [
-    "clap",
-    "tracing-opentelemetry",
-    "tracing-subscriber",
-    "opentelemetry",
-    "opentelemetry-otlp",
-    "atty",
-]
+cli = ["clap", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry", "opentelemetry-otlp", "atty"]
 # internal feature for e2e tests
 _e2e_tests = []
 
@@ -62,6 +55,7 @@ uuid = "1"
 wasmbus-rpc = "0.14"
 wasmcloud-control-interface = "0.28.1"
 semver = { version = "1.0.16", features = ["serde"] }
+base64 = "0.21.2"
 
 [dev-dependencies]
 serial_test = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ uuid = "1"
 wasmbus-rpc = "0.14"
 wasmcloud-control-interface = "0.28.1"
 semver = { version = "1.0.16", features = ["serde"] }
+regex = "1.9.3"
 base64 = "0.21.2"
 
 [dev-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ stream-cleanup: ## Purges all streams that wadm creates
 	$(NATS) stream purge wadm_events --force
 	$(NATS) stream purge wadm_notify --force
 	$(NATS) stream purge wadm_mirror --force
+	$(NATS) stream purge wadm_status --force
 	$(NATS) stream purge KV_wadm_state --force
 	$(NATS) stream purge KV_wadm_manifests --force
 

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -2,10 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_nats::jetstream::{
-    stream::{RetentionPolicy, Stream},
-    Context,
-};
+use async_nats::jetstream::{stream::Stream, Context};
 use clap::Parser;
 use tokio::sync::Semaphore;
 use tracing::log::debug;
@@ -202,9 +199,6 @@ async fn main() -> anyhow::Result<()> {
             "A stream that stores all events coming in on the wasmbus.evt topics in a cluster"
                 .to_string(),
         ),
-        RetentionPolicy::WorkQueue,
-        None,
-        None,
     )
     .await?;
 
@@ -215,20 +209,13 @@ async fn main() -> anyhow::Result<()> {
         COMMAND_STREAM_NAME.to_owned(),
         vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
         Some("A stream that stores all commands for wadm".to_string()),
-        RetentionPolicy::WorkQueue,
-        None,
-        None,
     )
     .await?;
 
-    let status_stream = nats::ensure_stream(
+    let status_stream = nats::ensure_status_stream(
         &context,
         STATUS_STREAM_NAME.to_owned(),
         vec![DEFAULT_STATUS_TOPIC.to_owned()],
-        Some("A stream that stores all status updates for wadm applications".to_string()),
-        RetentionPolicy::Limits,
-        Some(std::time::Duration::from_nanos(0)),
-        Some(10),
     )
     .await?;
 
@@ -249,9 +236,6 @@ async fn main() -> anyhow::Result<()> {
         mirror_stream.to_owned(),
         event_stream_topics.clone(),
         Some("A stream that publishes all events to the same stream".to_string()),
-        RetentionPolicy::WorkQueue,
-        None,
-        None,
     )
     .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub const DEFAULT_EVENTS_TOPIC: &str = "wasmbus.evt.*";
 pub const DEFAULT_MULTITENANT_EVENTS_TOPIC: &str = "*.wasmbus.evt.*";
 /// Default topic to listen to for all commands
 pub const DEFAULT_COMMANDS_TOPIC: &str = "wadm.cmd.*";
+/// Default topic to listen to for all status updates. wadm.status.<lattice_id>.<manifest_name>
+pub const DEFAULT_STATUS_TOPIC: &str = "wadm.status.*.*";
 /// The default listen topic for the merged wadm events stream. This topic is an amalgamation of
 /// wasmbus.evt topics plus the wadm.internal topics
 pub const DEFAULT_WADM_EVENTS_TOPIC: &str = "wadm.evt.*";

--- a/src/model/internal.rs
+++ b/src/model/internal.rs
@@ -3,7 +3,6 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::model::Manifest;
-use crate::server::ComponentStatus;
 
 use super::LATEST_VERSION;
 
@@ -16,11 +15,6 @@ pub(crate) struct StoredManifest {
     manifests: IndexMap<String, Manifest>,
     // Set only if a version is deployed
     deployed_version: Option<String>,
-    // TODO: Figure out which status to store (probably just the status for each component). We can
-    // convert it to the external facing type from the server as needed
-    status: Vec<ComponentStatus>,
-    // An optional top level status message to help with debugging or status for the whole manifest
-    status_message: Option<String>,
 }
 
 impl StoredManifest {
@@ -132,15 +126,5 @@ impl StoredManifest {
     /// Returns the total count of manifests
     pub fn count(&self) -> usize {
         self.manifests.len()
-    }
-
-    /// Returns a reference to the current status message, if any
-    pub fn status_message(&self) -> Option<&str> {
-        self.status_message.as_deref()
-    }
-
-    /// Returns a reference to the current status
-    pub fn status(&self) -> &Vec<ComponentStatus> {
-        &self.status
     }
 }

--- a/src/nats_utils.rs
+++ b/src/nats_utils.rs
@@ -41,7 +41,7 @@ impl LatticeIdParser {
                     && evt == EVENT_SUBJECT
                     && account_id.starts_with('A') =>
             {
-                (Some(lattice_id), Some(&account_id))
+                (Some(lattice_id), Some(account_id))
             }
             _ => (None, None),
         }

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -85,7 +85,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for SimpleActorScaler<S> {
             config,
             store: self.store.clone(),
             id: self.id.clone(),
-            status: StatusInfo::compensating("Cleaning up"),
+            status: StatusInfo::compensating(""),
         };
 
         cleanerupper.compute_actor_commands(&self.store).await
@@ -112,7 +112,7 @@ impl<S: ReadStore + Send + Sync> SimpleActorScaler<S> {
                 model_name,
             },
             id,
-            status: StatusInfo::compensating("Initializing simplescaler"),
+            status: StatusInfo::compensating(""),
         }
     }
 

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -257,7 +257,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
             spread_requirements,
             actor_id: self.actor_id.clone(),
             id: self.id.clone(),
-            status: RwLock::new(StatusInfo::compensating("Cleaning up")),
+            status: RwLock::new(StatusInfo::compensating("")),
         };
 
         cleanerupper.reconcile().await
@@ -286,7 +286,7 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
                 model_name,
             },
             id,
-            status: RwLock::new(StatusInfo::compensating("Initializing")),
+            status: RwLock::new(StatusInfo::compensating("")),
         }
     }
 

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -225,6 +225,9 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
                             .collect::<Vec<Command>>();
 
                         if commands.len() < num_to_start {
+                            // NOTE(brooksmtownsend): We're reporting status for the entire spreadscaler here, not just this individual
+                            // command, so we want to consider the providers that are already running for the spread over the 
+                            // total expected count.
                             let msg = format!("Could not satisfy spread {} for {}, {}/{} eligible hosts found.", spread.name, self.config.provider_reference, running_for_spread.len(), count);
                             spread_status.push(StatusInfo::failed(&msg));
                         }
@@ -268,7 +271,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
             spread_requirements,
             provider_id: self.provider_id.clone(),
             id: self.id.clone(),
-            status: RwLock::new(StatusInfo::compensating("Cleaning up")),
+            status: RwLock::new(StatusInfo::compensating("")),
         };
 
         cleanerupper.reconcile().await
@@ -288,7 +291,7 @@ impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
             provider_id: OnceCell::new(),
             config,
             id,
-            status: RwLock::new(StatusInfo::compensating("Initializing")),
+            status: RwLock::new(StatusInfo::compensating("")),
         }
     }
 

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -125,6 +125,7 @@ impl ModelStorage {
                         // TODO(thomastaylor312): Actually fetch the status info from the stored
                         // manifest once we figure it out
                         status: StatusType::default(),
+                        status_message: None,
                     }))
                 }
             });

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -59,6 +59,7 @@ pub struct ModelSummary {
     pub description: Option<String>,
     pub deployed_version: Option<String>,
     pub status: StatusType,
+    pub status_message: Option<String>,
 }
 
 /// The response to a versions request
@@ -192,6 +193,36 @@ pub struct StatusInfo {
     pub status_type: StatusType,
     #[serde(skip_serializing_if = "String::is_empty", default)]
     pub message: String,
+}
+
+impl StatusInfo {
+    pub fn undeployed(message: &str) -> Self {
+        StatusInfo {
+            status_type: StatusType::Undeployed,
+            message: message.to_owned(),
+        }
+    }
+
+    pub fn ready(message: &str) -> Self {
+        StatusInfo {
+            status_type: StatusType::Ready,
+            message: message.to_owned(),
+        }
+    }
+
+    pub fn failed(message: &str) -> Self {
+        StatusInfo {
+            status_type: StatusType::Failed,
+            message: message.to_owned(),
+        }
+    }
+
+    pub fn compensating(message: &str) -> Self {
+        StatusInfo {
+            status_type: StatusType::Compensating,
+            message: message.to_owned(),
+        }
+    }
 }
 
 /// All possible status types

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -724,7 +724,7 @@ where
             .publish_status(data.manifest.metadata.name.as_ref(), status)
             .await
         {
-            warn!(error = ?e, "Failed to set status to compensating");
+            warn!("Failed to set manifest status: {e:}");
         };
 
         // Now handle the result from reconciliation

--- a/src/workers/event_helpers.rs
+++ b/src/workers/event_helpers.rs
@@ -100,16 +100,16 @@ impl LinkSource for wasmcloud_control_interface::Client {
 pub struct StatusPublisher<Pub> {
     publisher: Pub,
     // Topic prefix, e.g. wadm.status.default
-    topic: String,
+    topic_prefix: String,
 }
 
 impl<Pub> StatusPublisher<Pub> {
     /// Creates an new status publisher configured with the given publisher that will send to the
-    /// specified topic
-    pub fn new(publisher: Pub, topic: &str) -> StatusPublisher<Pub> {
+    /// manifest status topic using the given prefix
+    pub fn new(publisher: Pub, topic_prefix: &str) -> StatusPublisher<Pub> {
         StatusPublisher {
             publisher,
-            topic: topic.to_owned(),
+            topic_prefix: topic_prefix.to_owned(),
         }
     }
 }
@@ -120,7 +120,7 @@ impl<Pub: Publisher> StatusPublisher<Pub> {
         self.publisher
             .publish(
                 serde_json::to_vec(&status)?,
-                Some(&format!("{}.{name}", self.topic)),
+                Some(&format!("{}.{name}", self.topic_prefix)),
             )
             .await
     }

--- a/src/workers/event_helpers.rs
+++ b/src/workers/event_helpers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use tracing::{instrument, warn};
 use wasmcloud_control_interface::{HostInventory, LinkDefinition};
 
-use crate::{commands::Command, publisher::Publisher, APP_SPEC_ANNOTATION};
+use crate::{commands::Command, publisher::Publisher, server::StatusInfo, APP_SPEC_ANNOTATION};
 
 /// A subset of needed claims to help populate state
 #[derive(Debug, Clone)]
@@ -92,6 +92,37 @@ impl LinkSource for wasmcloud_control_interface::Client {
             .await
             .map(|resp| resp.links)
             .map_err(|e| anyhow::anyhow!("{e:?}"))
+    }
+}
+
+/// A struct for publishing status updates
+#[derive(Clone)]
+pub struct StatusPublisher<Pub> {
+    publisher: Pub,
+    // Topic prefix, e.g. wadm.status.default
+    topic: String,
+}
+
+impl<Pub> StatusPublisher<Pub> {
+    /// Creates an new status publisher configured with the given publisher that will send to the
+    /// specified topic
+    pub fn new(publisher: Pub, topic: &str) -> StatusPublisher<Pub> {
+        StatusPublisher {
+            publisher,
+            topic: topic.to_owned(),
+        }
+    }
+}
+
+impl<Pub: Publisher> StatusPublisher<Pub> {
+    #[instrument(level = "trace", skip(self))]
+    pub async fn publish_status(&self, name: &str, status: StatusInfo) -> anyhow::Result<()> {
+        self.publisher
+            .publish(
+                serde_json::to_vec(&status)?,
+                Some(&format!("{}.{name}", self.topic)),
+            )
+            .await
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -509,7 +509,7 @@ pub fn check_providers(
     Ok(())
 }
 
-pub(crate) async fn get_manifest_status(
+pub async fn get_manifest_status(
     stream: &Stream,
     lattice_id: &str,
     name: &str,

--- a/tests/e2e_multitenant.rs
+++ b/tests/e2e_multitenant.rs
@@ -282,6 +282,8 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
             get_manifest_status(&stream, LATTICE_WEST, "messaging-simple").await,
         ) {
             (Some(east_status), Some(messaging_status)) => {
+                println!("East status {east_status:?}");
+                println!("West status {messaging_status:?}");
                 assert_eq!(east_status.status_type, StatusType::Ready);
                 assert_eq!(messaging_status.status_type, StatusType::Ready);
             }
@@ -357,6 +359,8 @@ async fn test_basic_separation(client_info: &ClientInfo) -> anyhow::Result<()> {
             get_manifest_status(&stream, LATTICE_WEST, "messaging-simple").await,
         ) {
             (Some(east_status), Some(messaging_status)) => {
+                println!("East status {east_status:?}");
+                println!("West status {messaging_status:?}");
                 assert_eq!(east_status.status_type, StatusType::Undeployed);
                 assert_eq!(messaging_status.status_type, StatusType::Undeployed);
             }

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -123,7 +123,6 @@ async fn test_event_stream() -> Result<()> {
 
     // Create a link
     helpers::run_wash_command([
-        "ctl",
         "link",
         "put",
         ECHO_ACTOR_ID,
@@ -154,7 +153,7 @@ async fn test_event_stream() -> Result<()> {
     evt.ack().await.expect("Should be able to ack event");
 
     // Delete link
-    helpers::run_wash_command(["ctl", "link", "del", ECHO_ACTOR_ID, CONTRACT_ID]).await;
+    helpers::run_wash_command(["link", "del", ECHO_ACTOR_ID, CONTRACT_ID]).await;
 
     let mut evt = wait_for_event(&mut stream, LINK_OPERATION_TIMEOUT_DURATION).await;
     if let Event::LinkdefDeleted(link) = evt.as_ref() {
@@ -175,7 +174,7 @@ async fn test_event_stream() -> Result<()> {
 
     // Stop provider
     let host_id = serde_json::from_slice::<HostResponse>(
-        &helpers::run_wash_command(["ctl", "get", "hosts", "-o", "json"]).await,
+        &helpers::run_wash_command(["get", "hosts", "-o", "json"]).await,
     )
     .unwrap()
     .hosts[0]
@@ -185,7 +184,6 @@ async fn test_event_stream() -> Result<()> {
         .unwrap()
         .to_owned();
     helpers::run_wash_command([
-        "ctl",
         "stop",
         "provider",
         &host_id,
@@ -208,7 +206,7 @@ async fn test_event_stream() -> Result<()> {
     evt.ack().await.expect("Should be able to ack event");
 
     // Stop an actor
-    helpers::run_wash_command(["ctl", "stop", "actor", &host_id, ECHO_ACTOR_ID]).await;
+    helpers::run_wash_command(["stop", "actor", &host_id, ECHO_ACTOR_ID]).await;
 
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
     if let Event::ActorStopped(actor) = evt.as_ref() {
@@ -223,7 +221,7 @@ async fn test_event_stream() -> Result<()> {
     evt.ack().await.expect("Should be able to ack event");
 
     // Stop the host
-    helpers::run_wash_command(["ctl", "stop", "host", &host_id]).await;
+    helpers::run_wash_command(["stop", "host", &host_id]).await;
 
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
     if let Event::HostStopped(host) = evt.as_ref() {

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -104,7 +104,7 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
         .to_string();
 
     // Build args
-    let mut args: Vec<&str> = Vec::from(["up", "-d", "--nats-port", &nats_port]);
+    let mut args: Vec<&str> = Vec::from(["up", "-d", "--disable-wadm", "--nats-port", &nats_port]);
     if cfg.nats_connect_only {
         args.push("--nats-connect-only");
     }
@@ -124,6 +124,7 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     };
 
     let output = cmd.status().await.expect("Unable to run detached wash up");
+
     assert!(output.success(), "Error trying to start host",);
 
     // Make sure we can connect to washboard


### PR DESCRIPTION
## Feature or Problem
This PR implements status for applications by adding a `status` function on the `Scaler` trait, and modifying the status accordingly. The `Undeployed` status is applied by default when a new model is put, or when the model is undeployed after deployment.

The way we calculate status is effectively a little state machine
1. When manifest deployed, set to `Compensating` as initial commands are sent out
2. After the initial set of expected events is received, ask the scaler to reconcile. 
3. If reconciliation returns commands, stay in `Compensating` state and publish those commands, and if the commands list is empty continue.
4. When commands are empty from a scaler, request the status from that scaler. The actor and provider spreadscalers are considered `Ready` if all of the spreads are satisfied, and `Failed` otherwise.
5. Publish the status to the `wadm_status` stream for consumption.
6. Whenever an event is handled by an individual scaler, set status to `Compensating` if commands are sent as a result of that event, or repeat 4.

The `wadm_status` stream will store the last 10 messages for status and those 10 messages will live forever.

## Related Issues
Fixes #142 

## Release Information
v0.5.0

## Consumer Impact
Consumers will see the status actually update from `Undeployed` when querying the wadm API.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Modified e2e tests to include status assertions, which is the closest real-world example that we have. 

### Manual Verification
I deployed a few manifests using this PR and made sure that some basic examples will result in a failed status, e.g. deploying 2 HTTP servers with only one host:
```
nats req "wadm.api.default.model.list" '{}'
10:24:44 Sending request on "wadm.api.default.model.list"
10:24:44 Received with rtt 6.0045ms
[{"name":"echo","version":"v0.0.2","description":"wasmCloud Echo Example","deployed_version":"v0.0.2","status":"failed","status_message":"Could not satisfy spread default for wasmcloud.azurecr.io/httpserver:0.17.0, 1/2 eligible hosts found."}]
```
