### PR TITLE
fix(scaler): avoid full reconcile on status check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/src/scaler/daemonscaler/mod.rs
+++ b/src/scaler/daemonscaler/mod.rs
@@ -55,7 +55,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorDaemonScaler<S> {
     }
 
     async fn status(&self) -> StatusInfo {
-        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -43,7 +43,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
     }
 
     async fn status(&self) -> StatusInfo {
-        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -65,7 +65,6 @@ where
     }
 
     async fn status(&self) -> StatusInfo {
-        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -59,7 +59,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
     }
 
     async fn status(&self) -> StatusInfo {
-        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -64,7 +64,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
     }
 
     async fn status(&self) -> StatusInfo {
-        let _ = self.reconcile().await;
         self.status.read().await.to_owned()
     }
 


### PR DESCRIPTION
## Feature or Problem
This PR removes the ~"just in case"~ call to reconcile upon calling `.status()` on a scaler. When originally writing this I had in mind that the status may be out of date and the scaler should query state and figure out the status just to be sure. After practical application, this results in WAY too many queries for applications that are already satisfied, and our scalers are already registering interest in all events that should modify the status.

edit: "Just in case" was a false assumption, the scaler reconciles when asked for status because wadm instances only handle an event once, so with 3 wadm instances a scaler only has a 1/3 chance to get the proper event.

Basically, this was an extra way too expensive reconcile pass when the status is already being updated in response to every `handle_event` call that actually affects the scaler status.

Rough numbers when running the e2e multiple hosts test:
Before: 519 control interface requests
After: 287 control interface requests

Keeping in mind that this will primarily reduce requests when scalers return no commands, that's a pretty good reduction.

## Related Issues
Compliments #211 on querying efficiency

## Release Information
`0.8.1`, this doesn't change behavior it just drastically reduces queries.

## Consumer Impact
Consumers will be able to think again without all the NATS traffic in their head.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Note that I re-ran the `e2e_upgrades` test a few times and am looking into the issue locally. 

### Manual Verification
WIP but passing e2e tests w.r.t. status should indicate this had no bearing on functionality. Testing
