### PR TITLE
fix/shared provider usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-nats 0.31.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]
@@ -11,7 +11,14 @@ repository = "https://github.com/wasmcloud/wadm"
 
 [features]
 default = []
-cli = ["clap", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry", "opentelemetry-otlp", "atty"]
+cli = [
+    "clap",
+    "tracing-opentelemetry",
+    "tracing-subscriber",
+    "opentelemetry",
+    "opentelemetry-otlp",
+    "atty",
+]
 # internal feature for e2e tests
 _e2e_tests = []
 

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -127,11 +127,8 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
 
     assert!(output.success(), "Error trying to start host",);
 
-    // Make sure we can connect to washboard
-    wait_for_server(&cfg.washboard_url()).await;
-
     // Give the host just a bit more time to get totally ready
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
     Ok(guard)
 }

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -16,8 +16,7 @@ use tokio::process::Command;
 use anyhow::Result;
 use wadm::consumers::{CommandConsumer, ScopedMessage};
 
-const DEFAULT_WASMCLOUD_PORT: u16 = 4000;
-const DEFAULT_NATS_PORT: u16 = 4222;
+pub const DEFAULT_NATS_PORT: u16 = 4222;
 pub const ECHO_ACTOR_ID: &str = "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5";
 pub const HTTP_SERVER_PROVIDER_ID: &str =
     "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M";
@@ -63,30 +62,17 @@ pub struct TestWashConfig {
 
     /// Only connect to pre-existing NATS instance
     pub nats_connect_only: bool,
-
-    /// Port on which to run wasmCloud (via `wash up`)
-    pub wasmcloud_port: Option<u16>,
 }
 
 impl TestWashConfig {
     /// Build a test wash configuration with randomized ports
     pub async fn random() -> Result<TestWashConfig> {
         let nats_port = Some(get_random_tcp_port());
-        let wasmcloud_port = Some(get_random_tcp_port());
 
         Ok(TestWashConfig {
             nats_port,
-            wasmcloud_port,
             ..TestWashConfig::default()
         })
-    }
-
-    /// Get the washboard URL for this config
-    pub fn washboard_url(&self) -> String {
-        format!(
-            "localhost:{}",
-            self.wasmcloud_port.unwrap_or(DEFAULT_WASMCLOUD_PORT)
-        )
     }
 
     /// Get the NATS URL for this config
@@ -98,13 +84,22 @@ impl TestWashConfig {
 /// Start a local wash instance
 async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     let nats_port = cfg.nats_port.unwrap_or(DEFAULT_NATS_PORT).to_string();
-    let wasmcloud_port = cfg
-        .wasmcloud_port
-        .unwrap_or(DEFAULT_WASMCLOUD_PORT)
-        .to_string();
+    let wash_host_key = nkeys::KeyPair::new_server();
+
+    let seed = wash_host_key.seed().expect("seed to exist").to_string();
 
     // Build args
-    let mut args: Vec<&str> = Vec::from(["up", "-d", "--disable-wadm", "--nats-port", &nats_port]);
+    let mut args: Vec<&str> = Vec::from([
+        "up",
+        "-d",
+        "--disable-wadm",
+        "--nats-port",
+        &nats_port,
+        "--host-seed",
+        &seed,
+        "--wasmcloud-version",
+        "v0.78.0-rc3",
+    ]);
     if cfg.nats_connect_only {
         args.push("--nats-connect-only");
     }
@@ -112,8 +107,6 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     // Build the command
     let mut cmd = Command::new("wash");
     cmd.args(&args)
-        .env("WASMCLOUD_PORT", &wasmcloud_port)
-        .env("WASMCLOUD_DASHBOARD_PORT", &wasmcloud_port)
         .stderr(std::process::Stdio::null())
         .stdout(std::process::Stdio::null());
 
@@ -124,32 +117,45 @@ async fn start_wash_instance(cfg: &TestWashConfig) -> Result<CleanupGuard> {
     };
 
     let output = cmd.status().await.expect("Unable to run detached wash up");
-
     assert!(output.success(), "Error trying to start host",);
 
-    // Give the host just a bit more time to get totally ready
-    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    // Run wash get inventory keypair.public_key() --nats-port {nats_port}
+    // and retry 5 times, sleeping for a second between tries, to ensure
+    // the host launched
+    let mut retries = 5;
+    while retries > 0 {
+        let output = Command::new("wash")
+            .args([
+                "get",
+                "inventory",
+                &wash_host_key.public_key(),
+                "--ctl-port",
+                &nats_port,
+            ])
+            .output()
+            .await
+            .expect("Unable to run wash command");
+        if output.status.success() {
+            break;
+        }
+        retries -= 1;
+        if retries == 0 {
+            panic!("Failed to launch host");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
 
     Ok(guard)
 }
 
 /// Set up and run a wash instance that can be used for a test
 pub async fn setup_test_wash(cfg: &TestWashConfig) -> CleanupGuard {
-    match tokio::net::TcpStream::connect(cfg.washboard_url()).await {
-        // NOTE: DO NOT use unwrap_or here. Otherwise we allocate a cleanup guard that then gets
-        // dropped, which runs `wash down`
-        #[allow(clippy::unnecessary_lazy_evaluations)]
-        Err(_) => start_wash_instance(cfg)
-            .await
-            .unwrap_or_else(|_| CleanupGuard {
-                child: None,
-                already_running: false,
-            }),
-        Ok(_) => CleanupGuard {
+    start_wash_instance(cfg)
+        .await
+        .unwrap_or_else(|_| CleanupGuard {
             child: None,
-            already_running: true,
-        },
-    }
+            already_running: false,
+        })
 }
 
 pub async fn wait_for_server(url: &str) {


### PR DESCRIPTION
- fix(scaler): count providers towards spread requirements
- chore: bump to 0.5.1

## Feature or Problem
This PR finishes the work in #119 to properly count hosts running providers towards each scaler that desires a specific provider id/link/contract combination running on a host. #120 still tracks the issue where we will attempt to make this better.

This PR fixes a bug where multiple applications require the same provider and the spreadscaler wouldn't properly count those providers as satisfying the scaler. One note is that we don't include running providers in the count when considering to _stop_ providers, to avoid provider scalers from considering that there are too many instances of a provider and ending up in an infinite loop.

## Related Issues
N/A

## Release Information
v0.5.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually watched this work without a bunch of extra `lp` commands!
