### PR TITLE
Fully reconstitute state from heartbeats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 test/e2e_log/
 
 *.dump
+
+# Thanks MacOS
+.DS_Store

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -755,6 +755,14 @@ where
                         prov.contract_id = info.contract_id.clone();
                         has_changes = true;
                     }
+                    if prov.name.is_empty() {
+                        prov.name = info.name.clone().unwrap_or_default();
+                        has_changes = true;
+                    }
+                    if prov.reference.is_empty() {
+                        prov.reference = info.image_ref.clone().unwrap_or_default();
+                        has_changes = true;
+                    }
                     if let Entry::Vacant(entry) = prov.hosts.entry(host.id.clone()) {
                         entry.insert(ProviderStatus::default());
                         has_changes = true;
@@ -775,6 +783,8 @@ where
                             contract_id: info.contract_id.clone(),
                             link_name: info.link_name.clone(),
                             hosts: [(host.id.clone(), ProviderStatus::default())].into(),
+                            name: info.name.clone().unwrap_or_default(),
+                            reference: info.image_ref.clone().unwrap_or_default(),
                             ..Default::default()
                         },
                     ))


### PR DESCRIPTION
## Feature or Problem
This PR adds additional logic to the host heartbeat handling to make sure that actors and providers fully reconstitute state from heartbeats, even if the `wadm_state` bucket was entirely deleted. Wadm currently restores _most_ critical information, but notably did not restore the image reference which would require you to delete and restart the actor or provider in order for wadm to find it.

## Related Issues
Mentioned #191 in the code here.

## Release Information
I think we should take out a release branch to publish a patch for 0.7.2 with this commit at least cherry picked in order to not hold this back on 0.8.0.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Updated the heartbeat missing information test to actually test that we restore _all_ data.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I tested this both with partial information and an entirely deleted `wadm_state` bucket.
