### PR TITLE
feat: support TLS CA certificates when building a NATS client

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -111,6 +111,10 @@ struct Args {
     )]
     nats_creds: Option<PathBuf>,
 
+    /// (Optional) NATS TLS certificate file to use when authenticating
+    #[arg(long = "nats-tls-ca-file", env = "WADM_NATS_TLS_CA_FILE")]
+    nats_tls_ca_file: Option<PathBuf>,
+
     /// Name of the bucket used for storage of lattice state
     #[arg(
         long = "state-bucket-name",
@@ -176,6 +180,7 @@ async fn main() -> anyhow::Result<()> {
         args.nats_seed.clone(),
         args.nats_jwt.clone(),
         args.nats_creds.clone(),
+        args.nats_tls_ca_file.clone(),
     )
     .await?;
 


### PR DESCRIPTION
## Feature or Problem
NATS servers support TLS, which means sometimes you need to be able to provide certificates when instantiating a client.

This specifically adds support for supplying a CA certificate to use when connecting to a NATS server. I opted not to add client certificate support for mTLS for now, but it's an easy lift if it should just be added now.
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
Tested locally using a NATS server with a self-signed CA and cert. Everything worked fine

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
