### PR TITLE
add certs back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim AS base
 
-RUN update-ca-certificates
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y ca-certificates
 
 FROM base AS base-amd64
 ARG BIN_AMD64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye-slim AS base
 
+RUN update-ca-certificates
+
 FROM base AS base-amd64
 ARG BIN_AMD64
 ARG BIN=$BIN_AMD64


### PR DESCRIPTION
## Feature or Problem
Need to run CA Certs update for wadm to work with NGS

I dont have docker on this machine, so im letting CI sanity check it