### PR TITLE
chore: updated release github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Publish to GHCR
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.WADM_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           draft: false
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,10 +189,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -207,7 +207,7 @@ jobs:
       - run: mv ./artifacts/wadm ./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64 && chmod +x ./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
This PR fixes an issue where we were storing a token as a secret and then referencing it rather than using the implicit GITHUB_TOKEN.