### PR TITLE
feat: manifest and application upgrades

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        e2e_test: [e2e_multiple_hosts, e2e_multitenant]
+        e2e_test: [e2e_multiple_hosts, e2e_multitenant, e2e_upgrades]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,10 @@ jobs:
   test:
     name: e2e
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        e2e_test: [e2e_multiple_hosts, e2e_multitenant]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,17 +29,19 @@ jobs:
         with:
           key: "ubuntu-22.04-rust-cache"
 
-      # Run all tests
-      - name: Run tests
+      # Run e2e tests in a matrix for efficiency
+      - name: Run tests ${{ matrix.e2e_test }}
         id: test
-        run: make test-e2e
-    
+        env:
+          WADM_E2E_TEST: ${{ matrix.e2e_test }}
+        run: make test-individual-e2e
+
       # if the previous step fails, upload logs
       - name: Upload logs for debugging
         uses: actions/upload-artifact@v2
         if: ${{ failure() && steps.test.outcome == 'failure' }}
         with:
-          name: e2e-logs
+          name: e2e-logs-${{ matrix.e2e_test }}
           path: ./test/e2e_log/*
           # Be nice and only retain the logs for 7 days
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ ifeq ($(shell nc -czt -w1 127.0.0.1 4222 || echo fail),fail)
 	@$(MAKE) build
 	RUST_BACKTRACE=1 $(CARGO) test --test e2e_multitenant --features _e2e_tests --  --nocapture 
 	RUST_BACKTRACE=1 $(CARGO) test --test e2e_multiple_hosts --features _e2e_tests --  --nocapture 
+	RUST_BACKTRACE=1 $(CARGO) test --test e2e_upgrades --features _e2e_tests --  --nocapture 
 else
 	@echo "WARN: Not running e2e tests. NATS must not be currently running"
 	exit 1

--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,14 @@ endif
 # Cleanup #
 ###########
 
-stream-cleanup: ## Purges all streams that wadm creates
-	$(NATS) stream purge wadm_commands --force
-	$(NATS) stream purge wadm_events --force
-	$(NATS) stream purge wadm_notify --force
-	$(NATS) stream purge wadm_mirror --force
-	$(NATS) stream purge wadm_status --force
-	$(NATS) stream purge KV_wadm_state --force
-	$(NATS) stream purge KV_wadm_manifests --force
+stream-cleanup: ## Removes all streams that wadm creates
+	-$(NATS) stream del wadm_commands --force
+	-$(NATS) stream del wadm_events --force
+	-$(NATS) stream del wadm_notify --force
+	-$(NATS) stream del wadm_mirror --force
+	-$(NATS) stream del wadm_multitenant_mirror --force
+	-$(NATS) stream del wadm_status --force
+	-$(NATS) stream del KV_wadm_state --force
+	-$(NATS) stream del KV_wadm_manifests --force
 
 .PHONY: check-cargo-clippy lint build build-watch test stream-cleanup clean test-e2e test 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,15 @@ else
 	exit 1
 endif
 
+test-individual-e2e:: ## Runs an individual e2e test based on the WADM_E2E_TEST env var
+ifeq ($(shell nc -czt -w1 127.0.0.1 4222 || echo fail),fail)
+	@$(MAKE) build
+	RUST_BACKTRACE=1 $(CARGO) test --test $(WADM_E2E_TEST) --features _e2e_tests --  --nocapture 
+else
+	@echo "WARN: Not running e2e tests. NATS must not be currently running"
+	exit 1
+endif
+
 ###########
 # Cleanup #
 ###########

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Reference](https://wasmcloud.dev/reference/wadm).
 As this is a new project there are some things we know are missing or buggy. A non-exhaustive list
 of these can be found below:
 
-- Currently the API does not update with the status of each scaler and reconcile action
 - It is _technically_ possible as things stand right now for a race condition with manifests when a
   manifest is updated/created and deleted simultaneously. In this case, one of the operations will
   win and you will end up with a manifest that still exists after you delete it or a manifest that

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -274,7 +274,8 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
         spread_config: SpreadScalerProperty,
         component_name: &str,
     ) -> Self {
-        let id = format!("{ACTOR_SPREAD_SCALER_TYPE}-{model_name}-{component_name}");
+        let id =
+            format!("{ACTOR_SPREAD_SCALER_TYPE}-{model_name}-{component_name}-{actor_reference}");
         Self {
             store,
             spread_requirements: compute_spread(&spread_config),

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -282,8 +282,8 @@ impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
     /// Construct a new ProviderSpreadScaler with specified configuration values
     pub fn new(store: S, config: ProviderSpreadConfig, component_name: &str) -> Self {
         let id = format!(
-            "{PROVIDER_SPREAD_SCALER_TYPE}-{}-{component_name}-{}",
-            config.model_name, config.provider_link_name,
+            "{PROVIDER_SPREAD_SCALER_TYPE}-{}-{component_name}-{}-{}",
+            config.model_name, config.provider_reference, config.provider_link_name,
         );
         Self {
             store,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -797,14 +797,11 @@ impl<P: Publisher> Handler<P> {
         // to ensure we fetch the latest message from the cluster leader.
         match self
             .status_stream
-            .get_last_raw_message_by_subject(&format!("wadm.status.{lattice_id}.{name}",))
+            .direct_get_last_for_subject(&format!("wadm.status.{lattice_id}.{name}",))
             .await
-            .map(|raw| {
-                B64decoder
-                    .decode(raw.payload)
-                    .map(|b| serde_json::from_slice::<StatusInfo>(&b))
-            }) {
-            Ok(Ok(Ok(status))) => Some(status),
+            .map(|msg| serde_json::from_slice::<StatusInfo>(&msg.payload))
+        {
+            Ok(Ok(status)) => Some(status),
             // Model status doesn't exist or is invalid, assuming undeployed
             _ => None,
         }

--- a/test/data/outdatedapp.yaml
+++ b/test/data/outdatedapp.yaml
@@ -1,0 +1,71 @@
+# This is an application for use in the update test suite. It contains
+# 1. An actor component that is up to date and shouldn't change (xkcd)
+# 2. An actor component that is out of date and should be updated (echo)
+#    - This component also has an out of date trait that should be updated (linkdef)
+# 3. An actor component that is no longer needed and should be deleted (kvcounter)
+# 4. A provider component that is out of date and should be updated (httpserver)
+# 5. A provider component that is no longer needed and should be deleted (redis)
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: updateapp
+  annotations:
+    version: v0.0.1
+    description: "According to all known laws of aviation"
+spec:
+  components:
+    # Latest, no modifications needed, actor component
+    - name: xkcd
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/xkcd:0.1.1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 5
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8081
+    # Old actor component
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.4
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 3
+        # Old linkdef trait
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080
+    # No longer needed actor component
+    - name: kvcounter
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/kvcounter:0.4.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 3
+        - type: linkdef
+          properties:
+            target: redis
+            values:
+              URL: redis://127.0.0.1:6379
+    # Old provider component
+    - name: httpserver
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+    # No longer needed provider component
+    - name: redis
+      type: capability
+      properties:
+        contract: wasmcloud:keyvalue
+        image: wasmcloud.azurecr.io/kvredis:0.22.0

--- a/test/data/upgradedapp.yaml
+++ b/test/data/upgradedapp.yaml
@@ -1,0 +1,54 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: updateapp
+  annotations:
+    version: v0.0.2
+    description: "Bees"
+spec:
+  components:
+    # Latest, no modifications needed, actor component
+    - name: xkcd
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/xkcd:0.1.1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 5
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8081
+    # Totally new actor component
+    - name: messagepub
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/message-pub:0.1.3
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+    # Updated actor component
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.8
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 3
+        # Updated linkdef trait
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8082
+
+    # Updated provider component
+    - name: httpserver
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.19.0

--- a/test/docker-compose-e2e-upgrade.yaml
+++ b/test/docker-compose-e2e-upgrade.yaml
@@ -1,0 +1,22 @@
+services:
+  nats:
+    image: nats:2.9-alpine
+    command: ["-js"]
+    ports:
+      - 4222:4222
+  wasmcloud:
+    image: wasmcloud/wasmcloud_host:0.63.1
+    depends_on:
+      - nats
+    deploy:
+      replicas: 1
+    environment:
+      LC_ALL: en_US.UTF-8
+      RUST_LOG: debug,hyper=info
+      WASMCLOUD_RPC_HOST: nats
+      WASMCLOUD_CTL_HOST: nats
+      WASMCLOUD_PROV_RPC_HOST: nats
+      WASMCLOUD_CLUSTER_SEED: SCAOGJWX53TGI4233T6GAXWYWBIB5ZDGPTCO6ODJQYELS52YCQCBQSRPA4
+      HOST_app: upgradey
+      HOST_region: us-brooks-east
+      HOST_high_availability: nope

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -824,7 +824,6 @@ async fn test_delete_deploy() {
 async fn test_status() {
     let test_server = setup_server("status".to_owned()).await;
 
-    // Create a manifest with 2 versions
     let raw = tokio::fs::read("./oam/petclinic.yaml")
         .await
         .expect("Unable to load file");

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "_e2e_tests")]
-use base64::{engine::general_purpose::STANDARD as B64decoder, Engine};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -515,14 +514,11 @@ pub async fn get_manifest_status(
     name: &str,
 ) -> Option<StatusInfo> {
     match stream
-        .get_last_raw_message_by_subject(&format!("wadm.status.{lattice_id}.{name}",))
+        .direct_get_last_for_subject(&format!("wadm.status.{lattice_id}.{name}",))
         .await
-        .map(|raw| {
-            B64decoder
-                .decode(raw.payload)
-                .map(|b| serde_json::from_slice::<StatusInfo>(&b))
-        }) {
-        Ok(Ok(Ok(status))) => Some(status),
+        .map(|msg| serde_json::from_slice::<StatusInfo>(&msg.payload))
+    {
+        Ok(Ok(status)) => Some(status),
         // Model status doesn't exist or is invalid, assuming undeployed
         _ => None,
     }

--- a/tests/e2e_multiple_hosts.rs
+++ b/tests/e2e_multiple_hosts.rs
@@ -179,6 +179,7 @@ async fn test_no_requirements(client_info: &ClientInfo) {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         if let Some(status) = get_manifest_status(&stream, "default", "echo-simple").await {
             assert_eq!(status.status_type, StatusType::Undeployed);
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             break;
         }
     }
@@ -202,6 +203,7 @@ async fn test_no_requirements(client_info: &ClientInfo) {
         let status = get_manifest_status(&stream, "default", "echo-simple")
             .await
             .unwrap();
+
         assert_eq!(status.status_type, StatusType::Undeployed);
 
         Ok(())

--- a/tests/e2e_upgrades.rs
+++ b/tests/e2e_upgrades.rs
@@ -1,0 +1,287 @@
+#![cfg(feature = "_e2e_tests")]
+use std::path::PathBuf;
+use std::time::Duration;
+
+use futures::FutureExt;
+use wadm::server::{DeployResult, PutResult, StatusType};
+
+mod e2e;
+mod helpers;
+
+use e2e::{assert_status, check_actors, check_providers, ClientInfo, ExpectedCount};
+use helpers::{ECHO_ACTOR_ID, HTTP_SERVER_PROVIDER_ID};
+
+use crate::e2e::get_manifest_status;
+
+const MANIFESTS_PATH: &str = "test/data";
+const DOCKER_COMPOSE_FILE: &str = "test/docker-compose-e2e-upgrade.yaml";
+const KV_COUNTER_ACTOR_ID: &str = "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E";
+const KV_REDIS_PROVIDER_ID: &str = "VAZVC4RX54J2NVCMCW7BPCAHGGG5XZXDBXFUMDUXGESTMQEJLC3YVZWB";
+
+#[cfg(feature = "_e2e_tests")]
+#[tokio::test(flavor = "multi_thread")]
+async fn run_upgrade_tests() {
+    let root_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Unable to find repo root"));
+    let manifest_dir = root_dir.join(MANIFESTS_PATH);
+    // NOTE(brooksmtownsend) reusing the e2e docker compose file for now but I'll only
+    // really be concerned with the application on a single host.
+    let compose_file = root_dir.join(DOCKER_COMPOSE_FILE);
+
+    let mut client_info = ClientInfo::new(manifest_dir, compose_file).await;
+    client_info.add_ctl_client("default", None).await;
+    client_info.launch_wadm().await;
+
+    // Wait for hosts to start
+    let mut did_start = false;
+    for _ in 0..10 {
+        match client_info.ctl_client("default").get_hosts().await {
+            Ok(hosts) if hosts.len() == 1 => {
+                did_start = true;
+                break;
+            }
+            Ok(hosts) => {
+                eprintln!(
+                    "Waiting for host to be available {}/1 currently available",
+                    hosts.len()
+                );
+            }
+            Err(e) => {
+                eprintln!("Error when fetching hosts: {e}",)
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    if !did_start {
+        panic!("Hosts didn't start")
+    }
+
+    test_upgrade(&client_info).boxed().await;
+}
+
+async fn test_upgrade(client_info: &ClientInfo) {
+    let stream = client_info.get_status_stream().await;
+    stream
+        .purge()
+        .await
+        .expect("shouldn't have errored purging stream");
+    let resp = client_info
+        .put_manifest_from_file("outdatedapp.yaml", None, None)
+        .await;
+
+    assert_ne!(
+        resp.result,
+        PutResult::Error,
+        "Shouldn't have errored when creating manifest: {resp:?}"
+    );
+
+    let resp = client_info
+        .deploy_manifest("updateapp", None, None, None)
+        .await;
+    assert_ne!(
+        resp.result,
+        DeployResult::Error,
+        "Shouldn't have errored when deploying manifest: {resp:?}"
+    );
+
+    // Once manifest is deployed, first status should be compensating
+    for _ in 0..5 {
+        if let Some(status) = get_manifest_status(&stream, "default", "updateapp").await {
+            assert_eq!(status.status_type, StatusType::Compensating);
+            break;
+        } else {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+
+    assert_status(None, Some(7), || async {
+        let inventory = client_info.get_all_inventory("default").await?;
+
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/xkcd:0.1.1",
+            "updateapp",
+            5,
+        )?;
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/echo:0.3.4",
+            "updateapp",
+            3,
+        )?;
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/kvcounter:0.4.0",
+            "updateapp",
+            3,
+        )?;
+        check_providers(
+            &inventory,
+            "wasmcloud.azurecr.io/httpserver:0.17.0",
+            ExpectedCount::Exactly(1),
+        )?;
+        check_providers(
+            &inventory,
+            "wasmcloud.azurecr.io/kvredis:0.22.0",
+            ExpectedCount::Exactly(1),
+        )?;
+        let links = client_info
+            .ctl_client("default")
+            .query_links()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+        if !links.links.iter().any(|ld| {
+            ld.actor_id == ECHO_ACTOR_ID
+                && ld.provider_id == HTTP_SERVER_PROVIDER_ID
+                && ld.contract_id == "wasmcloud:httpserver"
+                && ld
+                    .values
+                    .get("address")
+                    .map(|v| v == "0.0.0.0:8080")
+                    .expect("Linkdef values should have an address")
+        }) {
+            anyhow::bail!(
+                "Link between echo actor and http provider should exist: {:#?}",
+                links
+            )
+        }
+
+        if !links.links.iter().any(|ld| {
+            ld.actor_id == KV_COUNTER_ACTOR_ID
+                && ld.provider_id == KV_REDIS_PROVIDER_ID
+                && ld.contract_id == "wasmcloud:keyvalue"
+                && ld
+                    .values
+                    .get("URL")
+                    .map(|v| v == "redis://127.0.0.1:6379")
+                    .expect("Linkdef values should have a redis URL")
+        }) {
+            anyhow::bail!(
+                "Link between kvcounter actor and redis provider should exist: {:#?}",
+                links
+            )
+        }
+
+        // SAFETY: we already know some status existed when we checked for compensating. If there's no status now, it means
+        // we borked our stream and this _should_ fail
+        let status = get_manifest_status(&stream, "default", "updateapp")
+            .await
+            .unwrap();
+        assert_eq!(status.status_type, StatusType::Ready);
+
+        Ok(())
+    })
+    .await;
+
+    // Deploy updated manifest
+    let resp = client_info
+        .put_manifest_from_file("upgradedapp.yaml", None, None)
+        .await;
+
+    assert_ne!(
+        resp.result,
+        PutResult::Error,
+        "Shouldn't have errored when creating manifest: {resp:?}"
+    );
+
+    let resp = client_info
+        .deploy_manifest("updateapp", None, None, Some("v0.0.2"))
+        .await;
+    assert_ne!(
+        resp.result,
+        DeployResult::Error,
+        "Shouldn't have errored when deploying manifest: {resp:?}"
+    );
+
+    // Once manifest is updated, status should be compensating
+    for _ in 0..5 {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if let Some(status) = get_manifest_status(&stream, "default", "updateapp").await {
+            assert_eq!(status.status_type, StatusType::Compensating);
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            break;
+        }
+    }
+
+    assert_status(None, None, || async {
+        let inventory = client_info.get_all_inventory("default").await?;
+
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/xkcd:0.1.1",
+            "updateapp",
+            5,
+        )?;
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/message-pub:0.1.3",
+            "updateapp",
+            1,
+        )?;
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/echo:0.3.8",
+            "updateapp",
+            3,
+        )?;
+        check_actors(
+            &inventory,
+            "wasmcloud.azurecr.io/kvcounter:0.4.0",
+            "updateapp",
+            0,
+        )?;
+        check_providers(
+            &inventory,
+            "wasmcloud.azurecr.io/httpserver:0.19.0",
+            ExpectedCount::Exactly(1),
+        )?;
+        check_providers(
+            &inventory,
+            "wasmcloud.azurecr.io/kvredis:0.22.0",
+            ExpectedCount::Exactly(0),
+        )?;
+        let links = client_info
+            .ctl_client("default")
+            .query_links()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+        if !links.links.iter().any(|ld| {
+            ld.actor_id == ECHO_ACTOR_ID
+                && ld.provider_id == HTTP_SERVER_PROVIDER_ID
+                && ld.contract_id == "wasmcloud:httpserver"
+                && ld
+                    .values
+                    .get("address")
+                    .map(|v| v == "0.0.0.0:8082")
+                    .expect("Linkdef values should have an address")
+        }) {
+            anyhow::bail!(
+                "Link between echo actor and http provider should exist: {:#?}",
+                links
+            )
+        }
+
+        if links.links.iter().any(|ld| {
+            ld.actor_id == KV_COUNTER_ACTOR_ID
+                && ld.provider_id == KV_REDIS_PROVIDER_ID
+                && ld.contract_id == "wasmcloud:keyvalue"
+        }) {
+            anyhow::bail!(
+                "Link between kvcounter actor and redis provider should not exist: {:#?}",
+                links
+            )
+        }
+
+        let status = get_manifest_status(&stream, "default", "updateapp")
+            .await
+            .unwrap();
+
+        assert_eq!(status.status_type, StatusType::Ready);
+
+        Ok(())
+    })
+    .await;
+}


### PR DESCRIPTION
## Feature or Problem
This PR changes the manifest deployment logic to look at old scaler components, compare them to new components, and cleanup the resources if the components no longer exist. Refer to the example in #145 for when this is appropriate.

This PR also (in the second commit) implements version upgrades by considering Actor and Provider spreadscalers meaningfully different if their image reference is different. Doing this upgrade properly _does_ seem to depend on a short delay between cleaning up old resources and starting new ones, and before this PR is accepted I'd like to resolve that instead of sleeping. Ideally, I would like to proceed with reconciliation immediately and _only_ reconcile commands for scalers that are completely new, allowing scalers to instead launch new resources based off of the events from the old resources stopping. I'm 80% confident that this will work as intended, and I'm pretty sure the only thing preventing this from working at the time of writing this is the fact that scalers don't know those events are for the resources that are stopping 🤔 

NOTE: Link definition upgrades work _only_ if the actor or provider reference changes because of the ID structure. I don't want to encode each and every value into the linkdef scaler ID, but maybe I'll have to 🤔 

## Related Issues
Fixes #145 
Fixes #143 

## Release Information
v0.5.0 / v0.5.0-alpha.4

## Consumer Impact
If consumers expected old resources to stick around with new manifest versions, they will now be cleaned up.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually verified this works
