### PR TITLE
feat(status): Fully compute status when publishing status updates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
         e2e_test: [e2e_multiple_hosts, e2e_multitenant, e2e_upgrades]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install latest Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         nats_version: [2.9.15]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install latest Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -62,6 +62,7 @@ where
     }
 
     async fn status(&self) -> StatusInfo {
+        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -58,6 +58,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
     }
 
     async fn status(&self) -> StatusInfo {
+        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -61,6 +61,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
     }
 
     async fn status(&self) -> StatusInfo {
+        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -187,7 +187,7 @@ pub struct TraitStatus {
 }
 
 /// Common high-level status information
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct StatusInfo {
     #[serde(rename = "type")]
     pub status_type: StatusType,


### PR DESCRIPTION
Fixes https://github.com/wasmCloud/wadm/issues/149


This PR is a simplification of the status algorithm which should make manifest statuses more consistently correct. Essentially, when an event gets handled by a set of scalers, it follows this flow:
![image](https://github.com/wasmCloud/wadm/assets/12040685/69000b88-daed-4e54-abcf-55a725c4213e)

This is a little less efficient in terms of calculating the exact status of an individual scaler and publishing updates based on that, but it's simple for now and we can improve the algorithm as we see a good opportunity to do so. If you only ever ran one wadm instance this PR wouldn't be necessary, but as you can see from our e2e tests it results in a lot of flakiness when running multiple instances. Storing an internal property of `status` in a scaler works nice as long as that scaler is handling all of the relevant events, which when running multiple instances that is not guaranteed.

I am unable to make e2e tests fail locally because of statuses using this code. Very occasionally I believe an issue with storing the heartbeat will cause a leftover link definition, actor, or provider, but that's not related to this PR.