### PR TITLE
fix(*): set actor revision and version to be optional

### DIFF
--- a/src/events/data.rs
+++ b/src/events/data.rs
@@ -66,11 +66,11 @@ pub struct ActorClaims {
     pub issuer: String,
     pub name: String,
     pub not_before_human: String,
-    pub revision: usize,
+    pub revision: Option<usize>,
     // NOTE: This doesn't need a custom deserialize because unlike provider claims, these come out
     // in an array
     pub tags: Option<Vec<String>>,
-    pub version: String,
+    pub version: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq, Clone)]

--- a/src/scaler/simplescaler.rs
+++ b/src/scaler/simplescaler.rs
@@ -470,9 +470,9 @@ mod test {
             issuer: "AASDASDIAMAREALISSUER".to_string(),
             name: "real actor".to_string(),
             not_before_human: "N/A".to_string(),
-            revision: 1,
+            revision: Some(1),
             tags: None,
-            version: "v0.1.0".to_string(),
+            version: Some("v0.1.0".to_string()),
         }
     }
 }

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -1169,7 +1169,7 @@ mod test {
                 capabilites: vec!["empire:command".into()],
                 issuer: "Sheev Palpatine".into(),
                 name: "Grand Moff Tarkin".into(),
-                version: "0.1.0".into(),
+                version: Some("0.1.0".into()),
                 ..Default::default()
             },
             image_ref: "coruscant.galactic.empire/tarkin:0.1.0".into(),
@@ -1185,7 +1185,7 @@ mod test {
                 capabilites: vec!["empire:command".into(), "force_user:sith".into()],
                 issuer: "Sheev Palpatine".into(),
                 name: "Darth Vader".into(),
-                version: "0.1.0".into(),
+                version: Some("0.1.0".into()),
                 ..Default::default()
             },
             image_ref: "coruscant.galactic.empire/vader:0.1.0".into(),


### PR DESCRIPTION
## Feature or Problem
Technically the revision and the version information is _optional_ on actor claims, and if it was omitted wadm would fail to properly store actor information on startup. This PR just correctly sets these to optional and will not bork when omitted.

## Related Issues
N/A

## Release Information
v0.50.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I tested that this worked properly to store state with an actor that did not contain any version or revision information, reproduced by signing an actor with `wash claims sign ./echo.wasm --name echo` which results in all the defaults.
