### PR TITLE
chore: bump to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,7 +2636,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
This PR bumps to 0.9.0 to release dependency updates in #218 
