### PR TITLE
chore: bump to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-nats 0.31.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
Bumping to 0.7.1 to "officially" release 0.7.0, unfortunately I made a mistake in cutting the RC and we'll want to yank the crate 0.7.0.