### PR TITLE
feat(status): prevent duplicate status publishes

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -274,6 +274,7 @@ async fn main() -> anyhow::Result<()> {
         command_topic_prefix: DEFAULT_COMMANDS_TOPIC.trim_matches(trimmer).to_owned(),
         publisher: context.clone(),
         notify_stream,
+        status_stream: status_stream.clone(),
     };
     let events_manager: ConsumerManager<EventConsumer> = ConsumerManager::new(
         permit_pool.clone(),
@@ -373,6 +374,7 @@ struct EventWorkerCreator<StateStore> {
     command_topic_prefix: String,
     publisher: Context,
     notify_stream: Stream,
+    status_stream: Stream,
 }
 
 #[async_trait::async_trait]
@@ -392,8 +394,11 @@ where
             self.publisher.clone(),
             &format!("{}.{lattice_id}", self.command_topic_prefix),
         );
-        let status_publisher =
-            StatusPublisher::new(self.publisher.clone(), &format!("wadm.status.{lattice_id}"));
+        let status_publisher = StatusPublisher::new(
+            self.publisher.clone(),
+            Some(self.status_stream.clone()),
+            &format!("wadm.status.{lattice_id}"),
+        );
         let manager = ScalerManager::new(
             self.publisher.clone(),
             self.notify_stream.clone(),

--- a/src/scaler/daemonscaler/mod.rs
+++ b/src/scaler/daemonscaler/mod.rs
@@ -771,7 +771,7 @@ mod test {
             },
         );
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher,None,  "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -1260,7 +1260,7 @@ mod test {
 
         let lattice_source = TestLatticeSource::default();
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, None, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -1201,7 +1201,7 @@ mod test {
         let lattice_id = "all_state";
 
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, None, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),
@@ -1490,7 +1490,7 @@ mod test {
                         ActorDescription {
                             id: actor1.public_key.to_string(),
                             image_ref: None,
-                            /// The individual instances of this actor that are running
+                            // The individual instances of this actor that are running
                             instances: vec![
                                 ActorInstance {
                                     annotations: None,
@@ -1512,7 +1512,7 @@ mod test {
                         ActorDescription {
                             id: actor2.public_key.to_string(),
                             image_ref: None,
-                            /// The individual instances of this actor that are running
+                            // The individual instances of this actor that are running
                             instances: vec![
                                 ActorInstance {
                                     annotations: None,
@@ -1565,7 +1565,7 @@ mod test {
                         ActorDescription {
                             id: actor1.public_key.to_string(),
                             image_ref: None,
-                            /// The individual instances of this actor that are running
+                            // The individual instances of this actor that are running
                             instances: vec![
                                 ActorInstance {
                                     annotations: None,
@@ -1587,7 +1587,7 @@ mod test {
                         ActorDescription {
                             id: actor2.public_key.to_string(),
                             image_ref: None,
-                            /// The individual instances of this actor that are running
+                            // The individual instances of this actor that are running
                             instances: vec![
                                 ActorInstance {
                                     annotations: None,
@@ -1795,7 +1795,7 @@ mod test {
                     actors: vec![ActorDescription {
                         id: actor2.public_key.to_string(),
                         image_ref: None,
-                        /// The individual instances of this actor that are running
+                        // The individual instances of this actor that are running
                         instances: vec![
                             ActorInstance {
                                 annotations: None,
@@ -1828,7 +1828,7 @@ mod test {
                     actors: vec![ActorDescription {
                         id: actor2.public_key.to_string(),
                         image_ref: None,
-                        /// The individual instances of this actor that are running
+                        // The individual instances of this actor that are running
                         instances: vec![
                             ActorInstance {
                                 annotations: None,
@@ -1992,7 +1992,7 @@ mod test {
             ..Default::default()
         };
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, None, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),
@@ -2023,7 +2023,7 @@ mod test {
                     ActorDescription {
                         id: actor1_id.to_string(),
                         image_ref: None,
-                        /// The individual instances of this actor that are running
+                        // The individual instances of this actor that are running
                         instances: vec![
                             ActorInstance {
                                 annotations: None,
@@ -2045,7 +2045,7 @@ mod test {
                     ActorDescription {
                         id: actor2_id.to_string(),
                         image_ref: None,
-                        /// The individual instances of this actor that are running
+                        // The individual instances of this actor that are running
                         instances: vec![ActorInstance {
                             annotations: None,
                             instance_id: "3".to_string(),
@@ -2155,7 +2155,7 @@ mod test {
         let lattice_source = TestLatticeSource::default();
         let lattice_id = "provider_status";
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, None, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),
@@ -2272,7 +2272,7 @@ mod test {
         let lattice_id = "provider_contract_id";
 
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, None, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),
@@ -2376,7 +2376,7 @@ mod test {
         let lattice_id = "update_data";
 
         let command_publisher = CommandPublisher::new(NoopPublisher, "doesntmatter");
-        let status_publisher = StatusPublisher::new(NoopPublisher, "doesntmatter");
+        let status_publisher = StatusPublisher::new(NoopPublisher, None, "doesntmatter");
         let worker = EventWorker::new(
             store.clone(),
             lattice_source.clone(),


### PR DESCRIPTION
## Feature or Problem
This PR adds a simple check before publishing a status to query the previous status and skip publishing if it would be the exact same. This should quiet down the status stream quite a bit for already deployed applications and it should make it a lot easier to follow during debugging.

## Related Issues
Fixes #187 

## Release Information
`next` release, can be a patch.

## Consumer Impact
This PR does add a burden on the status stream with a stream get

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
The status stream was much less noisy during e2e tests, for example during the upgrade e2e test the number of status messages went from 57 to 23. This is impressive as this PR isn't primarily concerned with reducing the number during deployment, we just end up publishing a lot of duplicate statuses.
