### PR TITLE
chore: Update the default OTLP HTTP port to match the current OTEL spec

### DIFF
--- a/bin/logging.rs
+++ b/bin/logging.rs
@@ -60,7 +60,7 @@ pub fn configure_tracing(
     }
 
     let mut tracing_endpoint =
-        tracing_endpoint.unwrap_or_else(|| format!("http://localhost:55681{}", TRACING_PATH));
+        tracing_endpoint.unwrap_or_else(|| format!("http://localhost:4318{}", TRACING_PATH));
     if !tracing_endpoint.ends_with(TRACING_PATH) {
         tracing_endpoint.push_str(TRACING_PATH);
     }

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -63,7 +63,7 @@ struct Args {
     tracing_enabled: bool,
 
     /// The endpoint to use for tracing. Setting this flag enables tracing, even if --tracing is set
-    /// to false. Defaults to http://localhost:55681/v1/traces if not set and tracing is enabled
+    /// to false. Defaults to http://localhost:4318/v1/traces if not set and tracing is enabled
     #[arg(short = 'e', long = "tracing-endpoint", env = "WADM_TRACING_ENDPOINT")]
     tracing_endpoint: Option<String>,
 


### PR DESCRIPTION
## Feature or Problem

OTEL changed it's default port from 55680/55681 to 4317/4318 for [gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-default-port) and [HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp-default-port) respectively [a while back in the spec](https://github.com/open-telemetry/opentelemetry-specification/pull/1839) and [in the collector](https://github.com/open-telemetry/opentelemetry-collector/pull/3743), let's switch over to using the current ports defined in the spec.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
