### PR TITLE
[FEAT] Support upgrades of just link config or provider config

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,6 +1,6 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, path::PathBuf};
 
 use async_nats::jetstream::{stream::Stream, Context};
 use clap::Parser;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -193,7 +193,15 @@ impl Hash for CapabilityConfig {
                 //NOTE(@ahmedtadde): By default, Serde uses BtreeMap for JSON map objects which is good for determinism.
                 //However, for arrays, ordering is not guaranteed.
                 //In general, unless the json values are strictly equal (ordering, casing, white spaces, etc...), the hash will be different. This is something to be mindful of when using this hash function.
-                let json = serde_json::to_string(v).expect("Should be able to serialize");
+                let json = match serde_json::to_string(v) {
+                    Ok(json) => json,
+                    Err(e) => {
+                        // This really shouldn't happen, but if it does, we should log it and fallback to a default value '{}' to avoid panicking
+                        eprintln!("Failed to serialize json value: {}", e);
+                        "{}".to_string()
+                    }
+                };
+
                 json.hash(state);
             }
             CapabilityConfig::Opaque(v) => v.hash(state),

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -281,15 +281,8 @@ impl<S: ReadStore + Send + Sync> ProviderDaemonScaler<S> {
     }
 }
 
-fn compute_provider_config_hash(provider_config: &CapabilityConfig) -> Option<u64> {
-    match provider_config.try_base64_encoding() {
-        Ok(base64) => {
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            base64.hash(&mut hasher);
-            Some(hasher.finish())
-        }
-        Err(_) => None,
-    }
+fn compute_provider_config_hash(provider_config: &CapabilityConfig) -> Option<String> {
+    provider_config.try_base64_encoding().ok()
 }
 
 #[cfg(test)]

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -7,7 +8,7 @@ use tracing::{instrument, trace};
 
 use crate::commands::StopProvider;
 use crate::events::{HostHeartbeat, ProviderInfo};
-use crate::model::Spread;
+use crate::model::{CapabilityConfig, Spread};
 use crate::scaler::spreadscaler::provider::ProviderSpreadConfig;
 use crate::scaler::spreadscaler::{eligible_hosts, spreadscaler_annotations};
 use crate::server::StatusInfo;
@@ -209,10 +210,20 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
 impl<S: ReadStore + Send + Sync> ProviderDaemonScaler<S> {
     /// Construct a new ProviderDaemonScaler with specified configuration values
     pub fn new(store: S, config: ProviderSpreadConfig, component_name: &str) -> Self {
-        let id = format!(
-            "{PROVIDER_DAEMON_SCALER_TYPE}-{}-{component_name}-{}-{}",
-            config.model_name, config.provider_reference, config.provider_link_name,
-        );
+        let id = if let Some(provider_config) = &config.provider_config {
+            format!(
+                "{PROVIDER_DAEMON_SCALER_TYPE}-{}-{component_name}-{}-{}-{}",
+                config.model_name,
+                config.provider_reference,
+                config.provider_link_name,
+                compute_provider_config_hash(provider_config),
+            )
+        } else {
+            format!(
+                "{PROVIDER_DAEMON_SCALER_TYPE}-{}-{component_name}-{}-{}",
+                config.model_name, config.provider_reference, config.provider_link_name,
+            )
+        };
         // If no spreads are specified, an empty spread is sufficient to match _every_ host
         // in a lattice
         let spread_config = if config.spread_config.spread.is_empty() {
@@ -258,6 +269,12 @@ impl<S: ReadStore + Send + Sync> ProviderDaemonScaler<S> {
     }
 }
 
+fn compute_provider_config_hash(provider_config: &CapabilityConfig) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    provider_config.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[cfg(test)]
 mod test {
     use std::{
@@ -280,6 +297,68 @@ mod test {
     use super::*;
 
     const MODEL_NAME: &str = "test_provider_spreadscaler";
+
+    #[test]
+    fn test_id_generator() {
+        let config = ProviderSpreadConfig {
+            lattice_id: "lattice".to_string(),
+            provider_reference: "provider".to_string(),
+            provider_link_name: "link".to_string(),
+            provider_contract_id: "contract".to_string(),
+            model_name: MODEL_NAME.to_string(),
+            spread_config: SpreadScalerProperty {
+                replicas: 1,
+                spread: vec![],
+            },
+            provider_config: None,
+        };
+
+        let scaler = ProviderDaemonScaler::new(Arc::new(TestStore::default()), config, "component");
+        assert_eq!(
+            scaler.id(),
+            format!(
+                "{PROVIDER_DAEMON_SCALER_TYPE}-{}-component-provider-link",
+                MODEL_NAME
+            ),
+            "ProviderDaemonScaler ID should be valid"
+        );
+
+        let config = ProviderSpreadConfig {
+            lattice_id: "lattice".to_string(),
+            provider_reference: "provider".to_string(),
+            provider_link_name: "link".to_string(),
+            provider_contract_id: "contract".to_string(),
+            model_name: MODEL_NAME.to_string(),
+            spread_config: SpreadScalerProperty {
+                replicas: 1,
+                spread: vec![],
+            },
+            provider_config: Some(CapabilityConfig::Opaque("foobar".to_string())),
+        };
+
+        let scaler = ProviderDaemonScaler::new(Arc::new(TestStore::default()), config, "component");
+        assert_eq!(
+            scaler.id(),
+            format!(
+                "{PROVIDER_DAEMON_SCALER_TYPE}-{}-component-provider-link-{}",
+                MODEL_NAME,
+                compute_provider_config_hash(&CapabilityConfig::Opaque("foobar".to_string()))
+            ),
+            "ProviderDaemonScaler ID should be valid"
+        );
+
+        let mut scaler_id_tokens = scaler.id().split('-');
+        scaler_id_tokens.next_back();
+        let scaler_id_tokens = scaler_id_tokens.collect::<Vec<&str>>().join("-");
+        assert_eq!(
+            scaler_id_tokens,
+            format!(
+                "{PROVIDER_DAEMON_SCALER_TYPE}-{}-component-provider-link",
+                MODEL_NAME
+            ),
+            "ProviderDaemonScaler ID should be valid and depends on provider_config"
+        );
+    }
 
     #[tokio::test]
     async fn can_spread_on_multiple_hosts() -> Result<()> {

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::hash::{Hash, Hasher};
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -356,13 +356,6 @@ mod test {
 
         let values = HashMap::from([("foo".to_string(), "bar".to_string())]);
 
-        let mut linkdef = LinkDefinition::default();
-        linkdef.actor_id = "actor".to_string();
-        linkdef.provider_id = "provider".to_string();
-        linkdef.contract_id = "contract".to_string();
-        linkdef.link_name = "default".to_string();
-        linkdef.values = [("foo".to_string(), "bar".to_string())].into();
-
         let scaler = LinkScaler::new(
             create_store(&lattice_id, &actor_ref, &provider_ref).await,
             actor_ref.clone(),

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -386,7 +386,7 @@ mod test {
                 "{PROVIDER_SPREAD_SCALER_TYPE}-{}-component-provider-link",
                 MODEL_NAME
             ),
-            "ProviderScaler ID should be valid"
+            "ProviderSpreadScaler ID should be valid"
         );
 
         let config = ProviderSpreadConfig {
@@ -410,7 +410,7 @@ mod test {
                 MODEL_NAME,
                 compute_provider_config_hash(&CapabilityConfig::Opaque("foobar".to_string()))
             ),
-            "ProviderScaler ID should be valid"
+            "ProviderSpreadScaler ID should be valid"
         );
 
         let mut scaler_id_tokens = scaler.id().split('-');
@@ -422,7 +422,7 @@ mod test {
                 "{PROVIDER_SPREAD_SCALER_TYPE}-{}-component-provider-link",
                 MODEL_NAME
             ),
-            "ProviderScaler ID should be valid and depends on provider_config"
+            "ProviderSpreadScaler ID should be valid and depends on provider_config"
         );
     }
 

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashMap},
+    hash::{Hash, Hasher},
 };
 
 use anyhow::Result;
@@ -282,10 +283,21 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
 impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
     /// Construct a new ProviderSpreadScaler with specified configuration values
     pub fn new(store: S, config: ProviderSpreadConfig, component_name: &str) -> Self {
-        let id = format!(
-            "{PROVIDER_SPREAD_SCALER_TYPE}-{}-{component_name}-{}-{}",
-            config.model_name, config.provider_reference, config.provider_link_name,
-        );
+        let id = if let Some(provider_config) = &config.provider_config {
+            format!(
+                "{PROVIDER_SPREAD_SCALER_TYPE}-{}-{component_name}-{}-{}-{}",
+                config.model_name,
+                config.provider_reference,
+                config.provider_link_name,
+                compute_provider_config_hash(provider_config),
+            )
+        } else {
+            format!(
+                "{PROVIDER_SPREAD_SCALER_TYPE}-{}-{component_name}-{}-{}",
+                config.model_name, config.provider_reference, config.provider_link_name,
+            )
+        };
+
         Self {
             store,
             spread_requirements: compute_spread(&config.spread_config),
@@ -319,6 +331,12 @@ impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
     }
 }
 
+fn compute_provider_config_hash(provider_config: &CapabilityConfig) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    provider_config.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[cfg(test)]
 mod test {
     use std::{
@@ -345,6 +363,68 @@ mod test {
     use super::*;
 
     const MODEL_NAME: &str = "test_provider_spreadscaler";
+
+    #[test]
+    fn test_id_generator() {
+        let config = ProviderSpreadConfig {
+            lattice_id: "lattice".to_string(),
+            provider_reference: "provider".to_string(),
+            provider_link_name: "link".to_string(),
+            provider_contract_id: "contract".to_string(),
+            model_name: MODEL_NAME.to_string(),
+            spread_config: SpreadScalerProperty {
+                replicas: 1,
+                spread: vec![],
+            },
+            provider_config: None,
+        };
+
+        let scaler = ProviderSpreadScaler::new(Arc::new(TestStore::default()), config, "component");
+        assert_eq!(
+            scaler.id(),
+            format!(
+                "{PROVIDER_SPREAD_SCALER_TYPE}-{}-component-provider-link",
+                MODEL_NAME
+            ),
+            "ProviderScaler ID should be valid"
+        );
+
+        let config = ProviderSpreadConfig {
+            lattice_id: "lattice".to_string(),
+            provider_reference: "provider".to_string(),
+            provider_link_name: "link".to_string(),
+            provider_contract_id: "contract".to_string(),
+            model_name: MODEL_NAME.to_string(),
+            spread_config: SpreadScalerProperty {
+                replicas: 1,
+                spread: vec![],
+            },
+            provider_config: Some(CapabilityConfig::Opaque("foobar".to_string())),
+        };
+
+        let scaler = ProviderSpreadScaler::new(Arc::new(TestStore::default()), config, "component");
+        assert_eq!(
+            scaler.id(),
+            format!(
+                "{PROVIDER_SPREAD_SCALER_TYPE}-{}-component-provider-link-{}",
+                MODEL_NAME,
+                compute_provider_config_hash(&CapabilityConfig::Opaque("foobar".to_string()))
+            ),
+            "ProviderScaler ID should be valid"
+        );
+
+        let mut scaler_id_tokens = scaler.id().split('-');
+        scaler_id_tokens.next_back();
+        let scaler_id_tokens = scaler_id_tokens.collect::<Vec<&str>>().join("-");
+        assert_eq!(
+            scaler_id_tokens,
+            format!(
+                "{PROVIDER_SPREAD_SCALER_TYPE}-{}-component-provider-link",
+                MODEL_NAME
+            ),
+            "ProviderScaler ID should be valid and depends on provider_config"
+        );
+    }
 
     #[tokio::test]
     async fn can_spread_on_multiple_hosts() -> Result<()> {

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -1,7 +1,6 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashMap},
-    hash::{Hash, Hasher},
 };
 
 use anyhow::Result;

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -342,15 +342,8 @@ impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
     }
 }
 
-fn compute_provider_config_hash(provider_config: &CapabilityConfig) -> Option<u64> {
-    match provider_config.try_base64_encoding() {
-        Ok(base64) => {
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            base64.hash(&mut hasher);
-            Some(hasher.finish())
-        }
-        Err(_) => None,
-    }
+fn compute_provider_config_hash(provider_config: &CapabilityConfig) -> Option<String> {
+    provider_config.try_base64_encoding().ok()
 }
 
 #[cfg(test)]

--- a/test/data/upgradedapp2.yaml
+++ b/test/data/upgradedapp2.yaml
@@ -1,0 +1,53 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: updateapp
+  annotations:
+    version: v0.0.3
+    description: "Testing effect of linkdef values and provider config updates="
+spec:
+  components:
+    # Latest, no modifications needed, actor component
+    - name: xkcd
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/xkcd:0.1.1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 5
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8081
+    - name: messagepub
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/message-pub:0.1.3
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+    - name: echo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.8
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 3
+        - type: linkdef
+          properties:
+            target: httpserver
+            # Updated values
+            values:
+              address: 0.0.0.0:8088
+
+    - name: httpserver
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.19.0
+        # Updated provider config
+        config: { "some": "config", "number": 1 }

--- a/tests/e2e_upgrades.rs
+++ b/tests/e2e_upgrades.rs
@@ -302,7 +302,7 @@ async fn test_upgrade(client_info: &ClientInfo) {
 
     // Deploy another updated manifest -- this time just w/ link values and provider config modifications
     let resp = client_info
-        .put_manifest_from_file("upgradedapp.yaml", None, None)
+        .put_manifest_from_file("upgradedapp2.yaml", None, None)
         .await;
 
     assert_ne!(

--- a/tests/e2e_upgrades.rs
+++ b/tests/e2e_upgrades.rs
@@ -377,7 +377,7 @@ async fn test_upgrade(client_info: &ClientInfo) {
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
-        if !links.links.iter().any(|ld| {
+        if !links.iter().any(|ld| {
             ld.actor_id == ECHO_ACTOR_ID
                 && ld.provider_id == HTTP_SERVER_PROVIDER_ID
                 && ld.contract_id == "wasmcloud:httpserver"
@@ -393,7 +393,7 @@ async fn test_upgrade(client_info: &ClientInfo) {
             )
         }
 
-        if links.links.iter().any(|ld| {
+        if links.iter().any(|ld| {
             ld.actor_id == KV_COUNTER_ACTOR_ID
                 && ld.provider_id == KV_REDIS_PROVIDER_ID
                 && ld.contract_id == "wasmcloud:keyvalue"


### PR DESCRIPTION
## Feature or Problem
Currently, the check to ensure that a scaler is meaningfully different from a previous version is done by comparing the IDs to each other. However, the ID for a link scaler does not include its values, and the ID for a provider scaler does not include its provider config. We should generate some form of short hash of linkdef values and provider and append that to the ID so we can delete + put a link, or stop + start a provider when the configuration changes.

## Related Issues
#159 

## Release Information
v0.7.0

## Consumer Impact
improved correctness for `wadm` manifest change detection

## Testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
