### PR TITLE
Fixes from alpha2 testing, bump to alpha3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.11.0-alpha.2"
+version = "0.11.0-alpha.3"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.11.0-alpha.2"
+version = "0.11.0-alpha.3"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/src/scaler/daemonscaler/provider.rs
+++ b/src/scaler/daemonscaler/provider.rs
@@ -14,6 +14,7 @@ use crate::scaler::spreadscaler::{
     compute_ineligible_hosts, eligible_hosts, spreadscaler_annotations,
 };
 use crate::server::StatusInfo;
+use crate::SCALER_KEY;
 use crate::{
     commands::{Command, StartProvider},
     events::{Event, HostStarted, HostStopped},
@@ -122,7 +123,12 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
                         provider_ref: provider_ref.to_string(),
                         annotations: BTreeMap::default(),
                     })
-                    .is_some()
+                    .is_some_and(|provider| {
+                        provider
+                            .annotations
+                            .get(SCALER_KEY)
+                            .is_some_and(|id| id == &self.id)
+                    })
                 {
                     Some(Command::StopProvider(StopProvider {
                         provider_id: provider_id.to_owned(),

--- a/src/scaler/spreadscaler/link.rs
+++ b/src/scaler/spreadscaler/link.rs
@@ -106,7 +106,7 @@ where
             }) if source_id == &self.config.source_id
                 && name == &self.config.name
                 && wit_namespace == &self.config.wit_namespace
-                && wit_package == &self.config.wit_namespace =>
+                && wit_package == &self.config.wit_package =>
             {
                 self.reconcile().await
             }

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -200,7 +200,7 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ActorSpreadScaler<S> {
                         })
                         .unwrap_or_default();
                     let current_count: usize = running_actors_per_host.values().sum();
-                    tracing::info!(current = %current_count, expected = %count, "Calculated running actors, reconciling with expected count");
+                    trace!(current = %current_count, expected = %count, "Calculated running actors, reconciling with expected count");
                     // Here we'll generate commands for the proper host depending on where they are running
                     match current_count.cmp(count) {
                         Ordering::Equal => None,

--- a/src/scaler/spreadscaler/provider.rs
+++ b/src/scaler/spreadscaler/provider.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     server::StatusInfo,
     storage::{Host, ReadStore},
+    SCALER_KEY,
 };
 
 pub const PROVIDER_SPREAD_SCALER_TYPE: &str = "providerspreadscaler";
@@ -136,7 +137,12 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
                         provider_ref: provider_ref.to_string(),
                         annotations: BTreeMap::default(),
                     })
-                    .is_some()
+                    .is_some_and(|provider| {
+                        provider
+                            .annotations
+                            .get(SCALER_KEY)
+                            .is_some_and(|id| id == &self.id)
+                    })
                 {
                     Some(Command::StopProvider(StopProvider {
                         provider_id: provider_id.to_owned(),

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -909,7 +909,7 @@ where
             scaler_status(&scalers).await
         } else {
             StatusInfo::reconciling(&format!(
-                "Event {event} modified scaler \"{}\" state, running compensating commands",
+                "Event {event} modified app \"{}\" state, running compensating commands",
                 name.to_owned(),
             ))
         };
@@ -940,7 +940,7 @@ where
                 scaler_status(scalers).await
             } else {
                 StatusInfo::reconciling(&format!(
-                    "Event {event} modified scaler \"{}\" state, running compensating commands",
+                    "Event {event} modified app \"{}\" state, running compensating commands",
                     name.to_owned(),
                 ))
             };


### PR DESCRIPTION
- **fix(link): issue where delete didn't trigger put**
- **fix(scaler): remove ineligible components**
- **fix(scaler): remove ineligible providers**
- **chore: bump to v0.11.0-alpha.3**

## Feature or Problem
This PR fixes two issues found during alpha testing with v0.11.0
1. Fix issue where the comparison was wrong and deleting a link was not triggering the re-put of that link
1. Fix issue where scalers ignored hosts that were ineligible for their spread requirements. This most easily manifested when moving from one version of an application to another where the spread requirements changed. Since scalers only were concerned with the hosts that matched their requirements, if they previously started components on now "ineligible" hosts they would not remove them. This should make the scalers much better at keeping track of orphaned resources over time since they are constantly ensuring there aren't leftover resources.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v0.11.0-alpha.3

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
