### PR TITLE
chore: Replace atty with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,17 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,15 +805,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -1268,7 +1248,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2641,7 +2621,6 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
- "atty",
  "base64 0.21.5",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ cli = [
     "tracing-subscriber",
     "opentelemetry",
     "opentelemetry-otlp",
-    "atty",
 ]
 # internal feature for e2e tests
 _e2e_tests = []
@@ -26,7 +25,6 @@ _e2e_tests = []
 anyhow = "1"
 async-nats = "0.33"
 async-trait = "0.1"
-atty = { version = "0.2", optional = true }
 base64 = "0.21.2"
 bytes = "1"
 chrono = "0.4"

--- a/bin/logging.rs
+++ b/bin/logging.rs
@@ -3,6 +3,7 @@ use opentelemetry::sdk::{
     Resource,
 };
 use opentelemetry_otlp::{Protocol, WithExportConfig};
+use std::io::IsTerminal;
 use tracing::{Event as TracingEvent, Subscriber};
 use tracing_subscriber::fmt::{
     format::{Format, Full, Json, JsonFields, Writer},
@@ -109,7 +110,7 @@ where
 {
     let log_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
-        .with_ansi(atty::is(atty::Stream::Stderr));
+        .with_ansi(std::io::stderr().is_terminal());
     if structured_logging {
         Box::new(
             log_layer


### PR DESCRIPTION
## Feature or Problem

As best as I can tell, [`atty` is unmaintained](https://github.com/softprops/atty/), which is unfortunate because it has an outstanding security vulnerability ([RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145) / [GHSA-g98v-hv3f-hcfr](https://github.com/advisories/GHSA-g98v-hv3f-hcfr)).

Fortunately, [Rust 1.70.0 shipped native functionality to replace what `atty` was providing](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#isterminal).

I might've missed it, since I don't believe we have a defined msrv, I think expecting Rust 1.70.0 for this functionality seems fair.

If this is a bad assumption or we absolutely insist on supporting [Hermit](https://github.com/hermit-os), we should at least consider switching from `atty` to [`is-terminal`](https://crates.io/crates/is-terminal/), which is a drop-in replacement for `atty` but maintained.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
