### PR TITLE
feat(events): support actor_scaled event

### DIFF
--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -93,10 +93,8 @@ pub trait EventType {
 /// A lattice event
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum Event {
-    ActorStarted(ActorStarted),
     ActorsStarted(ActorsStarted),
     ActorsStartFailed(ActorsStartFailed),
-    ActorStopped(ActorStopped),
     ActorsStopped(ActorsStopped),
     ActorScaled(ActorScaled),
     ActorScaleFailed(ActorScaleFailed),
@@ -120,10 +118,8 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Event::ActorStarted(_) => write!(f, "ActorStarted"),
             Event::ActorsStarted(_) => write!(f, "ActorsStarted"),
             Event::ActorsStartFailed(_) => write!(f, "ActorsStartFailed"),
-            Event::ActorStopped(_) => write!(f, "ActorStopped"),
             Event::ActorsStopped(_) => write!(f, "ActorsStopped"),
             Event::ActorScaled(_) => write!(f, "ActorScaled"),
             Event::ActorScaleFailed(_) => write!(f, "ActorScaleFailed"),
@@ -149,12 +145,10 @@ impl TryFrom<CloudEvent> for Event {
 
     fn try_from(value: CloudEvent) -> Result<Self, Self::Error> {
         match value.ty() {
-            ActorStarted::TYPE => ActorStarted::try_from(value).map(Event::ActorStarted),
             ActorsStarted::TYPE => ActorsStarted::try_from(value).map(Event::ActorsStarted),
             ActorsStartFailed::TYPE => {
                 ActorsStartFailed::try_from(value).map(Event::ActorsStartFailed)
             }
-            ActorStopped::TYPE => ActorStopped::try_from(value).map(Event::ActorStopped),
             ActorsStopped::TYPE => ActorsStopped::try_from(value).map(Event::ActorsStopped),
             ActorScaled::TYPE => ActorScaled::try_from(value).map(Event::ActorScaled),
             ActorScaleFailed::TYPE => {
@@ -195,10 +189,8 @@ impl TryFrom<Event> for CloudEvent {
 
     fn try_from(value: Event) -> Result<Self, Self::Error> {
         let ty = match value {
-            Event::ActorStarted(_) => ActorStarted::TYPE,
             Event::ActorsStarted(_) => ActorsStarted::TYPE,
             Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
-            Event::ActorStopped(_) => ActorStopped::TYPE,
             Event::ActorsStopped(_) => ActorsStopped::TYPE,
             Event::ActorScaled(_) => ActorScaled::TYPE,
             Event::ActorScaleFailed(_) => ActorScaleFailed::TYPE,
@@ -235,10 +227,8 @@ impl Serialize for Event {
         S: serde::Serializer,
     {
         match self {
-            Event::ActorStarted(evt) => evt.serialize(serializer),
             Event::ActorsStarted(evt) => evt.serialize(serializer),
             Event::ActorsStartFailed(evt) => evt.serialize(serializer),
-            Event::ActorStopped(evt) => evt.serialize(serializer),
             Event::ActorsStopped(evt) => evt.serialize(serializer),
             Event::ActorScaled(evt) => evt.serialize(serializer),
             Event::ActorScaleFailed(evt) => evt.serialize(serializer),
@@ -268,10 +258,8 @@ impl Event {
     /// Returns the underlying raw cloudevent type for the event
     pub fn raw_type(&self) -> &str {
         match self {
-            Event::ActorStarted(_) => ActorStarted::TYPE,
             Event::ActorsStarted(_) => ActorsStarted::TYPE,
             Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
-            Event::ActorStopped(_) => ActorStopped::TYPE,
             Event::ActorsStopped(_) => ActorsStopped::TYPE,
             Event::ActorScaled(_) => ActorScaled::TYPE,
             Event::ActorScaleFailed(_) => ActorScaleFailed::TYPE,
@@ -313,28 +301,6 @@ pub enum ConversionError {
 //
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ActorStarted {
-    pub annotations: BTreeMap<String, String>,
-    // Commented out for now because the host broken it and we actually don't use this right now
-    // pub api_version: usize,
-    pub claims: ActorClaims,
-    pub image_ref: String,
-    // TODO: Parse as UUID?
-    pub instance_id: String,
-    // TODO: Parse as nkey?
-    pub public_key: String,
-    #[serde(default)]
-    pub host_id: String,
-}
-
-event_impl!(
-    ActorStarted,
-    "com.wasmcloud.lattice.actor_started",
-    source,
-    host_id
-);
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ActorsStarted {
     pub annotations: BTreeMap<String, String>,
     // Commented out for now because the host broken it and we actually don't use this right now
@@ -369,24 +335,6 @@ pub struct ActorsStartFailed {
 event_impl!(
     ActorsStartFailed,
     "com.wasmcloud.lattice.actors_start_failed",
-    source,
-    host_id
-);
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ActorStopped {
-    #[serde(default)]
-    pub annotations: BTreeMap<String, String>,
-    pub instance_id: String,
-    // TODO: Parse as nkey?
-    pub public_key: String,
-    #[serde(default)]
-    pub host_id: String,
-}
-
-event_impl!(
-    ActorStopped,
-    "com.wasmcloud.lattice.actor_stopped",
     source,
     host_id
 );

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -98,6 +98,8 @@ pub enum Event {
     ActorsStartFailed(ActorsStartFailed),
     ActorStopped(ActorStopped),
     ActorsStopped(ActorsStopped),
+    ActorScaled(ActorScaled),
+    ActorScaleFailed(ActorScaleFailed),
     ProviderStarted(ProviderStarted),
     ProviderStopped(ProviderStopped),
     ProviderStartFailed(ProviderStartFailed),
@@ -123,6 +125,8 @@ impl Display for Event {
             Event::ActorsStartFailed(_) => write!(f, "ActorsStartFailed"),
             Event::ActorStopped(_) => write!(f, "ActorStopped"),
             Event::ActorsStopped(_) => write!(f, "ActorsStopped"),
+            Event::ActorScaled(_) => write!(f, "ActorScaled"),
+            Event::ActorScaleFailed(_) => write!(f, "ActorScaleFailed"),
             Event::ProviderStarted(_) => write!(f, "ProviderStarted"),
             Event::ProviderStopped(_) => write!(f, "ProviderStopped"),
             Event::ProviderStartFailed(_) => write!(f, "ProviderStartFailed"),
@@ -152,6 +156,10 @@ impl TryFrom<CloudEvent> for Event {
             }
             ActorStopped::TYPE => ActorStopped::try_from(value).map(Event::ActorStopped),
             ActorsStopped::TYPE => ActorsStopped::try_from(value).map(Event::ActorsStopped),
+            ActorScaled::TYPE => ActorScaled::try_from(value).map(Event::ActorScaled),
+            ActorScaleFailed::TYPE => {
+                ActorScaleFailed::try_from(value).map(Event::ActorScaleFailed)
+            }
             ProviderStarted::TYPE => ProviderStarted::try_from(value).map(Event::ProviderStarted),
             ProviderStopped::TYPE => ProviderStopped::try_from(value).map(Event::ProviderStopped),
             ProviderStartFailed::TYPE => {
@@ -192,6 +200,8 @@ impl TryFrom<Event> for CloudEvent {
             Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
             Event::ActorStopped(_) => ActorStopped::TYPE,
             Event::ActorsStopped(_) => ActorsStopped::TYPE,
+            Event::ActorScaled(_) => ActorScaled::TYPE,
+            Event::ActorScaleFailed(_) => ActorScaleFailed::TYPE,
             Event::ProviderStarted(_) => ProviderStarted::TYPE,
             Event::ProviderStopped(_) => ProviderStopped::TYPE,
             Event::ProviderStartFailed(_) => ProviderStartFailed::TYPE,
@@ -230,6 +240,8 @@ impl Serialize for Event {
             Event::ActorsStartFailed(evt) => evt.serialize(serializer),
             Event::ActorStopped(evt) => evt.serialize(serializer),
             Event::ActorsStopped(evt) => evt.serialize(serializer),
+            Event::ActorScaled(evt) => evt.serialize(serializer),
+            Event::ActorScaleFailed(evt) => evt.serialize(serializer),
             Event::ProviderStarted(evt) => evt.serialize(serializer),
             Event::ProviderStopped(evt) => evt.serialize(serializer),
             Event::ProviderStartFailed(evt) => evt.serialize(serializer),
@@ -261,6 +273,8 @@ impl Event {
             Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
             Event::ActorStopped(_) => ActorStopped::TYPE,
             Event::ActorsStopped(_) => ActorsStopped::TYPE,
+            Event::ActorScaled(_) => ActorScaled::TYPE,
+            Event::ActorScaleFailed(_) => ActorScaleFailed::TYPE,
             Event::ProviderStarted(_) => ProviderStarted::TYPE,
             Event::ProviderStopped(_) => ProviderStopped::TYPE,
             Event::ProviderStartFailed(_) => ProviderStopped::TYPE,
@@ -394,6 +408,44 @@ pub struct ActorsStopped {
 event_impl!(
     ActorsStopped,
     "com.wasmcloud.lattice.actors_stopped",
+    source,
+    host_id
+);
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ActorScaled {
+    pub annotations: BTreeMap<String, String>,
+    pub claims: ActorClaims,
+    pub image_ref: String,
+    pub max_instances: usize,
+    // TODO: Parse as nkey?
+    pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
+}
+
+event_impl!(
+    ActorScaled,
+    "com.wasmcloud.lattice.actor_scaled",
+    source,
+    host_id
+);
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ActorScaleFailed {
+    pub annotations: BTreeMap<String, String>,
+    pub image_ref: String,
+    pub max_instances: usize,
+    // TODO: Parse as nkey?
+    pub public_key: String,
+    #[serde(default)]
+    pub host_id: String,
+    pub error: String,
+}
+
+event_impl!(
+    ActorScaleFailed,
+    "com.wasmcloud.lattice.actor_scale_failed",
     source,
     host_id
 );

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use super::StateKind;
 use crate::events::{
-    ActorScaled, ActorStarted, ActorsStarted, BackwardsCompatActors, BackwardsCompatProviders,
-    HostHeartbeat, HostStarted, ProviderInfo, ProviderStarted,
+    ActorScaled, ActorsStarted, BackwardsCompatActors, BackwardsCompatProviders, HostHeartbeat,
+    HostStarted, ProviderInfo, ProviderStarted,
 };
 
 /// A wasmCloud Capability provider
@@ -181,46 +181,6 @@ impl Actor {
 
 impl StateKind for Actor {
     const KIND: &'static str = "actor";
-}
-
-impl From<ActorStarted> for Actor {
-    fn from(value: ActorStarted) -> Self {
-        Actor {
-            id: value.public_key,
-            name: value.claims.name,
-            capabilities: value.claims.capabilites,
-            issuer: value.claims.issuer,
-            call_alias: value.claims.call_alias,
-            reference: value.image_ref,
-            instances: HashMap::from_iter([(
-                value.host_id,
-                HashSet::from_iter([WadmActorInfo {
-                    annotations: value.annotations,
-                    count: 1,
-                }]),
-            )]),
-        }
-    }
-}
-
-impl From<&ActorStarted> for Actor {
-    fn from(value: &ActorStarted) -> Self {
-        Actor {
-            id: value.public_key.clone(),
-            name: value.claims.name.clone(),
-            capabilities: value.claims.capabilites.clone(),
-            issuer: value.claims.issuer.clone(),
-            call_alias: value.claims.call_alias.clone(),
-            reference: value.image_ref.clone(),
-            instances: HashMap::from_iter([(
-                value.host_id.clone(),
-                HashSet::from_iter([WadmActorInfo {
-                    annotations: value.annotations.clone(),
-                    count: 1,
-                }]),
-            )]),
-        }
-    }
 }
 
 impl From<ActorsStarted> for Actor {

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use super::StateKind;
 use crate::events::{
-    ActorStarted, ActorsStarted, BackwardsCompatActors, BackwardsCompatProviders, HostHeartbeat,
-    HostStarted, ProviderInfo, ProviderStarted,
+    ActorScaled, ActorStarted, ActorsStarted, BackwardsCompatActors, BackwardsCompatProviders,
+    HostHeartbeat, HostStarted, ProviderInfo, ProviderStarted,
 };
 
 /// A wasmCloud Capability provider
@@ -257,6 +257,46 @@ impl From<&ActorsStarted> for Actor {
                 HashSet::from_iter([WadmActorInfo {
                     annotations: value.annotations.clone(),
                     count: value.count,
+                }]),
+            )]),
+        }
+    }
+}
+
+impl From<ActorScaled> for Actor {
+    fn from(value: ActorScaled) -> Self {
+        Actor {
+            id: value.public_key,
+            name: value.claims.name,
+            capabilities: value.claims.capabilites,
+            issuer: value.claims.issuer,
+            call_alias: value.claims.call_alias,
+            reference: value.image_ref,
+            instances: HashMap::from_iter([(
+                value.host_id,
+                HashSet::from_iter([WadmActorInfo {
+                    annotations: value.annotations,
+                    count: value.max_instances,
+                }]),
+            )]),
+        }
+    }
+}
+
+impl From<&ActorScaled> for Actor {
+    fn from(value: &ActorScaled) -> Self {
+        Actor {
+            id: value.public_key.clone(),
+            name: value.claims.name.clone(),
+            capabilities: value.claims.capabilites.clone(),
+            issuer: value.claims.issuer.clone(),
+            call_alias: value.claims.call_alias.clone(),
+            reference: value.image_ref.clone(),
+            instances: HashMap::from_iter([(
+                value.host_id.clone(),
+                HashSet::from_iter([WadmActorInfo {
+                    annotations: value.annotations.clone(),
+                    count: value.max_instances,
                 }]),
             )]),
         }

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -1167,11 +1167,8 @@ where
                 .annotations
                 .get(APP_SPEC_ANNOTATION)
                 .map(|s| s.as_str())),
-            // We don't care about the individual events, just when a full scale event happens (the
-            // ActorsStarted/Stopped events)
-            Event::ActorStarted(_) | Event::ActorStopped(_) => Ok(None),
             // All other events we don't care about for state. Explicitly mention them in order
-            // to make sure we don't forget to handle them
+            // to make sure we don't forget to handle them when new events are added.
             Event::LinkdefSet(_)
             | Event::LinkdefDeleted(_)
             | Event::ProviderStartFailed(_)

--- a/test/data/events.json
+++ b/test/data/events.json
@@ -106,32 +106,6 @@
   },
   {
     "data": {
-      "annotations": {},
-      "api_version": "n/a",
-      "claims": {
-        "call_alias": null,
-        "caps": ["wasmcloud:httpserver"],
-        "expires_human": "never",
-        "issuer": "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW",
-        "name": "Echo",
-        "not_before_human": "immediately",
-        "revision": 4,
-        "tags": [],
-        "version": "0.3.4"
-      },
-      "image_ref": "wasmcloud.azurecr.io/echo:0.3.4",
-      "instance_id": "5ebc4920-cec4-44a6-a718-df4d43d94b09",
-      "public_key": "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
-    },
-    "datacontenttype": "application/json",
-    "id": "84ee3ab6-f951-4423-99b6-73ddf58bcd1d",
-    "source": "NB6PMW4RGLBP3NAVUVO2IH34VFJFSX7LF7TJOQCDU4GGUGF3P57SZLPX",
-    "specversion": "1.0",
-    "time": "2023-02-14T19:21:38.222286Z",
-    "type": "com.wasmcloud.lattice.actor_started"
-  },
-  {
-    "data": {
       "actors": {
         "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5": 1
       },
@@ -242,18 +216,6 @@
     "specversion": "1.0",
     "time": "2023-02-14T19:22:57.131368Z",
     "type": "com.wasmcloud.lattice.linkdef_deleted"
-  },
-  {
-    "data": {
-      "instance_id": "5ebc4920-cec4-44a6-a718-df4d43d94b09",
-      "public_key": "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
-    },
-    "datacontenttype": "application/json",
-    "id": "fc22b1cb-5245-404c-9c36-a61ea8d3bac3",
-    "source": "NB6PMW4RGLBP3NAVUVO2IH34VFJFSX7LF7TJOQCDU4GGUGF3P57SZLPX",
-    "specversion": "1.0",
-    "time": "2023-02-14T19:23:01.877353Z",
-    "type": "com.wasmcloud.lattice.actor_stopped"
   },
   {
     "data": {

--- a/test/data/events.json
+++ b/test/data/events.json
@@ -1,5 +1,47 @@
 [
   {
+    "specversion": "1.0",
+    "id": "018d32ce-6133-2f9d-0b69-1437b25cf59c",
+    "type": "com.wasmcloud.lattice.actor_scaled",
+    "source": "NCBAWBHRT6JNSQIYQEURM3AQZ74I6HTQRRCFMTVPC3OAX4BUTCNTYADZ",
+    "datacontenttype": "application/json",
+    "time": "2024-01-22T20:13:22.611283Z",
+    "data": {
+      "annotations": {},
+      "claims": {
+        "call_alias": null,
+        "caps": ["wasmcloud:httpserver"],
+        "expires_human": "TODO",
+        "issuer": "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW",
+        "name": "Echo",
+        "not_before_human": "TODO",
+        "revision": 4,
+        "tags": [],
+        "version": "0.3.4"
+      },
+      "host_id": "NCBAWBHRT6JNSQIYQEURM3AQZ74I6HTQRRCFMTVPC3OAX4BUTCNTYADZ",
+      "image_ref": "wasmcloud.azurecr.io/echo:0.3.4",
+      "max_instances": 10,
+      "public_key": "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
+    }
+  },
+  {
+    "specversion": "1.0",
+    "id": "018d32d0-4687-8e53-e77b-4af4d6dc0a67",
+    "type": "com.wasmcloud.lattice.actor_scale_failed",
+    "source": "NCBAWBHRT6JNSQIYQEURM3AQZ74I6HTQRRCFMTVPC3OAX4BUTCNTYADZ",
+    "datacontenttype": "application/json",
+    "time": "2024-01-22T20:15:26.855859Z",
+    "data": {
+      "annotations": {},
+      "error": "actor is already running with a different image reference `wasmcloud.azurecr.io/echo:0.3.4`",
+      "host_id": "NCBAWBHRT6JNSQIYQEURM3AQZ74I6HTQRRCFMTVPC3OAX4BUTCNTYADZ",
+      "image_ref": "wasmcloud.azurecr.io/echo:0.3.8",
+      "max_instances": 11,
+      "public_key": "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
+    }
+  },
+  {
     "data": {
       "annotations": {},
       "claims": {

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -59,9 +59,7 @@ async fn test_commands() {
         .await
         .expect("Should be able to handle command properly");
 
-    // We are starting two actors so wait for both
-    wait_for_event(&mut sub, "actor_started").await;
-    wait_for_event(&mut sub, "actor_started").await;
+    wait_for_event(&mut sub, "actors_started").await;
     // Sorry for the lazy de-racing, but for some reason if we don't wait for a bit the host hasn't
     // finished updating its inventory
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -280,9 +278,7 @@ async fn test_commands() {
         .await
         .expect("Should be able to handle command properly");
 
-    // We're stopping two actors so we need to wait for both events
-    wait_for_event(&mut sub, "actor_stopped").await;
-    wait_for_event(&mut sub, "actor_stopped").await;
+    wait_for_event(&mut sub, "actors_stopped").await;
 
     // Get the current providers and make sure stuff was started
     let inventory = ctl_client

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -97,7 +97,7 @@ async fn test_event_stream() -> Result<()> {
     helpers::run_wash_command(["start", "actor", ECHO_REFERENCE, "--ctl-port", &ctl_port]).await;
 
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
-    if let Event::ActorStarted(actor) = evt.as_ref() {
+    if let Event::ActorsStarted(actor) = evt.as_ref() {
         assert_eq!(
             actor.public_key, ECHO_ACTOR_ID,
             "Expected to get a started event for the right actor, got ID: {}",
@@ -240,7 +240,7 @@ async fn test_event_stream() -> Result<()> {
     .await;
 
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
-    if let Event::ActorStopped(actor) = evt.as_ref() {
+    if let Event::ActorsStopped(actor) = evt.as_ref() {
         assert_eq!(
             actor.public_key, ECHO_ACTOR_ID,
             "Expected to get a stopped event for the right actor, got ID: {}",
@@ -291,7 +291,7 @@ async fn test_nack_and_rereceive() -> Result<()> {
     // Get the event and then nack it
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
     // Make sure we got the right event
-    if let Event::ActorStarted(actor) = evt.as_ref() {
+    if let Event::ActorsStarted(actor) = evt.as_ref() {
         assert_eq!(
             actor.public_key, ECHO_ACTOR_ID,
             "Expected to get a started event for the right actor, got ID: {}",
@@ -305,7 +305,7 @@ async fn test_nack_and_rereceive() -> Result<()> {
 
     // Now do it again and make sure we get the same event
     let mut evt = wait_for_event(&mut stream, DEFAULT_TIMEOUT_DURATION).await;
-    if let Event::ActorStarted(actor) = evt.as_ref() {
+    if let Event::ActorsStarted(actor) = evt.as_ref() {
         assert_eq!(
             actor.public_key, ECHO_ACTOR_ID,
             "Expected to get a started event for the right actor, got ID: {}",
@@ -341,11 +341,6 @@ async fn wait_for_event(
         Event::HostHeartbeat(_)
             | Event::ProviderHealthCheckPassed(_)
             | Event::ProviderHealthCheckFailed(_)
-            // NOTE(brooksmtownsend): Ignoring the plural actor event for now as this test
-            // is more for the event stream than scalers. When we use plural events to
-            // synthesize lattice state, this should be changed to the singular event
-            | Event::ActorsStarted(_)
-            | Event::ActorsStopped(_)
     ) {
         evt.ack().await.expect("Should be able to ack message");
         // Just a copy paste here so we don't have to deal with async recursion


### PR DESCRIPTION
## Feature or Problem
This PR adds a handler for the actor_scaled event which will be able to summarize all of the information in `actors_started` and `actors_stopped` with an idempotent event.

Though there's future work to really make this work with v0.82, this can be released at any time without problems as the event doesn't exist yet.

## Related Issues
Requires https://github.com/wasmCloud/wasmCloud/pull/1336
Filed #239 to cover future work that can't be done today.

## Release Information
v0.11.0

## Consumer Impact
Note that, if testing with the unreleased v0.82.0, this may cause duplicate state updates because both the actors_started and actor_scaled events will be handled. I'll be creating an issue shortly to cover this update.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
I modified the `test_all_state` function to ensure functionality around starting/stopping/scaling up/down actors.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
