### PR TITLE
feat(*): subscribe to updated lattice event subjects

### DIFF
--- a/bin/connections.rs
+++ b/bin/connections.rs
@@ -45,7 +45,7 @@ impl ControlClientConstructor {
 /// Returns the topic prefix to use for the given multitenant prefix and topic prefix. The
 /// default prefix is `wasmbus.ctl`.
 ///
-/// If running in multitenant mode, we listen to events on *.wasmbus.evt and need to send commands
+/// If running in multitenant mode, we listen to events on *.wasmbus.evt.*.> and need to send commands
 /// back to the '*' account. This match takes into account custom prefixes as well to support
 /// advanced use cases.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ pub mod test_util;
 /// some wiggle room. Exported to make setting defaults easy
 pub const DEFAULT_EXPIRY_TIME: Duration = Duration::from_secs(70);
 /// Default topic to listen to for all lattice events
-pub const DEFAULT_EVENTS_TOPIC: &str = "wasmbus.evt.*";
+pub const DEFAULT_EVENTS_TOPIC: &str = "wasmbus.evt.*.>";
 /// Default topic to listen to for all lattice events in a multitenant deployment
-pub const DEFAULT_MULTITENANT_EVENTS_TOPIC: &str = "*.wasmbus.evt.*";
+pub const DEFAULT_MULTITENANT_EVENTS_TOPIC: &str = "*.wasmbus.evt.*.>";
 /// Default topic to listen to for all commands
 pub const DEFAULT_COMMANDS_TOPIC: &str = "wadm.cmd.*";
 /// Default topic to listen to for all status updates. wadm.status.<lattice_id>.<manifest_name>

--- a/test/nats/nats-test.conf
+++ b/test/nats/nats-test.conf
@@ -29,8 +29,8 @@ accounts: {
         # Listen to wasmbus.evt events and wadm API commands from account A and B
         # Lattice IDs are unique, so we don't need to add account prefixes for them
         imports: [
-            {stream: {account: A, subject: wasmbus.evt.*}, prefix: Axxx}
-            {stream: {account: B, subject: wasmbus.evt.*}, prefix: Ayyy}
+            {stream: {account: A, subject: wasmbus.evt.>}, prefix: Axxx}
+            {stream: {account: B, subject: wasmbus.evt.>}, prefix: Ayyy}
             {service: {account: A, subject: wasmbus.ctl.>}, to: Axxx.wasmbus.ctl.>}
             {service: {account: B, subject: wasmbus.ctl.>}, to: Ayyy.wasmbus.ctl.>}
         ]
@@ -43,7 +43,7 @@ accounts: {
             {service: {account: WADM, subject: Axxx.wadm.api.>}, to: wadm.api.>}
         ]
         exports: [
-            {stream: wasmbus.evt.*, accounts: [WADM]}
+            {stream: wasmbus.evt.>, accounts: [WADM]}
             {service: wasmbus.ctl.>, accounts: [WADM], response_type: stream}
         ]
     }
@@ -55,7 +55,7 @@ accounts: {
             {service: {account: WADM, subject: Ayyy.wadm.api.>}, to: wadm.api.>}
         ]
         exports: [
-            {stream: wasmbus.evt.*, accounts: [WADM]}
+            {stream: wasmbus.evt.>, accounts: [WADM]}
             {service: wasmbus.ctl.>, accounts: [WADM], response_type: stream}
         ]
     }

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -37,7 +37,7 @@ async fn test_commands() {
 
     let mut sub = wrapper
         .client
-        .subscribe("wasmbus.evt.default".to_string())
+        .subscribe("wasmbus.evt.default.>".to_string())
         .await
         .unwrap();
 
@@ -310,7 +310,7 @@ async fn test_annotation_stop() {
 
     let mut sub = wrapper
         .client
-        .subscribe("wasmbus.evt.default".to_string())
+        .subscribe("wasmbus.evt.default.>".to_string())
         .await
         .unwrap();
 

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 const HTTP_SERVER_REFERENCE: &str = "wasmcloud.azurecr.io/httpserver:0.17.0";
 const ECHO_REFERENCE: &str = "wasmcloud.azurecr.io/echo:0.3.4";
 const CONTRACT_ID: &str = "wasmcloud:httpserver";
-const WASMBUS_EVENT_TOPIC: &str = "wasmbus.evt.default";
+const WASMBUS_EVENT_TOPIC: &str = "wasmbus.evt.default.>";
 const STREAM_NAME: &str = "test_wadm_events";
 
 // Timeout accounts for time to pull stuff from registry


### PR DESCRIPTION
## Feature or Problem
The wasmCloud host now emits events on `wasmbus.evt.{lattice-id}.{event-type}`, so this updates wadm to use the suffixed subject

## Release Information
~Next. Not a breaking change, so maybe v0.10.1?~
v0.11.0

## Consumer Impact
N/A

## Testing
Updated existing tests