### PR TITLE
Validate that linkdef targets actually exist in the manifest

### DIFF
--- a/test/data/missing_capability_component.yaml
+++ b/test/data/missing_capability_component.yaml
@@ -1,0 +1,33 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: echo-simple
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.7
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 4
+        - type: linkdef
+          properties:
+            # This is a simple typo which should be caught by validation: there is no capability component named "httpservr"
+            target: httpservr
+            values:
+              address: 0.0.0.0:8080
+
+    - name: httpserver
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1


### PR DESCRIPTION
## Feature or Problem
Today it's totally valid to define a `linkdef` with a target that's not specified.
```yaml
        - type: linkdef
          properties:
            target: httpserver-notreal
```
When there is no capability component with name `httpserver-not-real`, manifest validation should return an appropriate error.

## Related Issues
#179

## Release Information
v0.6.0

## Consumer Impact
better DX

## Testing


Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
[test_manifest_validation](https://github.com/ahmedtadde/wadm/blob/786ca22424b1b4cc8b1ec192c88e85baa873edd7/src/server/handlers.rs#L936) was updated to include ensure all declared linkdef targets can be mapped to some capability component.

### Acceptance or Integration

### Manual Verification

