### PR TITLE
[FEAT] Add the ability to set a stream prefix for all wadm internal streams 

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -137,8 +137,10 @@ struct Args {
     )]
     api_prefix: String,
 
-    /// The Stream topic prefix to use. This is an advanced setting that should only be used if you
-    /// know what you are doing
+    /// This prefix to used for the internal streams. When running in a multitenant environment,
+    /// clients share the same JS domain (since messages need to come from lattices).
+    /// Setting a stream prefix makes it possible to have a separate stream for different wadms running in a multitenant environment.
+    /// This is an advanced setting that should only be used if you know what you are doing.
     #[arg(long = "stream-prefix", env = "WADM_STREAM_PREFIX")]
     stream_prefix: Option<String>,
 

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{collections::HashMap, path::PathBuf};
 
 use async_nats::jetstream::{stream::Stream, Context};
 use clap::Parser;
@@ -137,6 +137,11 @@ struct Args {
     )]
     api_prefix: String,
 
+    /// The Stream topic prefix to use. This is an advanced setting that should only be used if you
+    /// know what you are doing
+    #[arg(long = "stream-prefix", env = "WADM_STREAM_PREFIX")]
+    stream_prefix: Option<String>,
+
     /// Name of the bucket used for storage of manifests
     #[arg(
         long = "manifest-bucket-name",
@@ -191,9 +196,22 @@ async fn main() -> anyhow::Result<()> {
 
     debug!("Ensuring event stream");
 
+    let internal_stream_name = |stream_name: &str| -> String {
+        match args.stream_prefix.clone() {
+            Some(stream_prefix) => {
+                format!(
+                    "{}.{}",
+                    stream_prefix.trim_end_matches(trimmer),
+                    stream_name
+                )
+            }
+            None => stream_name.to_string(),
+        }
+    };
+
     let event_stream = nats::ensure_stream(
         &context,
-        EVENT_STREAM_NAME.to_owned(),
+        internal_stream_name(EVENT_STREAM_NAME),
         vec![DEFAULT_WADM_EVENTS_TOPIC.to_owned()],
         Some(
             "A stream that stores all events coming in on the wasmbus.evt topics in a cluster"
@@ -206,7 +224,7 @@ async fn main() -> anyhow::Result<()> {
 
     let command_stream = nats::ensure_stream(
         &context,
-        COMMAND_STREAM_NAME.to_owned(),
+        internal_stream_name(COMMAND_STREAM_NAME),
         vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
         Some("A stream that stores all commands for wadm".to_string()),
     )
@@ -214,7 +232,7 @@ async fn main() -> anyhow::Result<()> {
 
     let status_stream = nats::ensure_status_stream(
         &context,
-        STATUS_STREAM_NAME.to_owned(),
+        internal_stream_name(STATUS_STREAM_NAME),
         vec![DEFAULT_STATUS_TOPIC.to_owned()],
     )
     .await?;
@@ -233,7 +251,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mirror_stream = nats::ensure_stream(
         &context,
-        mirror_stream.to_owned(),
+        internal_stream_name(mirror_stream),
         event_stream_topics.clone(),
         Some("A stream that publishes all events to the same stream".to_string()),
     )


### PR DESCRIPTION
## Feature or Problem
 currently, one can't have a separate stream for different wadms' running in a multitenant environment (e.g. wadm_status).

## Related Issues
#180

## Release Information
v0.7.x

## Consumer Impact
adds some flexibility to `wadm`

## Testing
<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)


### Acceptance or Integration


### Manual Verification
