### PR TITLE
fix(scaler): resolve possible linkdef loop

### DIFF
--- a/src/scaler/daemonscaler/mod.rs
+++ b/src/scaler/daemonscaler/mod.rs
@@ -217,8 +217,8 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorDaemonScaler<S> {
         trace!(?commands, "Calculated commands for actor daemon scaler");
 
         let status = match (spread_status.is_empty(), commands.is_empty()) {
-            (true, true) => StatusInfo::ready(""),
-            (_, false) => StatusInfo::compensating(""),
+            (true, true) => StatusInfo::deployed(""),
+            (_, false) => StatusInfo::reconciling(""),
             (false, true) => StatusInfo::failed(
                 &spread_status
                     .into_iter()
@@ -243,7 +243,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorDaemonScaler<S> {
             store: self.store.clone(),
             actor_id: self.actor_id.clone(),
             id: self.id.clone(),
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         };
 
         cleanerupper.reconcile().await
@@ -282,7 +282,7 @@ impl<S: ReadStore + Send + Sync> ActorDaemonScaler<S> {
                 model_name,
             },
             id,
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         }
     }
 

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -173,8 +173,8 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
         trace!(?commands, "Calculated commands for provider daemonscaler");
 
         let status = match (spread_status.is_empty(), commands.is_empty()) {
-            (true, true) => StatusInfo::ready(""),
-            (_, false) => StatusInfo::compensating(""),
+            (true, true) => StatusInfo::deployed(""),
+            (_, false) => StatusInfo::reconciling(""),
             (false, true) => StatusInfo::failed(
                 &spread_status
                     .into_iter()
@@ -199,7 +199,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
             store: self.store.clone(),
             provider_id: self.provider_id.clone(),
             id: self.id.clone(),
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         };
 
         cleanerupper.reconcile().await
@@ -253,7 +253,7 @@ impl<S: ReadStore + Send + Sync> ProviderDaemonScaler<S> {
                 ..config
             },
             id,
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         }
     }
 

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -102,13 +102,21 @@ where
                 self.reconcile().await
             }
             Event::LinkdefDeleted(LinkdefDeleted { linkdef })
-            | Event::LinkdefSet(LinkdefSet { linkdef })
                 if linkdef.contract_id == self.config.provider_contract_id
                     && linkdef.link_name == self.config.provider_link_name
                     && linkdef.provider_id == self.provider_id().await.unwrap_or_default()
                     && linkdef.actor_id == self.actor_id().await.unwrap_or_default() =>
             {
                 self.reconcile().await
+            }
+            Event::LinkdefSet(LinkdefSet { linkdef })
+                if linkdef.contract_id == self.config.provider_contract_id
+                    && linkdef.link_name == self.config.provider_link_name
+                    && linkdef.provider_id == self.provider_id().await.unwrap_or_default()
+                    && linkdef.actor_id == self.actor_id().await.unwrap_or_default() =>
+            {
+                *self.status.write().await = StatusInfo::ready("");
+                Ok(Vec::new())
             }
             _ => Ok(Vec::new()),
         }

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -115,7 +115,7 @@ where
                     && linkdef.provider_id == self.provider_id().await.unwrap_or_default()
                     && linkdef.actor_id == self.actor_id().await.unwrap_or_default() =>
             {
-                *self.status.write().await = StatusInfo::ready("");
+                *self.status.write().await = StatusInfo::deployed("");
                 Ok(Vec::new())
             }
             _ => Ok(Vec::new()),
@@ -169,7 +169,7 @@ where
             // };
 
             let commands = if !exists {
-                *self.status.write().await = StatusInfo::compensating(&format!(
+                *self.status.write().await = StatusInfo::reconciling(&format!(
                     "Putting link definition between {actor_id} and {provider_id}"
                 ));
                 vec![Command::PutLinkdef(PutLinkdef {
@@ -181,13 +181,13 @@ where
                     model_name: self.config.model_name.to_owned(),
                 })]
             } else {
-                *self.status.write().await = StatusInfo::ready("");
+                *self.status.write().await = StatusInfo::deployed("");
                 Vec::with_capacity(0)
             };
             Ok(commands)
         } else {
             trace!("Actor ID and provider ID are not initialized, skipping linkdef creation");
-            *self.status.write().await = StatusInfo::compensating(&format!(
+            *self.status.write().await = StatusInfo::reconciling(&format!(
                 "Linkdef pending, waiting for {} and {} to start",
                 self.config.actor_reference, self.config.provider_reference
             ));
@@ -253,7 +253,7 @@ impl<S: ReadStore + Send + Sync, L: LinkSource> LinkScaler<S, L> {
             },
             ctl_client,
             id,
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         }
     }
 

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -230,7 +230,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
         trace!(?commands, "Calculated commands for actor scaler");
 
         let status = if spread_status.is_empty() {
-            StatusInfo::ready("")
+            StatusInfo::deployed("")
         } else {
             StatusInfo::failed(
                 &spread_status
@@ -258,7 +258,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
             spread_requirements,
             actor_id: self.actor_id.clone(),
             id: self.id.clone(),
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         };
 
         cleanerupper.reconcile().await
@@ -288,7 +288,7 @@ impl<S: ReadStore + Send + Sync> ActorSpreadScaler<S> {
                 model_name,
             },
             id,
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         }
     }
 

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -244,7 +244,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
         trace!(?commands, "Calculated commands for provider scaler");
 
         let status = if spread_status.is_empty() {
-            StatusInfo::ready("")
+            StatusInfo::deployed("")
         } else {
             StatusInfo::failed(
                 &spread_status
@@ -272,7 +272,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
             spread_requirements,
             provider_id: self.provider_id.clone(),
             id: self.id.clone(),
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         };
 
         cleanerupper.reconcile().await
@@ -314,7 +314,7 @@ impl<S: ReadStore + Send + Sync> ProviderSpreadScaler<S> {
             provider_id: OnceCell::new(),
             config,
             id,
-            status: RwLock::new(StatusInfo::compensating("")),
+            status: RwLock::new(StatusInfo::reconciling("")),
         }
     }
 

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -203,7 +203,7 @@ impl StatusInfo {
         }
     }
 
-    pub fn ready(message: &str) -> Self {
+    pub fn deployed(message: &str) -> Self {
         StatusInfo {
             status_type: StatusType::Deployed,
             message: message.to_owned(),
@@ -217,7 +217,7 @@ impl StatusInfo {
         }
     }
 
-    pub fn compensating(message: &str) -> Self {
+    pub fn reconciling(message: &str) -> Self {
         StatusInfo {
             status_type: StatusType::Reconciling,
             message: message.to_owned(),

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -858,7 +858,7 @@ where
         let status = if commands.is_empty() {
             scaler_status(&scalers).await
         } else {
-            StatusInfo::compensating("Model deployed, running initial compensating commands")
+            StatusInfo::reconciling("Model deployed, running initial compensating commands")
         };
 
         trace!(?status, "Setting status");
@@ -909,7 +909,7 @@ where
         let status = if commands.is_empty() {
             scaler_status(&scalers).await
         } else {
-            StatusInfo::compensating(&format!(
+            StatusInfo::reconciling(&format!(
                 "Event {event} modified scaler \"{}\" state, running compensating commands",
                 name.to_owned(),
             ))
@@ -940,7 +940,7 @@ where
             let status = if commands.is_empty() {
                 scaler_status(scalers).await
             } else {
-                StatusInfo::compensating(&format!(
+                StatusInfo::reconciling(&format!(
                     "Event {event} modified scaler \"{}\" state, running compensating commands",
                     name.to_owned(),
                 ))


### PR DESCRIPTION
## Feature or Problem
This PR resolves a problematic infinite loop when it comes to link scalers. In rare cases it's possible for a link scaler to receive a `LinkdefSet` event for its own link definition, but when it goes to query the list of link definitions nothing comes back. This is an external problem to wadm, usually manifesting if a host fails to respond in time, but in this case the link scaler will publish a command to set the link definition and then will trigger a `LinkdefSet` event ➿.

This PR simply shortens this feedback loop to doing what is intended, when a link scaler receives the `LinkdefSet` event and it matches all of its configuration parameters, it updates its internal status to `Deployed`. 

## Related Issues
This is a temporary patch, #206 should make this unnecessary but there's no harm in keeping this logic.

## Release Information
v0.10.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
