### PR TITLE
feat(model): support labels in manifest

### DIFF
--- a/oam/kvcounter.yaml
+++ b/oam/kvcounter.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     version: v0.0.1
     description: "Kvcounter demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
+  labels:
+    app.oam.io/name: kvcounter-rust
 spec:
   components:
     - name: kvcounter

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -73,9 +73,12 @@ impl Manifest {
 pub struct Metadata {
     /// The name of the manifest. This must be unique per lattice
     pub name: String,
-    /// Optional data for annotating this manifest
+    /// Optional data for annotating this manifest see <https://github.com/oam-dev/spec/blob/master/metadata.md#annotations-format>
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<String, String>,
+    /// Optional data for labeling this manifest, see <https://github.com/oam-dev/spec/blob/master/metadata.md#label-format>
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
 }
 
 /// A representation of an OAM specification
@@ -656,6 +659,10 @@ mod test {
                     "This is my app".to_string(),
                 ),
             ]),
+            labels: BTreeMap::from([(
+                "prefix.dns.prefix/name-for_a.123".to_string(),
+                "this is a valid label".to_string(),
+            )]),
         };
         let manifest = Manifest {
             api_version: OAM_VERSION.to_owned(),

--- a/test/data/simple.yaml
+++ b/test/data/simple.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: hello-simple
   annotations:
-    version: v0.0.1
+    version: "v0.0.1"
     description: "A Hello World app for testing, most basic HTTP link"
 spec:
   components:


### PR DESCRIPTION
## Feature or Problem
This PR adds supports for serializing the labels in a manifest and validating that they are correct according to the kubernetes label specification, which also matches the OAM specification.

## Related Issues
Fixes #249 

## Release Information
Next wadm

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Added unit test to sanity check validation rules.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
With a manifest:
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: kvcounter-rust
  annotations:
    version: v0.0.1
    description: "Kvcounter demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
  labels:
    app.kubernetes.io/name: kvcounter-rust
spec:
```

The requested spec comes back as (including the label):
```bash
➜ nats req "wadm.api.default.model.get.kvcounter-rust" '{}'
17:15:21 Sending request on "wadm.api.default.model.get.kvcounter-rust"
17:15:21 Received with rtt 2.827708ms
{"result":"success","message":"Successfully fetched model kvcounter-rust","manifest":{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"kvcounter-rust","annotations":{"description":"Kvcounter demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)","version":"v0.0.1"},"labels":{"app.kubernetes.io/name":"kvcounter-rust"}}
```