### PR TITLE
fix(state): allow actor alias for compat

### DIFF
--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -257,6 +257,7 @@ impl From<&ComponentScaled> for Component {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Host {
     /// A map of component IDs to the number of instances of the component running on the host
+    #[serde(alias = "actors")]
     pub components: HashMap<String, usize>,
 
     /// The randomly generated friendly name of the host


### PR DESCRIPTION
## Feature or Problem
This PR adds a simple serde alias to let wadm handle state from a host that was stored with the "actors" field instead of "components"

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
