### PR TITLE
Modified provider checks to be version independant

### DIFF
--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -533,6 +533,7 @@ impl<P: Publisher> Handler<P> {
         };
 
         let staged_model = match req.version.clone() {
+            Some(v) if v == LATEST_VERSION => manifests.get_current(),
             Some(v) => {
                 if let Some(model) = manifests.get_version(&v) {
                     model

--- a/test/data/duplicate_imageref1.yaml
+++ b/test/data/duplicate_imageref1.yaml
@@ -40,6 +40,6 @@ spec:
     - name: webcap2
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.13.1
+        image: wasmcloud.azurecr.io/httpserver:0.14.1
         contract: wasmcloud:blinkenlights
         link_name: default

--- a/test/data/upgradedapp3.yaml
+++ b/test/data/upgradedapp3.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: dontupdateapp
+  annotations:
+    version: v0.0.1
+    description: "Testing effect of duplicate providers"
+spec:
+  components:
+    # Provider component of an old version that should not be allowed
+    - name: httpserver
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.17.0


### PR DESCRIPTION
## Feature or Problem
Bug: Providers deployed in a manifest on a link name needed to have a unique image reference associated with it. This allowed for providers with the same reference but different versions to be created on the same link name. 

Fix: This PR improves upon this issue by associating an image ref, regardless of the version, with a link name. By ignoring the version, we permit only unique image references into the manifest/lattice.

## Related Issues


## Release Information
next

## Consumer Impact
Capabilities with duplicate image refs will be removed.

## Testing
manually tested

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Modified `test_manifest_validation`

### Acceptance or Integration
Updated e2e test named `e2e_upgrades` to check for provider versioning

### Manual Verification
manually verified.