### PR TITLE
fix(scaler): remove backoff wrapper around link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,7 +2636,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.9.0"
+version = "0.9.2"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    events::{Event, Linkdef, LinkdefSet, ProviderClaims, ProviderStartFailed, ProviderStarted},
+    events::{Event, ProviderClaims, ProviderStartFailed, ProviderStarted},
     model::CapabilityConfig,
     workers::insert_managed_annotations,
 };
@@ -78,32 +78,6 @@ impl Command {
                     })),
                 ))
             }
-            Command::PutLinkdef(PutLinkdef {
-                actor_id,
-                provider_id,
-                link_name,
-                contract_id,
-                values,
-                ..
-            }) => Some((
-                Event::LinkdefSet(LinkdefSet {
-                    linkdef: Linkdef {
-                        actor_id: actor_id.to_owned(),
-                        contract_id: contract_id.to_owned(),
-                        link_name: link_name.to_owned(),
-                        provider_id: provider_id.to_owned(),
-                        values: values.to_owned(),
-                        // We don't know the linkdef ID from the command
-                        id: String::with_capacity(0),
-                    },
-                }),
-                None,
-            )),
-            // NOTE: this is explicitly added as a reminder that scaling an actor
-            // doesn't have an exact corresponding event, but we're not really worried about that
-            // because scale is idempotent. So, in the worst case, we issue multiple commands which
-            // would result in the same state as if we issued one command.
-            Command::ScaleActor(_) => None,
             _ => None,
         }
     }

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -581,35 +581,23 @@ where
                 scalers.extend(traits.unwrap_or(&EMPTY_TRAIT_VEC).iter().filter_map(|trt| {
                     match (trt.trait_type.as_str(), &trt.properties) {
                         (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                            Some(Box::new(BackoffAwareScaler::new(
-                                ActorSpreadScaler::new(
-                                    snapshot_data.clone(),
-                                    props.image.to_owned(),
-                                    lattice_id.to_owned(),
-                                    name.to_owned(),
-                                    p.to_owned(),
-                                    &component.name,
-                                ),
-                                notifier.to_owned(),
-                                notifier_subject,
-                                name,
-                                None,
+                            Some(Box::new(ActorSpreadScaler::new(
+                                snapshot_data.clone(),
+                                props.image.to_owned(),
+                                lattice_id.to_owned(),
+                                name.to_owned(),
+                                p.to_owned(),
+                                &component.name,
                             )) as BoxedScaler)
                         }
                         (DAEMONSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                            Some(Box::new(BackoffAwareScaler::new(
-                                ActorDaemonScaler::new(
-                                    snapshot_data.clone(),
-                                    props.image.to_owned(),
-                                    lattice_id.to_owned(),
-                                    name.to_owned(),
-                                    p.to_owned(),
-                                    &component.name,
-                                ),
-                                notifier.to_owned(),
-                                notifier_subject,
-                                name,
-                                None,
+                            Some(Box::new(ActorDaemonScaler::new(
+                                snapshot_data.clone(),
+                                props.image.to_owned(),
+                                lattice_id.to_owned(),
+                                name.to_owned(),
+                                p.to_owned(),
+                                &component.name,
                             )) as BoxedScaler)
                         }
                         (LINKDEF_TRAIT, TraitProperty::Linkdef(p)) => {
@@ -619,22 +607,16 @@ where
                                     Properties::Capability { properties: cappy }
                                         if component.name == p.target =>
                                     {
-                                        Some(Box::new(BackoffAwareScaler::new(
-                                            LinkScaler::new(
-                                                snapshot_data.clone(),
-                                                props.image.to_owned(),
-                                                cappy.image.to_owned(),
-                                                cappy.contract.to_owned(),
-                                                cappy.link_name.to_owned(),
-                                                lattice_id.to_owned(),
-                                                name.to_owned(),
-                                                p.values.to_owned(),
-                                                snapshot_data.clone(),
-                                            ),
-                                            notifier.to_owned(),
-                                            notifier_subject,
-                                            name,
-                                            None,
+                                        Some(Box::new(LinkScaler::new(
+                                            snapshot_data.clone(),
+                                            props.image.to_owned(),
+                                            cappy.image.to_owned(),
+                                            cappy.contract.to_owned(),
+                                            cappy.link_name.to_owned(),
+                                            lattice_id.to_owned(),
+                                            name.to_owned(),
+                                            p.values.to_owned(),
+                                            snapshot_data.clone(),
                                         ))
                                             as BoxedScaler)
                                     }


### PR DESCRIPTION
## Feature or Problem
This PR removes the `BackoffAwareScaler` wrapper around Actor and link scalers as it is not a useful addition to the scaler logic. Both actor and link scalers issue idempotent commands and actor scalers actually haven't utilized the backoff functionality since #171. In some cases we even see linkdef scalers looping infinitely so this should fix that. 

## Related Issues
#171

## Release Information
v0.9.2 with a cherry pick

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
