### PR TITLE
chore: bump to v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.8.0-rc.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.8.0-rc.3"
+version = "0.8.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
This PR just bumps to v0.8.0 once we're ready to release officially

