### PR TITLE
chore: Better JSON validation error messages

### DIFF
--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -969,7 +969,7 @@ pub(crate) async fn validate_manifest(manifest: Manifest) -> anyhow::Result<()> 
             ));
         }
         return Err(anyhow!(
-            "Validation Error : \n{}Please check for missing or incorrect elements",
+            "Validation Error: \n{}Please check for missing or incorrect elements",
             error_message
         ));
     }


### PR DESCRIPTION
## Feature or Problem
Better error messages for JSON validation.

Currently, when manifests are validated, the deserialization and validation is internally  handled by serde and it prints out error messages that specify the exact location of the error in the file. Here are some of the errors thrown by serde:
```
Should be able to parse: spec.components[5]: missing field `contract` at line 97 column 7

Should be able to parse: spec.components[0]: invalid type: unit value, expected struct ActorProperties at line 10 column 7
```

Serde handles a majority of the cases in the `Manifest` schema but in the case of `Traits`,  if there are any missing or incorrect properties that do not fall under type `Linkedef` or `Spreadscaler`, serde deserializes to `Custom` `TraitProperty`.  Upon which the validation falls through to the OAM validation schema. Due to the limited features of the `jsonschema` crate, it pinpoints to the correct area with the problematic code but does not tell the user the exact problem with the schema.

This PR takes the best it can of the `ValidationError` provided by `jsonschema` and gives error messages as follows:

```
Validation Error : 
Should be able to parse object at: spec/components/ at index: 0 
Please check for missing or incorrect elements

Validation Error : 
Should be able to parse object at: spec/components/ at index: 0 
Should be able to parse object at: spec/components/ at index: 1 
Please check for missing or incorrect elements
```

## Related Issues
#195 

## Release Information
next

## Consumer Impact
NA

## Testing
manually tested

### Unit Test(s)
Modified `test_manifest_validation` 

### Acceptance or Integration
NA

### Manual Verification
manually verified
