### PR TITLE
Derive PartialEq and Eq for DeleteResult

### DIFF
--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -98,7 +98,7 @@ pub struct DeleteModelResponse {
 }
 
 /// All possible outcomes of a delete operation
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DeleteResult {
     Deleted,


### PR DESCRIPTION
## Feature or Problem

`DeleteResult` enum is missing `PartialEq` and `Eq`, which seem to be implemented for all of the other `<Operation>Result` types.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
