### PR TITLE
Refactor manifest upgrade for more efficient scaler computation 

### DIFF
--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -248,8 +248,11 @@ where
     /// This only constructs the scalers and doesn't reconcile. The returned [`Scalers`] type can be
     /// used to set this model to backoff mode
     #[instrument(level = "trace", skip_all, fields(name = %manifest.metadata.name, lattice_id = %self.lattice_id))]
-    pub async fn add_scalers<'a>(&'a self, manifest: &'a Manifest) -> Result<Scalers> {
-        let scalers = self.scalers_for_manifest(manifest);
+    pub async fn add_scalers<'a>(
+        &'a self,
+        manifest: &'a Manifest,
+        scalers: ScalerList,
+    ) -> Result<Scalers> {
         self.add_raw_scalers(&manifest.metadata.name, scalers).await;
         let notification = serde_json::to_vec(&Notifications::CreateScalers(manifest.to_owned()))?;
         self.client

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -793,8 +793,7 @@ where
         // redelivered. When it is, the ones that succeeded will be in backoff mode and the ones
         // that failed will be retried.
 
-        // TODO: inefficient to compute scalers twice, consider refactoring
-        let scalers = self.scalers.add_scalers(&data.manifest).await?;
+        let scalers = self.scalers.add_scalers(&data.manifest, scalers).await?;
 
         let (commands, res) = get_commands_and_result(
             scalers.iter().map(|s| s.reconcile()),


### PR DESCRIPTION
## Feature or Problem

on [handle_manifest_published](https://github.com/ahmedtadde/wadm/blob/261dae2604fa65fb00f070a34de5c0b40809ce65/src/workers/event.rs#L756) the scaler components are extracted twice from the manifest. First to compute the difference between the old (previously added to the ScalerManager) and the ones in the manifest received. It is then computed again in order to actually add the ones in the manifest received to the ScalerManager.

## Related Issues
#161 

## Release Information
v.0.6.0

## Consumer Impact
n/a

## Testing


Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

### Acceptance or Integration

### Manual Verification
