### PR TITLE
feat(model): max_concurrent instead of replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
         - type: linkdef
           properties:
             target: httpserver
@@ -67,7 +67,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
 ```
 
 Then, use **wadm** to put the manifest and deploy it.
@@ -90,7 +90,7 @@ wash app undeploy echo
 ### Modifying applications
 
 **wadm** supports upgrading applications by `put`ting new versions of manifests and then `deploy`ing
-them. Try changing the manifest you created above by updating the number of echo replicas.
+them. Try changing the manifest you created above by updating the number of echo instances.
 
 ```yaml
 <<ELIDED>>
@@ -107,7 +107,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 10 # Let's run 10!
+            instances: 10 # Let's run 10!
 <<ELIDED>>
 ```
 
@@ -143,7 +143,7 @@ in a lattice is forthcoming._
 In advanced use cases, **wadm** is also capable of:
 
 - Monitoring multiple lattices.
-- Running multiple replicas to distribute load among multiple processes, or for a high-availability
+- Running multiple instances to distribute load among multiple processes, or for a high-availability
   architecture.
 
 🚧 The above functionality is somewhat tested, but not as rigorously as a single instance monitoring

--- a/oam/README.md
+++ b/oam/README.md
@@ -1,17 +1,23 @@
 # wadm Open Application Model
+
 The wasmCloud Application Deployment Manager uses the [Open Application Model](https://oam.dev) to define application specifications. Because this specification is extensible and _platform agnostic_, it makes for an ideal way to represent applications with metadata specific to wasmCloud.
 
 ## wasmCloud OAM Components
+
 The following is a list of the `component`s wasmCloud has added to the model.
-* `actor` - An actor
-* `provider` - A capability provider
+
+- `actor` - An actor
+- `provider` - A capability provider
 
 ## wasmCloud OAM Traits
+
 The following is a list of the `traits` wasmCloud has added via customization to its application model.
-* `spreadscaler` - Defines the spread of instances of a particular entity across multiple hosts with affinity requirements
-* `linkdef` - A link definition that describes a link between an actor and a capability provider
+
+- `spreadscaler` - Defines the spread of instances of a particular entity across multiple hosts with affinity requirements
+- `linkdef` - A link definition that describes a link between an actor and a capability provider
 
 ## Example Application YAML
+
 The following is an example YAML file describing an ALC application
 
 ```yaml
@@ -31,7 +37,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 4
+            instances: 4
             spread:
               - name: eastcoast
                 requirements:
@@ -63,7 +69,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: haslights
                 requirements:

--- a/oam/custom.yaml
+++ b/oam/custom.yaml
@@ -15,7 +15,7 @@ spec:
         # NOTE: This demonstrates what a custom scaler could look like. This functionality does not currently exist
         - type: customscaler
           properties:
-            replicas: 4
+            instances: 4
             clouds:
               - aws
               - azure

--- a/oam/echo.yaml
+++ b/oam/echo.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
         - type: linkdef
           properties:
             target: httpserver
@@ -29,4 +29,4 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1

--- a/oam/oam.schema.json
+++ b/oam/oam.schema.json
@@ -262,8 +262,17 @@
       "type": "object",
       "description": "A properties object (for spreadscaler configuration) is an object whose structure is determined by the spreadscaler property schema. It may be a simple value, or it may be a complex object.",
       "properties": {
-        "replicas": {
-          "type": "integer"
+        "instances": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "title": "instances"
+            },
+            {
+              "type": "integer",
+              "title": "replicas"
+            }
+          ]
         },
         "spread": {
           "type": "array",
@@ -287,7 +296,14 @@
           }
         }
       },
-      "required": ["replicas", "spread"]
+      "oneOf": [
+        {
+          "required": ["instances", "spread"]
+        },
+        {
+          "required": ["replicas", "spread"]
+        }
+      ]
     },
     "propertiesObject": {
       "anyOf": [

--- a/oam/petclinic.yaml
+++ b/oam/petclinic.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: uiclinicapp
                 requirements:
@@ -32,7 +32,7 @@ spec:
               uri: postgres://user:pass@your.db.host.com/petclinic
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: customersclinicapp
                 requirements:
@@ -50,7 +50,7 @@ spec:
               uri: postgres://user:pass@your.db.host.com/petclinic
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: vetsclinicapp
                 requirements:
@@ -69,7 +69,7 @@ spec:
 
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: visitsclinicapp
                 requirements:
@@ -82,7 +82,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: clinicapp
                 requirements:
@@ -101,7 +101,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: httpserverspread
                 requirements:
@@ -115,7 +115,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: postgresspread
                 requirements:

--- a/oam/simple1.json
+++ b/oam/simple1.json
@@ -1,88 +1,88 @@
 {
-    "apiVersion": "core.oam.dev/v1beta1",
-    "kind": "Application",
-    "metadata": {
-        "name": "my-example-app",
-        "annotations": {
-            "version": "v0.0.1",
-            "description": "This is my app"
-        }
-    },
-    "spec": {
-        "components": [
-            {
-                "name": "userinfo",
-                "type": "actor",
-                "properties": {
-                    "image": "wasmcloud.azurecr.io/fake:1"
-                },
-                "traits": [
-                    {
-                        "type": "spreadscaler",
-                        "properties": {
-                            "replicas": 4,
-                            "spread": [
-                                {
-                                    "name": "eastcoast",
-                                    "requirements": {
-                                        "zone": "us-east-1"
-                                    },
-                                    "weight": 80
-                                },
-                                {
-                                    "name": "westcoast",
-                                    "requirements": {
-                                        "zone": "us-west-1"
-                                    },
-                                    "weight": 20
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "type": "linkdef",
-                        "properties": {
-                            "target": "webcap",
-                            "values": {
-                                "port": "8080"
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "webcap",
-                "type": "capability",
-                "properties": {
-                    "contract": "wasmcloud:httpserver",
-                    "image": "wasmcloud.azurecr.io/httpserver:0.13.1",
-                    "link_name": "default"
-                }
-            },
-            {
-                "name": "ledblinky",
-                "type": "capability",
-                "properties": {
-                    "image": "wasmcloud.azurecr.io/ledblinky:0.0.1",
-                    "contract": "wasmcloud:blinkenlights"
-                },
-                "traits": [
-                    {
-                        "type": "spreadscaler",
-                        "properties": {
-                            "replicas": 1,
-                            "spread": [
-                                {
-                                    "name": "haslights",
-                                    "requirements": {
-                                        "ledenabled": "true"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        ]
+  "apiVersion": "core.oam.dev/v1beta1",
+  "kind": "Application",
+  "metadata": {
+    "name": "my-example-app",
+    "annotations": {
+      "version": "v0.0.1",
+      "description": "This is my app"
     }
+  },
+  "spec": {
+    "components": [
+      {
+        "name": "userinfo",
+        "type": "actor",
+        "properties": {
+          "image": "wasmcloud.azurecr.io/fake:1"
+        },
+        "traits": [
+          {
+            "type": "spreadscaler",
+            "properties": {
+              "instances": 4,
+              "spread": [
+                {
+                  "name": "eastcoast",
+                  "requirements": {
+                    "zone": "us-east-1"
+                  },
+                  "weight": 80
+                },
+                {
+                  "name": "westcoast",
+                  "requirements": {
+                    "zone": "us-west-1"
+                  },
+                  "weight": 20
+                }
+              ]
+            }
+          },
+          {
+            "type": "linkdef",
+            "properties": {
+              "target": "webcap",
+              "values": {
+                "port": "8080"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "webcap",
+        "type": "capability",
+        "properties": {
+          "contract": "wasmcloud:httpserver",
+          "image": "wasmcloud.azurecr.io/httpserver:0.13.1",
+          "link_name": "default"
+        }
+      },
+      {
+        "name": "ledblinky",
+        "type": "capability",
+        "properties": {
+          "image": "wasmcloud.azurecr.io/ledblinky:0.0.1",
+          "contract": "wasmcloud:blinkenlights"
+        },
+        "traits": [
+          {
+            "type": "spreadscaler",
+            "properties": {
+              "instances": 1,
+              "spread": [
+                {
+                  "name": "haslights",
+                  "requirements": {
+                    "ledenabled": "true"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/oam/simple2.yaml
+++ b/oam/simple2.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 4
+            instances: 4
             spread:
               - name: eastcoast
                 requirements:
@@ -43,7 +43,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: haslights
                 requirements:

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -246,7 +246,7 @@ pub enum TraitProperty {
     Linkdef(LinkdefProperty),
     SpreadScaler(SpreadScalerProperty),
     // TODO(thomastaylor312): This is still broken right now with deserializing. If the incoming
-    // type specifies replicas, it matches with spreadscaler first. So we need to implement a custom
+    // type specifies instances, it matches with spreadscaler first. So we need to implement a custom
     // parser here
     Custom(serde_json::Value),
 }
@@ -282,9 +282,10 @@ pub struct LinkdefProperty {
 /// Properties for spread scalers
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct SpreadScalerProperty {
-    /// Number of replicas to scale
-    pub replicas: usize,
-    /// Requirements for spreading those replicas
+    /// Number of instances to spread across matching requirements
+    #[serde(alias = "replicas")]
+    pub instances: usize,
+    /// Requirements for spreading those instances
     #[serde(default)]
     pub spread: Vec<Spread>,
 }
@@ -508,7 +509,7 @@ mod test {
         spread_vec.push(spread_item);
         let mut trait_vec: Vec<Trait> = Vec::new();
         let spreadscalerprop = SpreadScalerProperty {
-            replicas: 4,
+            instances: 4,
             spread: spread_vec,
         };
         let trait_item = Trait::new_spreadscaler(spreadscalerprop);
@@ -552,7 +553,7 @@ mod test {
         };
         spread_vec.push(spread_item);
         let spreadscalerprop = SpreadScalerProperty {
-            replicas: 1,
+            instances: 1,
             spread: spread_vec,
         };
         let mut trait_vec: Vec<Trait> = Vec::new();

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -714,7 +714,7 @@ where
                                 lattice_id: lattice_id.to_owned(),
                                 provider_reference: props.image.to_owned(),
                                 spread_config: SpreadScalerProperty {
-                                    replicas: 1,
+                                    instances: 1,
                                     spread: vec![],
                                 },
                                 provider_contract_id: props.contract.to_owned(),

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -41,12 +41,12 @@ pub struct ProviderSpreadConfig {
     pub provider_config: Option<CapabilityConfig>,
 }
 
-/// The ProviderSpreadScaler ensures that a certain number of provider replicas are running,
+/// The ProviderSpreadScaler ensures that a certain number of provider instances are running,
 /// spread across a number of hosts according to a [SpreadScalerProperty](crate::model::SpreadScalerProperty)
 ///
-/// If no [Spreads](crate::model::Spread) are specified, this Scaler simply maintains the number of replicas
+/// If no [Spreads](crate::model::Spread) are specified, this Scaler simply maintains the number of instances
 /// on an available host. It's important to note that only one instance of a provider id + link + contract
-/// can run on each host, so it's possible to specify too many replicas to be satisfied by the spread configs.
+/// can run on each host, so it's possible to specify too many instances to be satisfied by the spread configs.
 pub struct ProviderSpreadScaler<S: ReadStore + Send + Sync> {
     store: S,
     pub config: ProviderSpreadConfig,
@@ -263,7 +263,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
     #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name))]
     async fn cleanup(&self) -> Result<Vec<Command>> {
         let mut config_clone = self.config.clone();
-        config_clone.spread_config.replicas = 0;
+        config_clone.spread_config.instances = 0;
         let spread_requirements = compute_spread(&config_clone.spread_config);
 
         let cleanerupper = ProviderSpreadScaler {
@@ -381,7 +381,7 @@ mod test {
             provider_contract_id: "contract".to_string(),
             model_name: MODEL_NAME.to_string(),
             spread_config: SpreadScalerProperty {
-                replicas: 1,
+                instances: 1,
                 spread: vec![],
             },
             provider_config: None,
@@ -404,7 +404,7 @@ mod test {
             provider_contract_id: "contract".to_string(),
             model_name: MODEL_NAME.to_string(),
             spread_config: SpreadScalerProperty {
-                replicas: 1,
+                instances: 1,
                 spread: vec![],
             },
             provider_config: Some(CapabilityConfig::Opaque("foobar".to_string())),
@@ -506,7 +506,7 @@ mod test {
 
         // Ensure we spread evenly with equal weights, clean division
         let multi_spread_even = SpreadScalerProperty {
-            replicas: 2,
+            instances: 2,
             spread: vec![
                 Spread {
                     name: "SimpleOne".to_string(),
@@ -592,7 +592,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn can_do_multiple_replicas_per_spread() -> Result<()> {
+    async fn can_do_multiple_instances_per_spread() -> Result<()> {
         let lattice_id = "provider_spread_multi_host";
         let provider_ref = "fakecloud.azurecr.io/provider:3.2.1".to_string();
         let provider_id = "VASDASDIAMAREALPROVIDERPROVIDER";
@@ -615,7 +615,7 @@ mod test {
         // start proivder with 1 replica on 3
         // stop provider with 1 replica on 4
         let multi_spread_hard = SpreadScalerProperty {
-            replicas: 3,
+            instances: 3,
             spread: vec![
                 Spread {
                     name: "ComplexOne".to_string(),
@@ -942,7 +942,7 @@ mod test {
 
         // Ensure we spread evenly with equal weights, clean division
         let multi_spread_even = SpreadScalerProperty {
-            replicas: 2,
+            instances: 2,
             spread: vec![
                 Spread {
                     name: "SimpleOne".to_string(),
@@ -1084,7 +1084,7 @@ mod test {
 
         // Ensure we spread evenly with equal weights, clean division
         let multi_spread_even = SpreadScalerProperty {
-            replicas: 2,
+            instances: 2,
             spread: vec![
                 Spread {
                     name: "SimpleOne".to_string(),
@@ -1158,7 +1158,7 @@ mod test {
 
         // Ensure we spread evenly with equal weights, clean division
         let multi_spread_even = SpreadScalerProperty {
-            replicas: 1,
+            instances: 1,
             spread: vec![Spread {
                 name: "SimpleOne".to_string(),
                 requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),

--- a/test/data/all_hosts.yaml
+++ b/test/data/all_hosts.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
             spread:
               - name: eastcoast
                 requirements:
@@ -42,7 +42,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
             spread:
               - name: eastcoast
                 requirements:

--- a/test/data/complex.yaml
+++ b/test/data/complex.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
             spread:
               - name: eastcoast
                 requirements:
@@ -43,7 +43,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 3
+            instances: 3
             spread:
               - name: westcoast
                 requirements:
@@ -62,7 +62,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: the-moon
                 requirements:

--- a/test/data/duplicate_component.yaml
+++ b/test/data/duplicate_component.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: uiclinicapp
                 requirements:
@@ -32,7 +32,7 @@ spec:
               uri: postgres://user:pass@your.db.host.com/petclinic
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: customersclinicapp
                 requirements:
@@ -51,7 +51,7 @@ spec:
               foo: bar
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: vetsclinicapp
                 requirements:
@@ -70,7 +70,7 @@ spec:
 
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: visitsclinicapp
                 requirements:
@@ -83,7 +83,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: clinicapp
                 requirements:
@@ -102,7 +102,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: httpserverspread
                 requirements:
@@ -116,7 +116,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: postgresspread
                 requirements:

--- a/test/data/duplicate_imageref1.yaml
+++ b/test/data/duplicate_imageref1.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 4
+            instances: 4
             spread:
               - name: eastcoast
                 requirements:

--- a/test/data/duplicate_imageref2.yaml
+++ b/test/data/duplicate_imageref2.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: uiclinicapp
                 requirements:
@@ -27,7 +27,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: customersclinicapp
                 requirements:

--- a/test/data/duplicate_linkdef.yaml
+++ b/test/data/duplicate_linkdef.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: uiclinicapp
                 requirements:
@@ -32,7 +32,7 @@ spec:
               uri: postgres://user:pass@your.db.host.com/petclinic
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: customersclinicapp
                 requirements:
@@ -56,7 +56,7 @@ spec:
               uri: postgres://user:pass@your.db.host.com/petclinic2
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: vetsclinicapp
                 requirements:
@@ -75,7 +75,7 @@ spec:
 
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: visitsclinicapp
                 requirements:
@@ -88,7 +88,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: clinicapp
                 requirements:
@@ -107,7 +107,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: httpserverspread
                 requirements:
@@ -121,7 +121,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: postgresspread
                 requirements:

--- a/test/data/host_stop.yaml
+++ b/test/data/host_stop.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
             spread:
               - name: eastcoast
                 requirements:

--- a/test/data/incorrect_component.yaml
+++ b/test/data/incorrect_component.yaml
@@ -31,7 +31,7 @@ spec:
               uri: postgres://user:pass@your.db.host.com/petclinic
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: customersclinicapp
                 requirements:
@@ -50,7 +50,7 @@ spec:
               foo: bar
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: vetsclinicapp
                 requirements:
@@ -69,7 +69,7 @@ spec:
 
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: visitsclinicapp
                 requirements:
@@ -82,7 +82,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: clinicapp
                 requirements:
@@ -101,7 +101,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: httpserverspread
                 requirements:
@@ -115,7 +115,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
             spread:
               - name: postgresspread
                 requirements:

--- a/test/data/long_image_refs.yaml
+++ b/test/data/long_image_refs.yaml
@@ -20,4 +20,4 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1

--- a/test/data/lotta_actors.yaml
+++ b/test/data/lotta_actors.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 200
+            instances: 200
         - type: linkdef
           properties:
             target: httpserver
@@ -29,4 +29,4 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1

--- a/test/data/missing_capability_component.yaml
+++ b/test/data/missing_capability_component.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 4
+            instances: 4
         - type: linkdef
           properties:
             # This is a simple typo which should be caught by validation: there is no capability component named "httpservr"
@@ -30,4 +30,4 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1

--- a/test/data/outdatedapp.yaml
+++ b/test/data/outdatedapp.yaml
@@ -22,7 +22,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
         - type: linkdef
           properties:
             target: httpserver
@@ -36,7 +36,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 3
+            instances: 3
         # Old linkdef trait
         - type: linkdef
           properties:
@@ -51,7 +51,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 3
+            instances: 3
         - type: linkdef
           properties:
             target: redis

--- a/test/data/simple.yaml
+++ b/test/data/simple.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 4
+            instances: 4
         - type: linkdef
           properties:
             target: httpserver
@@ -29,4 +29,4 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1

--- a/test/data/simple2.yaml
+++ b/test/data/simple2.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
         - type: linkdef
           properties:
             target: messaging

--- a/test/data/upgradedapp.yaml
+++ b/test/data/upgradedapp.yaml
@@ -15,7 +15,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
         - type: linkdef
           properties:
             target: httpserver
@@ -29,7 +29,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
     # Updated actor component
     - name: echo
       type: actor
@@ -38,7 +38,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 3
+            instances: 3
         # Updated linkdef trait
         - type: linkdef
           properties:

--- a/test/data/upgradedapp2.yaml
+++ b/test/data/upgradedapp2.yaml
@@ -15,7 +15,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 5
+            instances: 5
         - type: linkdef
           properties:
             target: httpserver
@@ -28,7 +28,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 1
     - name: echo
       type: actor
       properties:
@@ -36,7 +36,7 @@ spec:
       traits:
         - type: spreadscaler
           properties:
-            replicas: 3
+            instances: 3
         - type: linkdef
           properties:
             target: httpserver


### PR DESCRIPTION
## Feature or Problem
This PR updates the manifest definition to refer to replicas of actors and providers as `instances`, rather than simply `replicas`. After the change to the host to effectively autoscale to a maximum concurrent load, we aren't really spreading replicas around like we used to.

I acknowledge this is a little awkward when it comes to having an underscore in a yaml property, and the fact that this doesn't really make as much sense for capability providers. For that reason this is a change that's mostly internal, and you can still use `replicas` as the property for now. In the future, I would love to rethink this trait property and how it pertains to  our scaling model. With capability providers being WASI-based, it may make sense to use this concurrency property for providers too.

## Related Issues
Changes in the host implemented in https://github.com/wasmCloud/wasmCloud/pull/1107. After that merges and the new control interface cuts, we'll need to update our test code in wadm to change the `u16` values to `u32`s.

## Release Information
v0.9.0 or v0.10.0

## Consumer Impact
This, from a model standpoint, is a backwards compatible change and we'll support `replicas` as an option for the forseeable future. This just lets us use consistent wording across projects.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Modified all YAMLs other than one (to ensure backwards compatibility) to denote `replicas` as `instances`.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
