### PR TITLE
Add Actor and Provider Daemonscalers

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -24,6 +24,8 @@ pub const VERSION_ANNOTATION_KEY: &str = "version";
 pub const DESCRIPTION_ANNOTATION_KEY: &str = "description";
 /// The identifier for the builtin spreadscaler trait type
 pub const SPREADSCALER_TRAIT: &str = "spreadscaler";
+/// The identifier for the builtin daemonscaler trait type
+pub const DAEMONSCALER_TRAIT: &str = "daemonscaler";
 /// The identifier for the builtin linkdef trait type
 pub const LINKDEF_TRAIT: &str = "linkdef";
 /// The string used for indicating a latest version. It is explicitly forbidden to use as a version
@@ -204,6 +206,13 @@ impl Trait {
     pub fn new_spreadscaler(props: SpreadScalerProperty) -> Trait {
         Trait {
             trait_type: SPREADSCALER_TRAIT.to_owned(),
+            properties: TraitProperty::SpreadScaler(props),
+        }
+    }
+
+    pub fn new_daemonscaler(props: SpreadScalerProperty) -> Trait {
+        Trait {
+            trait_type: DAEMONSCALER_TRAIT.to_owned(),
             properties: TraitProperty::SpreadScaler(props),
         }
     }

--- a/src/scaler/daemonscaler/mod.rs
+++ b/src/scaler/daemonscaler/mod.rs
@@ -1,0 +1,1041 @@
+use std::cmp::Ordering;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::{OnceCell, RwLock};
+use tracing::{instrument, trace};
+
+use crate::events::HostHeartbeat;
+use crate::model::Spread;
+use crate::scaler::spreadscaler::{eligible_hosts, spreadscaler_annotations};
+use crate::server::StatusInfo;
+use crate::{
+    commands::{Command, StartActor, StopActor},
+    events::{Event, HostStarted, HostStopped},
+    model::{SpreadScalerProperty, TraitProperty},
+    scaler::Scaler,
+    storage::{Actor, Host, ReadStore},
+};
+
+// pub mod provider;
+
+// Annotation constants
+pub const ACTOR_DAEMON_SCALER_TYPE: &str = "actordaemonscaler";
+
+/// Config for an ActorDaemonScaler
+#[derive(Clone, Debug)]
+struct ActorSpreadConfig {
+    /// OCI, Bindle, or File reference for an actor
+    actor_reference: String,
+    /// Lattice ID that this DaemonScaler monitors
+    lattice_id: String,
+    /// The name of the wadm model this DaemonScaler is under
+    model_name: String,
+    /// Configuration for this DaemonScaler
+    spread_config: SpreadScalerProperty,
+}
+
+/// The ActorDaemonScaler ensures that a certain number of replicas are running on every host, according to a
+/// [SpreadScalerProperty](crate::model::SpreadScalerProperty)
+///
+/// If no [Spreads](crate::model::Spread) are specified, this Scaler simply maintains the number of replicas
+/// on every available host.
+pub struct ActorDaemonScaler<S> {
+    config: ActorSpreadConfig,
+    actor_id: OnceCell<String>,
+    store: S,
+    id: String,
+    status: RwLock<StatusInfo>,
+}
+
+#[async_trait]
+impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorDaemonScaler<S> {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn status(&self) -> StatusInfo {
+        let _ = self.reconcile().await;
+        self.status.read().await.to_owned()
+    }
+
+    async fn update_config(&mut self, config: TraitProperty) -> Result<Vec<Command>> {
+        let spread_config = match config {
+            TraitProperty::SpreadScaler(prop) => prop,
+            _ => anyhow::bail!("Given config was not a daemon scaler config object"),
+        };
+        // If no spreads are specified, an empty spread is sufficient to match _every_ host
+        // in a lattice
+        let spread_config = if spread_config.spread.is_empty() {
+            SpreadScalerProperty {
+                replicas: spread_config.replicas,
+                spread: vec![Spread::default()],
+            }
+        } else {
+            spread_config
+        };
+        self.config.spread_config = spread_config;
+        self.reconcile().await
+    }
+
+    #[instrument(level = "trace", skip_all, fields(scaler_id = %self.id))]
+    async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
+        // NOTE(brooksmtownsend): We could be more efficient here and instead of running
+        // the entire reconcile, smart compute exactly what needs to change, but it just
+        // requires more code branches and would be fine as a future improvement
+        match event {
+            Event::ActorsStarted(actor_started) => {
+                if actor_started.image_ref == self.config.actor_reference {
+                    trace!(image_ref = %actor_started.image_ref, "Found image we care about");
+                    self.reconcile().await
+                } else {
+                    Ok(Vec::new())
+                }
+            }
+            Event::ActorsStopped(actor_stopped) => {
+                let actor_id = self.actor_id().await?;
+                if actor_stopped.public_key == actor_id {
+                    trace!(%actor_id, "Found actor we care about");
+                    self.reconcile().await
+                } else {
+                    Ok(Vec::new())
+                }
+            }
+            Event::HostStopped(HostStopped { labels, .. })
+            | Event::HostStarted(HostStarted { labels, .. })
+            | Event::HostHeartbeat(HostHeartbeat { labels, .. }) => {
+                // If the host labels match any spread requirement, perform reconcile
+                if self.config.spread_config.spread.iter().any(|spread| {
+                    spread.requirements.iter().all(|(key, value)| {
+                        labels.get(key).map(|val| val == value).unwrap_or(false)
+                    })
+                }) {
+                    trace!("Host event matches spread requirements. Will reconcile");
+                    self.reconcile().await
+                } else {
+                    Ok(Vec::new())
+                }
+            }
+            // No other event impacts the job of this scaler so we can ignore it
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name, scaler_id = %self.id))]
+    async fn reconcile(&self) -> Result<Vec<Command>> {
+        let hosts = self.store.list::<Host>(&self.config.lattice_id).await?;
+
+        let actor = if let Ok(id) = self.actor_id().await {
+            self.store.get::<Actor>(&self.config.lattice_id, id).await?
+        } else {
+            // If this is the first time we have ever loaded the actor, there won't be a way to get
+            // the ID, so an error will occur. We can just return None and let the scaler try to
+            // start stuff
+            None
+        };
+
+        let actor_id = actor.as_ref().map(|actor| actor.id.as_str());
+
+        let mut spread_status = vec![];
+
+        trace!(spread = ?self.config.spread_config.spread, ?actor_id, "Computing commands");
+        let commands = self
+            .config
+            .spread_config
+            .spread
+            .iter()
+            .filter_map(|spread| {
+                let eligible_hosts = eligible_hosts(&hosts, spread);
+                if !eligible_hosts.is_empty() {
+                    // Create a list of (host_id, current_count) tuples
+                    // current_count is the number of actor instances that are running for this spread on this host
+                    let actors_per_host = eligible_hosts
+                        .into_keys()
+                        .map(|id| {
+                            let count = actor
+                                .as_ref()
+                                .and_then(|actor| {
+                                    actor.instances.get(&id.to_string()).map(|instances| {
+                                        instances
+                                            .iter()
+                                            .filter(|instance| {
+                                                spreadscaler_annotations(&spread.name, self.id())
+                                                    .iter()
+                                                    .all(|(key, value)| {
+                                                        instance
+                                                            .annotations
+                                                            .get(key)
+                                                            .map(|v| v == value)
+                                                            .unwrap_or(false)
+                                                    })
+                                            })
+                                            .count()
+                                    })
+                                })
+                                .unwrap_or(0);
+                            (id, count)
+                        })
+                        .collect::<Vec<(&String, usize)>>();
+
+                    Some(
+                        actors_per_host
+                            .iter()
+                            .filter_map(|(host_id, current_count)| {
+                                println!(
+                                    "Calculated running actors, reconciling with expected count"
+                                );
+                                // Here we'll generate commands for the proper host depending on where they are running
+                                match current_count.cmp(&self.config.spread_config.replicas) {
+                                    Ordering::Equal => None,
+                                    // Start actors to reach desired replicas
+                                    Ordering::Less => {
+                                        // Right now just start on the first available host. We can be smarter about it later
+                                        Some(Command::StartActor(StartActor {
+                                            reference: self.config.actor_reference.to_owned(),
+                                            host_id: host_id.to_string(),
+                                            count: self.config.spread_config.replicas
+                                                - current_count,
+                                            model_name: self.config.model_name.to_owned(),
+                                            annotations: spreadscaler_annotations(
+                                                &spread.name,
+                                                self.id(),
+                                            ),
+                                        }))
+                                    }
+                                    // Stop actors to reach desired replicas
+                                    Ordering::Greater => Some(Command::StopActor(StopActor {
+                                        actor_id: actor_id.unwrap_or_default().to_owned(),
+                                        host_id: host_id.to_string(),
+                                        count: current_count - self.config.spread_config.replicas,
+                                        model_name: self.config.model_name.to_owned(),
+                                        annotations: spreadscaler_annotations(
+                                            &spread.name,
+                                            self.id(),
+                                        ),
+                                    })),
+                                }
+                            })
+                            .collect::<Vec<Command>>(),
+                    )
+                } else {
+                    // No hosts were eligible, so we can't attempt to add or remove actors
+                    trace!(?spread.name, "Found no eligible hosts for daemon scaler");
+                    spread_status.push(StatusInfo::failed(&format!(
+                        "Could not satisfy daemonscaler {} for {}, 0 eligible hosts found.",
+                        spread.name, self.config.actor_reference
+                    )));
+                    None
+                }
+            })
+            .flatten()
+            .collect::<Vec<Command>>();
+        trace!(?commands, "Calculated commands for actor daemon scaler");
+
+        let status = match (spread_status.is_empty(), commands.is_empty()) {
+            (true, true) => StatusInfo::ready(""),
+            (_, false) => StatusInfo::compensating(""),
+            (false, true) => StatusInfo::failed(
+                &spread_status
+                    .into_iter()
+                    .map(|s| s.message)
+                    .collect::<Vec<String>>()
+                    .join(" "),
+            ),
+        };
+        trace!(?status, "Updating scaler status");
+        *self.status.write().await = status;
+
+        Ok(commands)
+    }
+
+    #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name))]
+    async fn cleanup(&self) -> Result<Vec<Command>> {
+        let mut config_clone = self.config.clone();
+        config_clone.spread_config.replicas = 0;
+
+        let cleanerupper = ActorDaemonScaler {
+            config: config_clone,
+            store: self.store.clone(),
+            actor_id: self.actor_id.clone(),
+            id: self.id.clone(),
+            status: RwLock::new(StatusInfo::compensating("")),
+        };
+
+        cleanerupper.reconcile().await
+    }
+}
+
+impl<S: ReadStore + Send + Sync> ActorDaemonScaler<S> {
+    /// Construct a new ActorDaemonScaler with specified configuration values
+    pub fn new(
+        store: S,
+        actor_reference: String,
+        lattice_id: String,
+        model_name: String,
+        spread_config: SpreadScalerProperty,
+        component_name: &str,
+    ) -> Self {
+        let id =
+            format!("{ACTOR_DAEMON_SCALER_TYPE}-{model_name}-{component_name}-{actor_reference}");
+        // If no spreads are specified, an empty spread is sufficient to match _every_ host
+        // in a lattice
+        let spread_config = if spread_config.spread.is_empty() {
+            SpreadScalerProperty {
+                replicas: spread_config.replicas,
+                spread: vec![Spread::default()],
+            }
+        } else {
+            spread_config
+        };
+        Self {
+            store,
+            actor_id: OnceCell::new(),
+            config: ActorSpreadConfig {
+                actor_reference,
+                lattice_id,
+                spread_config,
+                model_name,
+            },
+            id,
+            status: RwLock::new(StatusInfo::compensating("")),
+        }
+    }
+
+    /// Helper function to retrieve the actor ID for the configured actor
+    async fn actor_id(&self) -> Result<&str> {
+        self.actor_id
+            .get_or_try_init(|| async {
+                self.store
+                    .list::<Actor>(&self.config.lattice_id)
+                    .await?
+                    .iter()
+                    .find(|(_id, actor)| actor.reference == self.config.actor_reference)
+                    .map(|(id, _actor)| id.to_owned())
+                    // Default here means the below `get` will find zero running actors, which is fine because
+                    // that accurately describes the current lattice having zero instances.
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Couldn't find an actor id for the actor reference {}",
+                            self.config.actor_reference
+                        )
+                    })
+            })
+            .await
+            .map(|id| id.as_str())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use anyhow::Result;
+    use chrono::Utc;
+    use wasmcloud_control_interface::HostInventory;
+
+    use crate::{
+        commands::{Command, StartActor},
+        consumers::{manager::Worker, ScopedMessage},
+        events::{
+            Event, Linkdef, LinkdefDeleted, LinkdefSet, ProviderClaims, ProviderStarted,
+            ProviderStopped,
+        },
+        model::{Spread, SpreadScalerProperty},
+        scaler::{daemonscaler::ActorDaemonScaler, manager::ScalerManager, Scaler},
+        server::StatusType,
+        storage::{Actor, Host, Store, WadmActorInstance},
+        test_util::{NoopPublisher, TestLatticeSource, TestStore},
+        workers::{CommandPublisher, EventWorker, StatusPublisher},
+    };
+
+    const MODEL_NAME: &str = "daemonscaler_test";
+
+    #[tokio::test]
+    async fn can_compute_spread_commands() -> Result<()> {
+        let lattice_id = "one_host";
+        let actor_reference = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let host_id = "NASDASDIMAREALHOST";
+
+        let store = Arc::new(TestStore::default());
+
+        // STATE SETUP BEGIN, ONE HOST
+        store
+            .store(
+                lattice_id,
+                host_id.to_string(),
+                Host {
+                    actors: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::new(),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // Daemonscalers ignore weight, so it should have no bearing
+        let complex_spread = SpreadScalerProperty {
+            replicas: 13,
+            spread: vec![
+                Spread {
+                    name: "ComplexOne".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(42),
+                },
+                Spread {
+                    name: "ComplexTwo".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(3),
+                },
+                Spread {
+                    name: "ComplexThree".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(37),
+                },
+                Spread {
+                    name: "ComplexFour".to_string(),
+                    requirements: BTreeMap::new(),
+                    weight: Some(384),
+                },
+            ],
+        };
+
+        let daemonscaler = ActorDaemonScaler::new(
+            store.clone(),
+            actor_reference.to_string(),
+            lattice_id.to_string(),
+            MODEL_NAME.to_string(),
+            complex_spread,
+            "fake_component",
+        );
+
+        let cmds = daemonscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 4);
+        assert!(cmds.contains(&Command::StartActor(StartActor {
+            reference: actor_reference.to_string(),
+            host_id: host_id.to_string(),
+            count: 13,
+            model_name: MODEL_NAME.to_string(),
+            annotations: spreadscaler_annotations("ComplexOne", daemonscaler.id())
+        })));
+        assert!(cmds.contains(&Command::StartActor(StartActor {
+            reference: actor_reference.to_string(),
+            host_id: host_id.to_string(),
+            count: 13,
+            model_name: MODEL_NAME.to_string(),
+            annotations: spreadscaler_annotations("ComplexTwo", daemonscaler.id())
+        })));
+        assert!(cmds.contains(&Command::StartActor(StartActor {
+            reference: actor_reference.to_string(),
+            host_id: host_id.to_string(),
+            count: 13,
+            model_name: MODEL_NAME.to_string(),
+            annotations: spreadscaler_annotations("ComplexThree", daemonscaler.id())
+        })));
+        assert!(cmds.contains(&Command::StartActor(StartActor {
+            reference: actor_reference.to_string(),
+            host_id: host_id.to_string(),
+            count: 13,
+            model_name: MODEL_NAME.to_string(),
+            annotations: spreadscaler_annotations("ComplexFour", daemonscaler.id())
+        })));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_scale_up_and_down() -> Result<()> {
+        let lattice_id = "computing_spread_commands";
+        let echo_ref = "fakecloud.azurecr.io/echo:0.3.4".to_string();
+        let echo_id = "MASDASDIAMAREALACTORECHO";
+        let blobby_ref = "fakecloud.azurecr.io/blobby:0.5.2".to_string();
+        let blobby_id = "MASDASDIAMAREALACTORBLOBBY";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+        let host_id_three = "NASDASDIMAREALHOSTTREE";
+
+        let store = Arc::new(TestStore::default());
+
+        let echo_spread_property = SpreadScalerProperty {
+            replicas: 412,
+            spread: vec![
+                Spread {
+                    name: "RunInFakeCloud".to_string(),
+                    requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                    weight: None,
+                },
+                Spread {
+                    name: "RunInRealCloud".to_string(),
+                    requirements: BTreeMap::from_iter([("cloud".to_string(), "real".to_string())]),
+                    weight: None,
+                },
+                Spread {
+                    name: "RunInPurgatoryCloud".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "cloud".to_string(),
+                        "purgatory".to_string(),
+                    )]),
+                    weight: None,
+                },
+            ],
+        };
+
+        let blobby_spread_property = SpreadScalerProperty {
+            replicas: 3,
+            spread: vec![
+                Spread {
+                    name: "CrossRegionCustom".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "region".to_string(),
+                        "us-brooks-1".to_string(),
+                    )]),
+                    weight: Some(123123),
+                },
+                Spread {
+                    name: "CrossRegionReal".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "region".to_string(),
+                        "us-midwest-4".to_string(),
+                    )]),
+                    weight: None,
+                },
+                Spread {
+                    name: "RunOnEdge".to_string(),
+                    requirements: BTreeMap::from_iter([(
+                        "location".to_string(),
+                        "edge".to_string(),
+                    )]),
+                    weight: Some(33),
+                },
+            ],
+        };
+
+        let echo_daemonscaler = ActorDaemonScaler::new(
+            store.clone(),
+            echo_ref.to_string(),
+            lattice_id.to_string(),
+            MODEL_NAME.to_string(),
+            echo_spread_property,
+            "fake_echo",
+        );
+
+        let blobby_daemonscaler = ActorDaemonScaler::new(
+            store.clone(),
+            blobby_ref.to_string(),
+            lattice_id.to_string(),
+            MODEL_NAME.to_string(),
+            blobby_spread_property,
+            "fake_blobby",
+        );
+
+        // STATE SETUP BEGIN
+
+        store
+            .store(
+                lattice_id,
+                echo_id.to_string(),
+                Actor {
+                    id: echo_id.to_string(),
+                    name: "Echo".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    instances: HashMap::from_iter([
+                        (
+                            host_id_one.to_string(),
+                            // One instance on this host
+                            HashSet::from_iter([WadmActorInstance {
+                                instance_id: "1".to_string(),
+                                annotations: spreadscaler_annotations(
+                                    "RunInFakeCloud",
+                                    echo_daemonscaler.id(),
+                                ),
+                            }]),
+                        ),
+                        (
+                            host_id_two.to_string(),
+                            // 103 instances on this host
+                            HashSet::from_iter((2..105).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "RunInRealCloud",
+                                    echo_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                        (
+                            host_id_three.to_string(),
+                            // 400 instances on this host
+                            HashSet::from_iter((105..505).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "RunInPurgatoryCloud",
+                                    echo_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                    ]),
+                    reference: echo_ref.to_string(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                blobby_id.to_string(),
+                Actor {
+                    id: blobby_id.to_string(),
+                    name: "Blobby".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    instances: HashMap::from_iter([
+                        (
+                            host_id_one.to_string(),
+                            // 3 instances on this host
+                            HashSet::from_iter((0..3).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "CrossRegionCustom",
+                                    blobby_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                        (
+                            host_id_two.to_string(),
+                            // 19 instances on this host
+                            HashSet::from_iter((3..22).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "CrossRegionReal",
+                                    blobby_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                    ]),
+                    reference: blobby_ref.to_string(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    actors: HashMap::from_iter([
+                        (echo_id.to_string(), 1),
+                        (blobby_id.to_string(), 3),
+                        ("MSOMEOTHERACTOR".to_string(), 3),
+                    ]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-brooks-1".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    actors: HashMap::from_iter([
+                        (echo_id.to_string(), 103),
+                        (blobby_id.to_string(), 19),
+                    ]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "real".to_string()),
+                        ("region".to_string(), "us-midwest-4".to_string()),
+                        ("label".to_string(), "value".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_three.to_string(),
+                Host {
+                    actors: HashMap::from_iter([(echo_id.to_string(), 400)]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "purgatory".to_string()),
+                        ("location".to_string(), "edge".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_three.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // STATE SETUP END
+
+        let cmds = echo_daemonscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 3);
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    if start.host_id == host_id_one.to_string() {
+                        assert_eq!(start.count, 411);
+                        assert_eq!(start.reference, echo_ref);
+                    } else if start.host_id == host_id_two.to_string() {
+                        assert_eq!(start.count, 309);
+                        assert_eq!(start.reference, echo_ref);
+                    } else {
+                        assert_eq!(start.count, 12);
+                        assert_eq!(start.reference, echo_ref);
+                    }
+                }
+                _ => panic!("Unexpected command in daemonscaler list"),
+            }
+        }
+
+        let cmds = blobby_daemonscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 2);
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    assert_eq!(start.host_id, host_id_three.to_string());
+                    assert_eq!(start.count, 3);
+                    assert_eq!(start.reference, blobby_ref);
+                }
+                Command::StopActor(stop) => {
+                    assert_eq!(stop.host_id, host_id_two.to_string());
+                    assert_eq!(stop.count, 16);
+                    assert_eq!(stop.actor_id, blobby_id);
+                }
+                _ => panic!("Unexpected command in daemonscaler list"),
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_react_to_host_events() -> Result<()> {
+        let lattice_id = "computing_spread_commands";
+        let blobby_ref = "fakecloud.azurecr.io/blobby:0.5.2".to_string();
+        let blobby_id = "MASDASDIAMAREALACTORBLOBBY";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+        let host_id_three = "NASDASDIMAREALHOSTTREE";
+
+        let store = Arc::new(TestStore::default());
+
+        let lattice_source = TestLatticeSource::default();
+        // Inserting for heartbeat handling later
+        lattice_source.inventory.write().await.insert(
+            host_id_three.to_string(),
+            HostInventory {
+                actors: vec![],
+                friendly_name: "hey".to_string(),
+                labels: HashMap::from_iter([
+                    ("cloud".to_string(), "purgatory".to_string()),
+                    ("location".to_string(), "edge".to_string()),
+                    ("region".to_string(), "us-brooks-1".to_string()),
+                ]),
+                providers: vec![],
+                host_id: host_id_three.to_string(),
+                issuer: "NASDASD".to_string(),
+            },
+        );
+        let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let worker = EventWorker::new(
+            store.clone(),
+            lattice_source.clone(),
+            command_publisher.clone(),
+            status_publisher.clone(),
+            ScalerManager::test_new(
+                NoopPublisher,
+                lattice_id,
+                store.clone(),
+                command_publisher,
+                lattice_source,
+            )
+            .await,
+        );
+        let blobby_spread_property = SpreadScalerProperty {
+            replicas: 10,
+            spread: vec![Spread {
+                name: "HighAvailability".to_string(),
+                requirements: BTreeMap::from_iter([(
+                    "region".to_string(),
+                    "us-brooks-1".to_string(),
+                )]),
+                weight: None,
+            }],
+        };
+        let blobby_daemonscaler = ActorDaemonScaler::new(
+            store.clone(),
+            blobby_ref.to_string(),
+            lattice_id.to_string(),
+            MODEL_NAME.to_string(),
+            blobby_spread_property,
+            "fake_blobby",
+        );
+
+        // STATE SETUP BEGIN
+        store
+            .store(
+                lattice_id,
+                blobby_id.to_string(),
+                Actor {
+                    id: blobby_id.to_string(),
+                    name: "Blobby".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    instances: HashMap::from_iter([
+                        (
+                            host_id_one.to_string(),
+                            // 10 instances on this host
+                            HashSet::from_iter((0..10).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "HighAvailability",
+                                    blobby_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                        (
+                            host_id_two.to_string(),
+                            // 10 instances on this host
+                            HashSet::from_iter((10..20).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "HighAvailability",
+                                    blobby_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                        (
+                            host_id_three.to_string(),
+                            // 0 instances on this host
+                            HashSet::new(),
+                        ),
+                    ]),
+                    reference: blobby_ref.to_string(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    actors: HashMap::from_iter([
+                        (blobby_id.to_string(), 10),
+                        ("MSOMEOTHERACTOR".to_string(), 3),
+                    ]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-brooks-1".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    actors: HashMap::from_iter([(blobby_id.to_string(), 10)]),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "real".to_string()),
+                        ("region".to_string(), "us-brooks-1".to_string()),
+                        ("label".to_string(), "value".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // Don't care about these events
+        assert!(blobby_daemonscaler
+            .handle_event(&Event::ProviderStarted(ProviderStarted {
+                annotations: HashMap::new(),
+                claims: ProviderClaims::default(),
+                contract_id: "".to_string(),
+                image_ref: "".to_string(),
+                instance_id: "".to_string(),
+                link_name: "".to_string(),
+                public_key: "".to_string(),
+                host_id: host_id_one.to_string()
+            }))
+            .await?
+            .is_empty());
+        assert!(blobby_daemonscaler
+            .handle_event(&Event::ProviderStopped(ProviderStopped {
+                annotations: HashMap::default(),
+                contract_id: "".to_string(),
+                instance_id: "".to_string(),
+                link_name: "".to_string(),
+                public_key: "".to_string(),
+                reason: "".to_string(),
+                host_id: host_id_two.to_string()
+            }))
+            .await?
+            .is_empty());
+        assert!(blobby_daemonscaler
+            .handle_event(&Event::LinkdefSet(LinkdefSet {
+                linkdef: Linkdef::default()
+            }))
+            .await?
+            .is_empty());
+        assert!(blobby_daemonscaler
+            .handle_event(&Event::LinkdefDeleted(LinkdefDeleted {
+                linkdef: Linkdef::default()
+            }))
+            .await?
+            .is_empty());
+
+        // Let a new host come online, should match the spread
+        let modifying_event = HostHeartbeat {
+            actors: HashMap::new(),
+            friendly_name: "hey".to_string(),
+            labels: HashMap::from_iter([
+                ("cloud".to_string(), "purgatory".to_string()),
+                ("location".to_string(), "edge".to_string()),
+                ("region".to_string(), "us-brooks-1".to_string()),
+            ]),
+            annotations: HashMap::new(),
+            providers: vec![],
+            uptime_seconds: 123,
+            version: semver::Version::new(0, 63, 1),
+            id: host_id_three.to_string(),
+            uptime_human: "time_is_a_human_construct".to_string(),
+        };
+
+        worker
+            .do_work(ScopedMessage::<Event> {
+                lattice_id: lattice_id.to_string(),
+                inner: Event::HostHeartbeat(modifying_event.clone()),
+                acker: None,
+            })
+            .await
+            .expect("should be able to handle an event");
+
+        let cmds = blobby_daemonscaler
+            .handle_event(&Event::HostHeartbeat(modifying_event))
+            .await?;
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(
+            blobby_daemonscaler.status().await.status_type,
+            StatusType::Compensating
+        );
+
+        for cmd in cmds.iter() {
+            match cmd {
+                Command::StartActor(start) => {
+                    assert_eq!(start.host_id, host_id_three.to_string());
+                    assert_eq!(start.count, 10);
+                    assert_eq!(start.reference, blobby_ref);
+                }
+                _ => panic!("Unexpected command in daemonscaler list"),
+            }
+        }
+
+        // Remove the host, blobby shouldn't be concerned as other hosts match
+        store
+            .delete_many::<Host, _, _>(lattice_id, vec![host_id_three])
+            .await?;
+        store
+            .store(
+                lattice_id,
+                blobby_id.to_string(),
+                Actor {
+                    id: blobby_id.to_string(),
+                    name: "Blobby".to_string(),
+                    capabilities: vec![],
+                    issuer: "AASDASDASDASD".to_string(),
+                    call_alias: None,
+                    instances: HashMap::from_iter([
+                        (
+                            host_id_one.to_string(),
+                            // 10 instances on this host
+                            HashSet::from_iter((0..10).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "HighAvailability",
+                                    blobby_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                        (
+                            host_id_two.to_string(),
+                            // 10 instances on this host
+                            HashSet::from_iter((10..20).map(|n| WadmActorInstance {
+                                instance_id: format!("{n}"),
+                                annotations: spreadscaler_annotations(
+                                    "HighAvailability",
+                                    blobby_daemonscaler.id(),
+                                ),
+                            })),
+                        ),
+                    ]),
+                    reference: blobby_ref.to_string(),
+                },
+            )
+            .await?;
+        let cmds = blobby_daemonscaler.reconcile().await?;
+        assert_eq!(cmds.len(), 0);
+
+        assert_eq!(
+            blobby_daemonscaler.status().await.status_type,
+            StatusType::Ready
+        );
+
+        Ok(())
+    }
+}

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -1,0 +1,440 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::{OnceCell, RwLock};
+use tracing::{instrument, trace};
+
+use crate::commands::StopProvider;
+use crate::events::{HostHeartbeat, ProviderInfo};
+use crate::model::Spread;
+use crate::scaler::spreadscaler::provider::ProviderSpreadConfig;
+use crate::scaler::spreadscaler::{eligible_hosts, spreadscaler_annotations};
+use crate::server::StatusInfo;
+use crate::storage::Provider;
+use crate::{
+    commands::{Command, StartProvider},
+    events::{Event, HostStarted, HostStopped},
+    model::{SpreadScalerProperty, TraitProperty},
+    scaler::Scaler,
+    storage::{Host, ReadStore},
+};
+
+// Annotation constants
+pub const PROVIDER_DAEMON_SCALER_TYPE: &str = "providerdaemonscaler";
+
+/// The ProviderDaemonScaler ensures that a provider is running on every host, according to a
+/// [SpreadScalerProperty](crate::model::SpreadScalerProperty)
+///
+/// If no [Spreads](crate::model::Spread) are specified, this Scaler simply maintains the number of replicas
+/// on every available host.
+pub struct ProviderDaemonScaler<S> {
+    config: ProviderSpreadConfig,
+    provider_id: OnceCell<String>,
+    store: S,
+    id: String,
+    status: RwLock<StatusInfo>,
+}
+
+#[async_trait]
+impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn status(&self) -> StatusInfo {
+        let _ = self.reconcile().await;
+        self.status.read().await.to_owned()
+    }
+
+    async fn update_config(&mut self, config: TraitProperty) -> Result<Vec<Command>> {
+        let spread_config = match config {
+            TraitProperty::SpreadScaler(prop) => prop,
+            _ => anyhow::bail!("Given config was not a daemon scaler config object"),
+        };
+        // If no spreads are specified, an empty spread is sufficient to match _every_ host
+        // in a lattice
+        let spread_config = if spread_config.spread.is_empty() {
+            SpreadScalerProperty {
+                replicas: spread_config.replicas,
+                spread: vec![Spread::default()],
+            }
+        } else {
+            spread_config
+        };
+        self.config.spread_config = spread_config;
+        self.reconcile().await
+    }
+
+    #[instrument(level = "trace", skip_all, fields(scaler_id = %self.id))]
+    async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
+        // NOTE(brooksmtownsend): We could be more efficient here and instead of running
+        // the entire reconcile, smart compute exactly what needs to change, but it just
+        // requires more code branches and would be fine as a future improvement
+        match event {
+            Event::ProviderStarted(provider_started)
+                if provider_started.contract_id == self.config.provider_contract_id
+                    && provider_started.image_ref == self.config.provider_reference
+                    && provider_started.link_name == self.config.provider_link_name =>
+            {
+                self.reconcile().await
+            }
+            Event::ProviderStopped(provider_stopped)
+                if provider_stopped.contract_id == self.config.provider_contract_id
+                    && provider_stopped.link_name == self.config.provider_link_name
+                    // If this is None, provider hasn't been started in the lattice yet, so we don't need to reconcile
+                    && self.provider_id().await.map(|id| id == provider_stopped.public_key).unwrap_or(false) =>
+            {
+                self.reconcile().await
+            }
+            // If the host labels match any spread requirement, perform reconcile
+            Event::HostStopped(HostStopped { labels, .. })
+            | Event::HostStarted(HostStarted { labels, .. })
+            | Event::HostHeartbeat(HostHeartbeat { labels, .. })
+                if self.config.spread_config.spread.iter().any(|spread| {
+                    spread.requirements.iter().all(|(key, value)| {
+                        labels.get(key).map(|val| val == value).unwrap_or(false)
+                    })
+                }) =>
+            {
+                self.reconcile().await
+            }
+            // No other event impacts the job of this scaler so we can ignore it
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name, scaler_id = %self.id))]
+    async fn reconcile(&self) -> Result<Vec<Command>> {
+        let hosts = self.store.list::<Host>(&self.config.lattice_id).await?;
+
+        let provider_id = self.provider_id().await.unwrap_or_default();
+        let contract_id = &self.config.provider_contract_id;
+        let link_name = &self.config.provider_link_name;
+        let provider_ref = &self.config.provider_reference;
+
+        let mut spread_status = vec![];
+
+        trace!(spread = ?self.config.spread_config.spread, ?provider_id, "Computing commands");
+        let commands = self
+            .config
+            .spread_config
+            .spread
+            .iter()
+            .flat_map(|spread| {
+                let eligible_hosts = eligible_hosts(&hosts, spread);
+                if !eligible_hosts.is_empty() {
+                    eligible_hosts
+                        .iter()
+                        // Filter out hosts that are already running this provider
+                        .filter_map(|(_host_id, host)| {
+                            let provider_on_host = host.providers.get(&ProviderInfo {
+                                contract_id: contract_id.to_string(),
+                                link_name: link_name.to_string(),
+                                public_key: provider_id.to_string(),
+                                annotations: HashMap::default(),
+                            });
+                            match (provider_on_host, self.config.spread_config.replicas) {
+                                // Spread replicas set to 0 means we're cleaning up and should stop
+                                // running providers
+                                (Some(_), 0) => Some(Command::StopProvider(StopProvider {
+                                    provider_id: provider_id.to_owned(),
+                                    host_id: host.id.to_string(),
+                                    link_name: Some(self.config.provider_link_name.to_owned()),
+                                    contract_id: self.config.provider_contract_id.to_owned(),
+                                    model_name: self.config.model_name.to_owned(),
+                                    annotations: spreadscaler_annotations(&spread.name, &self.id),
+                                })),
+                                // Whenever replicas > 0, we should start a provider if it's not already running
+                                (None, _n) => Some(Command::StartProvider(StartProvider {
+                                    reference: provider_ref.to_owned(),
+                                    host_id: host.id.to_string(),
+                                    link_name: Some(link_name.to_owned()),
+                                    model_name: self.config.model_name.to_owned(),
+                                    annotations: spreadscaler_annotations(&spread.name, &self.id),
+                                    config: self.config.provider_config.clone(),
+                                })),
+                                _ => None,
+                            }
+                        })
+                        .collect::<Vec<Command>>()
+                } else {
+                    // No hosts were eligible, so we can't attempt to add or remove providers
+                    trace!(?spread.name, "Found no eligible hosts for daemon scaler");
+                    spread_status.push(StatusInfo::failed(&format!(
+                        "Could not satisfy daemonscaler {} for {}, 0 eligible hosts found.",
+                        spread.name, self.config.provider_reference
+                    )));
+                    vec![]
+                }
+            })
+            .collect::<Vec<Command>>();
+
+        trace!(?commands, "Calculated commands for provider daemonscaler");
+
+        let status = match (spread_status.is_empty(), commands.is_empty()) {
+            (true, true) => StatusInfo::ready(""),
+            (_, false) => StatusInfo::compensating(""),
+            (false, true) => StatusInfo::failed(
+                &spread_status
+                    .into_iter()
+                    .map(|s| s.message)
+                    .collect::<Vec<String>>()
+                    .join(" "),
+            ),
+        };
+        trace!(?status, "Updating scaler status");
+        *self.status.write().await = status;
+
+        Ok(commands)
+    }
+
+    #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name))]
+    async fn cleanup(&self) -> Result<Vec<Command>> {
+        let mut config_clone = self.config.clone();
+        config_clone.spread_config.replicas = 0;
+
+        let cleanerupper = ProviderDaemonScaler {
+            config: config_clone,
+            store: self.store.clone(),
+            provider_id: self.provider_id.clone(),
+            id: self.id.clone(),
+            status: RwLock::new(StatusInfo::compensating("")),
+        };
+
+        cleanerupper.reconcile().await
+    }
+}
+
+impl<S: ReadStore + Send + Sync> ProviderDaemonScaler<S> {
+    /// Construct a new ProviderDaemonScaler with specified configuration values
+    pub fn new(store: S, config: ProviderSpreadConfig, component_name: &str) -> Self {
+        let id = format!(
+            "{PROVIDER_DAEMON_SCALER_TYPE}-{}-{component_name}-{}-{}",
+            config.model_name, config.provider_reference, config.provider_link_name,
+        );
+        // If no spreads are specified, an empty spread is sufficient to match _every_ host
+        // in a lattice
+        let spread_config = if config.spread_config.spread.is_empty() {
+            SpreadScalerProperty {
+                replicas: config.spread_config.replicas,
+                spread: vec![Spread::default()],
+            }
+        } else {
+            config.spread_config
+        };
+        Self {
+            store,
+            provider_id: OnceCell::new(),
+            config: ProviderSpreadConfig {
+                spread_config,
+                ..config
+            },
+            id,
+            status: RwLock::new(StatusInfo::compensating("")),
+        }
+    }
+
+    /// Helper function to retrieve the provider ID for the configured provider
+    async fn provider_id(&self) -> Result<&str> {
+        self.provider_id
+            .get_or_try_init(|| async {
+                self.store
+                    .list::<Provider>(&self.config.lattice_id)
+                    .await
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|(_id, provider)| provider.reference == self.config.provider_reference)
+                    .map(|(_id, provider)| provider.id.to_owned())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Couldn't find a provider id for the provider reference {}",
+                            self.config.provider_reference
+                        )
+                    })
+            })
+            .await
+            .map(|id| id.as_str())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use anyhow::Result;
+    use chrono::Utc;
+
+    use crate::{
+        commands::{Command, StartProvider},
+        model::{CapabilityConfig, Spread, SpreadScalerProperty},
+        scaler::{spreadscaler::spreadscaler_annotations, Scaler},
+        storage::{Host, Provider, Store},
+        test_util::TestStore,
+        DEFAULT_LINK_NAME,
+    };
+
+    use super::*;
+
+    const MODEL_NAME: &str = "test_provider_spreadscaler";
+
+    #[tokio::test]
+    async fn can_spread_on_multiple_hosts() -> Result<()> {
+        let lattice_id = "provider_spread_multi_host";
+        let provider_ref = "fakecloud.azurecr.io/provider:3.2.1".to_string();
+        let provider_id = "VASDASDIAMAREALPROVIDERPROVIDER";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+
+        let store = Arc::new(TestStore::default());
+
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    actors: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("inda".to_string(), "cloud".to_string()),
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-noneofyourbusiness-1".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    actors: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("inda".to_string(), "cloud".to_string()),
+                        ("cloud".to_string(), "real".to_string()),
+                        ("region".to_string(), "us-yourhouse-1".to_string()),
+                    ]),
+                    annotations: HashMap::new(),
+                    providers: HashSet::new(),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                provider_id.to_string(),
+                Provider {
+                    id: provider_id.to_string(),
+                    name: "provider".to_string(),
+                    issuer: "issuer".to_string(),
+                    contract_id: "prov:ider".to_string(),
+                    reference: provider_ref.to_string(),
+                    link_name: DEFAULT_LINK_NAME.to_string(),
+                    hosts: HashMap::new(),
+                },
+            )
+            .await?;
+
+        // Ensure we spread evenly with equal weights, clean division
+        let multi_spread_even = SpreadScalerProperty {
+            // Replicas are ignored so putting an absurd number
+            replicas: 12312,
+            spread: vec![Spread {
+                name: "SimpleOne".to_string(),
+                requirements: BTreeMap::from_iter([("inda".to_string(), "cloud".to_string())]),
+                weight: Some(100),
+            }],
+        };
+
+        let spreadscaler = ProviderDaemonScaler::new(
+            store.clone(),
+            ProviderSpreadConfig {
+                lattice_id: lattice_id.to_string(),
+                provider_reference: provider_ref.to_string(),
+                spread_config: multi_spread_even,
+                provider_contract_id: "prov:ider".to_string(),
+                provider_link_name: DEFAULT_LINK_NAME.to_string(),
+                model_name: MODEL_NAME.to_string(),
+                provider_config: Some(CapabilityConfig::Opaque("foobar".to_string())),
+            },
+            "fake_component",
+        );
+
+        let mut commands = spreadscaler.reconcile().await?;
+        assert_eq!(commands.len(), 2);
+        // Sort to enable predictable test
+        commands.sort_unstable_by(|a, b| match (a, b) {
+            (Command::StartProvider(a), Command::StartProvider(b)) => a.host_id.cmp(&b.host_id),
+            _ => panic!("Should have been start providers"),
+        });
+
+        let cmd_one = commands.get(0).cloned();
+        match cmd_one {
+            None => panic!("command should have existed"),
+            Some(Command::StartProvider(start)) => {
+                assert_eq!(
+                    start,
+                    StartProvider {
+                        reference: provider_ref.to_string(),
+                        host_id: host_id_one.to_string(),
+                        link_name: Some(DEFAULT_LINK_NAME.to_string()),
+                        model_name: MODEL_NAME.to_string(),
+                        annotations: spreadscaler_annotations("SimpleOne", spreadscaler.id()),
+                        config: Some(CapabilityConfig::Opaque("foobar".to_string())),
+                    }
+                );
+                // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
+                // correct ones
+                assert_eq!(
+                    start.annotations,
+                    spreadscaler_annotations("SimpleOne", spreadscaler.id())
+                )
+            }
+            Some(_other) => panic!("command should have been a start provider"),
+        }
+
+        let cmd_two = commands.get(1).cloned();
+        match cmd_two {
+            None => panic!("command should have existed"),
+            Some(Command::StartProvider(start)) => {
+                assert_eq!(
+                    start,
+                    StartProvider {
+                        reference: provider_ref.to_string(),
+                        host_id: host_id_two.to_string(),
+                        link_name: Some(DEFAULT_LINK_NAME.to_string()),
+                        model_name: MODEL_NAME.to_string(),
+                        annotations: spreadscaler_annotations("SimpleTwo", spreadscaler.id()),
+                        config: Some(CapabilityConfig::Opaque("foobar".to_string())),
+                    }
+                );
+                // This manual assertion is because we don't hash on annotations and I want to be extra sure we have the
+                // correct ones
+                assert_eq!(
+                    start.annotations,
+                    spreadscaler_annotations("SimpleOne", spreadscaler.id())
+                )
+            }
+            Some(_other) => panic!("command should have been a start provider"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -21,8 +21,8 @@ use tracing::{debug, error, instrument, trace, warn};
 use crate::{
     events::Event,
     model::{
-        Component, Manifest, Properties, SpreadScalerProperty, Trait, TraitProperty, LINKDEF_TRAIT,
-        SPREADSCALER_TRAIT,
+        Component, Manifest, Properties, SpreadScalerProperty, Trait, TraitProperty,
+        DAEMONSCALER_TRAIT, LINKDEF_TRAIT, SPREADSCALER_TRAIT,
     },
     publisher::Publisher,
     scaler::{spreadscaler::ActorSpreadScaler, Command, Scaler},
@@ -32,6 +32,7 @@ use crate::{
 };
 
 use super::{
+    daemonscaler::ActorDaemonScaler,
     spreadscaler::{
         link::LinkScaler,
         provider::{ProviderSpreadConfig, ProviderSpreadScaler},
@@ -539,6 +540,22 @@ where
                         (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
                             Some(Box::new(BackoffAwareScaler::new(
                                 ActorSpreadScaler::new(
+                                    store.clone(),
+                                    props.image.to_owned(),
+                                    lattice_id.to_owned(),
+                                    name.to_owned(),
+                                    p.to_owned(),
+                                    &component.name,
+                                ),
+                                notifier.to_owned(),
+                                notifier_subject,
+                                name,
+                                None,
+                            )) as BoxedScaler)
+                        }
+                        (DAEMONSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
+                            Some(Box::new(BackoffAwareScaler::new(
+                                ActorDaemonScaler::new(
                                     store.clone(),
                                     props.image.to_owned(),
                                     lattice_id.to_owned(),

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     server::StatusInfo,
 };
 
+pub mod daemonscaler;
 pub mod manager;
 mod simplescaler;
 pub mod spreadscaler;

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -317,7 +317,10 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
 }
 
 /// Helper function to create a predictable annotations map for a spread
-fn spreadscaler_annotations(spread_name: &str, scaler_id: &str) -> HashMap<String, String> {
+pub(crate) fn spreadscaler_annotations(
+    spread_name: &str,
+    scaler_id: &str,
+) -> HashMap<String, String> {
     HashMap::from_iter([
         (SCALER_KEY.to_string(), scaler_id.to_string()),
         (SPREAD_KEY.to_string(), spread_name.to_string()),
@@ -325,7 +328,7 @@ fn spreadscaler_annotations(spread_name: &str, scaler_id: &str) -> HashMap<Strin
 }
 
 /// Helper function that computes a list of eligible hosts to match with a spread
-fn eligible_hosts<'a>(
+pub(crate) fn eligible_hosts<'a>(
     all_hosts: &'a HashMap<String, Host>,
     spread: &Spread,
 ) -> HashMap<&'a String, &'a Host> {


### PR DESCRIPTION
## Feature or Problem
This PR adds a new scaler type, the `daemonscaler`, which is a drop-in replacement for the `spreadscaler` trait. Instead of spreading a certain number of replicas across a specified set of constraints, the `daemonscaler` spreads a certain number of replicas across _all_ hosts in a lattice that match the requirements of the spread.

Kubernetes developers can think of a Spreadscaler as a k8s deployment with label selectors, and the Daemonscaler as a k8s DaemonSet (with optional label selectors)

More documentation will be needed here (PR forthcoming), but just so you know:
1. The daemonscaler uses the exact same config as the spreadscaler
2. Both daemonscalers ignore `weight` entirely
3. The provider spreadscaler ignores the `replicas` field, as you can only run one copy of a provider per host. 

## Related Issues
N/A

## Release Information
v0.6.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Added unit tests for the actor daemonscaler to ensure spreading logic works

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually tested this working with and without constraints.
