### PR TITLE
feat: named configuration management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.11.0-alpha.3"
+version = "0.11.0-alpha.4"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.11.0-alpha.3"
+version = "0.11.0-alpha.4"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/oam/config.yaml
+++ b/oam/config.yaml
@@ -7,7 +7,7 @@ metadata:
     description: "This is my app"
 spec:
   components:
-    - name: webcap
+    - name: http
       type: component
       properties:
         image: wasmcloud.azurecr.io/http-hello-world:0.1.0
@@ -20,7 +20,7 @@ spec:
     - name: webcap
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.17.0
+        image: ghcr.io/wasmcloud/http-server:0.20.0
         # You can pass any config data you'd like sent to your provider as a string->string map
         config:
           - name: provider_config

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -32,7 +32,7 @@ pub enum Command {
     PutLink(PutLink),
     DeleteLink(DeleteLink),
     PutConfig(PutConfig),
-    DeleteConfig(String),
+    DeleteConfig(DeleteConfig),
 }
 
 impl Command {
@@ -245,3 +245,12 @@ pub struct PutConfig {
 }
 
 from_impl!(PutConfig);
+
+/// Struct for the DeleteConfig command
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct DeleteConfig {
+    /// The name of the configuration to delete
+    pub config_name: String,
+}
+
+from_impl!(DeleteConfig);

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -168,6 +168,8 @@ impl TryFrom<CloudEvent> for Event {
             HostHeartbeat::TYPE => HostHeartbeat::try_from(value).map(Event::HostHeartbeat),
             LinkdefSet::TYPE => LinkdefSet::try_from(value).map(Event::LinkdefSet),
             LinkdefDeleted::TYPE => LinkdefDeleted::try_from(value).map(Event::LinkdefDeleted),
+            ConfigSet::TYPE => ConfigSet::try_from(value).map(Event::ConfigSet),
+            ConfigDeleted::TYPE => ConfigDeleted::try_from(value).map(Event::ConfigDeleted),
             ManifestPublished::TYPE => {
                 ManifestPublished::try_from(value).map(Event::ManifestPublished)
             }

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -95,9 +95,6 @@ pub trait EventType {
 /// A lattice event
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum Event {
-    ActorsStarted(ActorsStarted),
-    ActorsStartFailed(ActorsStartFailed),
-    ActorsStopped(ActorsStopped),
     ComponentScaled(ComponentScaled),
     ComponentScaleFailed(ComponentScaleFailed),
     ProviderStarted(ProviderStarted),
@@ -120,9 +117,6 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Event::ActorsStarted(_) => write!(f, "ActorsStarted"),
-            Event::ActorsStartFailed(_) => write!(f, "ActorsStartFailed"),
-            Event::ActorsStopped(_) => write!(f, "ActorsStopped"),
             Event::ComponentScaled(_) => write!(f, "ComponentScaled"),
             Event::ComponentScaleFailed(_) => write!(f, "ComponentScaleFailed"),
             Event::ProviderStarted(_) => write!(f, "ProviderStarted"),
@@ -147,11 +141,6 @@ impl TryFrom<CloudEvent> for Event {
 
     fn try_from(value: CloudEvent) -> Result<Self, Self::Error> {
         match value.ty() {
-            ActorsStarted::TYPE => ActorsStarted::try_from(value).map(Event::ActorsStarted),
-            ActorsStartFailed::TYPE => {
-                ActorsStartFailed::try_from(value).map(Event::ActorsStartFailed)
-            }
-            ActorsStopped::TYPE => ActorsStopped::try_from(value).map(Event::ActorsStopped),
             ComponentScaled::TYPE => ComponentScaled::try_from(value).map(Event::ComponentScaled),
             ComponentScaleFailed::TYPE => {
                 ComponentScaleFailed::try_from(value).map(Event::ComponentScaleFailed)
@@ -191,9 +180,6 @@ impl TryFrom<Event> for CloudEvent {
 
     fn try_from(value: Event) -> Result<Self, Self::Error> {
         let ty = match value {
-            Event::ActorsStarted(_) => ActorsStarted::TYPE,
-            Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
-            Event::ActorsStopped(_) => ActorsStopped::TYPE,
             Event::ComponentScaled(_) => ComponentScaled::TYPE,
             Event::ComponentScaleFailed(_) => ComponentScaleFailed::TYPE,
             Event::ProviderStarted(_) => ProviderStarted::TYPE,
@@ -229,9 +215,6 @@ impl Serialize for Event {
         S: serde::Serializer,
     {
         match self {
-            Event::ActorsStarted(evt) => evt.serialize(serializer),
-            Event::ActorsStartFailed(evt) => evt.serialize(serializer),
-            Event::ActorsStopped(evt) => evt.serialize(serializer),
             Event::ComponentScaled(evt) => evt.serialize(serializer),
             Event::ComponentScaleFailed(evt) => evt.serialize(serializer),
             Event::ProviderStarted(evt) => evt.serialize(serializer),
@@ -260,9 +243,6 @@ impl Event {
     /// Returns the underlying raw cloudevent type for the event
     pub fn raw_type(&self) -> &str {
         match self {
-            Event::ActorsStarted(_) => ActorsStarted::TYPE,
-            Event::ActorsStartFailed(_) => ActorsStartFailed::TYPE,
-            Event::ActorsStopped(_) => ActorsStopped::TYPE,
             Event::ComponentScaled(_) => ComponentScaled::TYPE,
             Event::ComponentScaleFailed(_) => ComponentScaleFailed::TYPE,
             Event::ProviderStarted(_) => ProviderStarted::TYPE,
@@ -301,66 +281,6 @@ pub enum ConversionError {
 //
 // EVENTS START HERE
 //
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ActorsStarted {
-    pub annotations: BTreeMap<String, String>,
-    // Commented out for now because the host broken it and we actually don't use this right now
-    // pub api_version: usize,
-    pub claims: ComponentClaims,
-    pub image_ref: String,
-    pub count: usize,
-    // TODO: Parse as nkey?
-    pub public_key: String,
-    #[serde(default)]
-    pub host_id: String,
-}
-
-event_impl!(
-    ActorsStarted,
-    "com.wasmcloud.lattice.actors_started",
-    source,
-    host_id
-);
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ActorsStartFailed {
-    pub annotations: BTreeMap<String, String>,
-    pub image_ref: String,
-    // TODO: Parse as nkey?
-    pub public_key: String,
-    #[serde(default)]
-    pub host_id: String,
-    pub error: String,
-}
-
-event_impl!(
-    ActorsStartFailed,
-    "com.wasmcloud.lattice.actors_start_failed",
-    source,
-    host_id
-);
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ActorsStopped {
-    #[serde(default)]
-    pub annotations: BTreeMap<String, String>,
-    // TODO: Parse as nkey?
-    pub public_key: String,
-    #[serde(default)]
-    pub host_id: String,
-    /// Number of actors stopped from this command
-    pub count: usize,
-    /// Remaining number of this actor running on the host
-    pub remaining: usize,
-}
-
-event_impl!(
-    ActorsStopped,
-    "com.wasmcloud.lattice.actors_stopped",
-    source,
-    host_id
-);
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ComponentScaled {

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -108,6 +108,8 @@ pub enum Event {
     HostHeartbeat(HostHeartbeat),
     LinkdefSet(LinkdefSet),
     LinkdefDeleted(LinkdefDeleted),
+    ConfigSet(ConfigSet),
+    ConfigDeleted(ConfigDeleted),
     // NOTE(thomastaylor312): We may change where and how these get published, but it makes sense
     // for now to have them here even though they aren't technically lattice events
     ManifestPublished(ManifestPublished),
@@ -130,6 +132,8 @@ impl Display for Event {
             Event::HostHeartbeat(_) => write!(f, "HostHeartbeat"),
             Event::LinkdefSet(_) => write!(f, "LinkdefSet"),
             Event::LinkdefDeleted(_) => write!(f, "LinkdefDeleted"),
+            Event::ConfigSet(_) => write!(f, "ConfigSet"),
+            Event::ConfigDeleted(_) => write!(f, "ConfigDeleted"),
             Event::ManifestPublished(_) => write!(f, "ManifestPublished"),
             Event::ManifestUnpublished(_) => write!(f, "ManifestUnpublished"),
         }
@@ -193,6 +197,8 @@ impl TryFrom<Event> for CloudEvent {
             Event::HostHeartbeat(_) => HostHeartbeat::TYPE,
             Event::LinkdefSet(_) => LinkdefSet::TYPE,
             Event::LinkdefDeleted(_) => LinkdefDeleted::TYPE,
+            Event::ConfigSet(_) => ConfigSet::TYPE,
+            Event::ConfigDeleted(_) => ConfigDeleted::TYPE,
             Event::ManifestPublished(_) => ManifestPublished::TYPE,
             Event::ManifestUnpublished(_) => ManifestUnpublished::TYPE,
         };
@@ -228,6 +234,8 @@ impl Serialize for Event {
             Event::HostHeartbeat(evt) => evt.serialize(serializer),
             Event::LinkdefSet(evt) => evt.serialize(serializer),
             Event::LinkdefDeleted(evt) => evt.serialize(serializer),
+            Event::ConfigSet(evt) => evt.serialize(serializer),
+            Event::ConfigDeleted(evt) => evt.serialize(serializer),
             Event::ManifestPublished(evt) => evt.serialize(serializer),
             Event::ManifestUnpublished(evt) => evt.serialize(serializer),
         }
@@ -256,6 +264,8 @@ impl Event {
             Event::HostHeartbeat(_) => HostHeartbeat::TYPE,
             Event::LinkdefSet(_) => LinkdefSet::TYPE,
             Event::LinkdefDeleted(_) => LinkdefDeleted::TYPE,
+            Event::ConfigSet(_) => ConfigSet::TYPE,
+            Event::ConfigDeleted(_) => ConfigDeleted::TYPE,
             Event::ManifestPublished(_) => ManifestPublished::TYPE,
             Event::ManifestUnpublished(_) => ManifestUnpublished::TYPE,
         }
@@ -281,6 +291,8 @@ pub enum ConversionError {
 //
 // EVENTS START HERE
 //
+
+// Component Events
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ComponentScaled {
@@ -320,6 +332,8 @@ event_impl!(
     source,
     host_id
 );
+
+// Provider Events
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ProviderStarted {
@@ -405,6 +419,8 @@ event_impl!(
     "com.wasmcloud.lattice.health_check_status"
 );
 
+// Link Events
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct LinkdefSet {
     #[serde(flatten)]
@@ -422,6 +438,24 @@ pub struct LinkdefDeleted {
 }
 
 event_impl!(LinkdefDeleted, "com.wasmcloud.lattice.linkdef_deleted");
+
+// Config Events
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ConfigSet {
+    pub config_name: String,
+}
+
+event_impl!(ConfigSet, "com.wasmcloud.lattice.config_set");
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ConfigDeleted {
+    pub config_name: String,
+}
+
+event_impl!(ConfigDeleted, "com.wasmcloud.lattice.config_deleted");
+
+// Host Events
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HostStarted {
@@ -484,6 +518,8 @@ event_impl!(
     source,
     host_id
 );
+
+// Manifest Events
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ManifestPublished {

--- a/src/scaler/configscaler.rs
+++ b/src/scaler/configscaler.rs
@@ -6,27 +6,28 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 use tracing::debug;
+use tracing::error;
 use tracing::instrument;
 use tracing::trace;
 
 use crate::commands::{DeleteConfig, PutConfig};
 use crate::events::ConfigDeleted;
+use crate::events::ConfigSet;
 use crate::server::StatusInfo;
-use crate::{
-    commands::Command, events::Event, model::TraitProperty, scaler::Scaler, storage::ReadStore,
-};
+use crate::server::StatusType;
+use crate::workers::ConfigSource;
+use crate::{commands::Command, events::Event, model::TraitProperty, scaler::Scaler};
 
-pub struct ConfigScaler<S> {
-    store: S,
+pub struct ConfigScaler<ConfigSource> {
+    config_bucket: ConfigSource,
     id: String,
-    lattice_id: String,
     config_name: String,
     config: HashMap<String, String>,
     status: RwLock<StatusInfo>,
 }
 
 #[async_trait]
-impl<S: ReadStore + Send + Sync + Clone> Scaler for ConfigScaler<S> {
+impl<C: ConfigSource + Send + Sync + Clone> Scaler for ConfigScaler<C> {
     fn id(&self) -> &str {
         &self.id
     }
@@ -44,15 +45,17 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ConfigScaler<S> {
     #[instrument(level = "trace", skip_all, fields(scaler_id = %self.id))]
     async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
         match event {
-            Event::ConfigSet(config_set) => {
-                if config_set.config_name == self.config_name {
-                    // TODO: This will only be handled by one wadm instance, need to either check the store for status
-                    // or send a notification.
-                    *self.status.write().await = StatusInfo::deployed("");
+            Event::ConfigSet(ConfigSet { config_name })
+            | Event::ConfigDeleted(ConfigDeleted { config_name }) => {
+                if config_name == &self.config_name {
+                    return self.reconcile().await;
                 }
             }
-            Event::ConfigDeleted(ConfigDeleted { config_name }) => {
-                if config_name == &self.config_name {
+            // This is a workaround to ensure that the config has a chance to periodically
+            // update itself if it is out of sync. For efficiency, we only fetch configuration
+            // again if the status is not deployed.
+            Event::HostHeartbeat(_) => {
+                if !matches!(self.status.read().await.status_type, StatusType::Deployed) {
                     return self.reconcile().await;
                 }
             }
@@ -60,24 +63,31 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ConfigScaler<S> {
                 trace!("ConfigScaler does not support this event, ignoring");
             }
         }
-        if let Event::ConfigDeleted(ConfigDeleted { config_name }) = event {
-            if config_name == &self.config_name {
-                return self.reconcile().await;
-            }
-        }
         Ok(Vec::new())
     }
 
     #[instrument(level = "trace", skip_all, scaler_id = %self.id)]
     async fn reconcile(&self) -> Result<Vec<Command>> {
-        // TODO: Check for config existence in the store
-
-        debug!(self.config_name, "Putting configuration");
-        *self.status.write().await = StatusInfo::reconciling("Putting configuration");
-        Ok(vec![Command::PutConfig(PutConfig {
-            config_name: self.config_name.clone(),
-            config: self.config.clone(),
-        })])
+        debug!(self.config_name, "Fetching configuration");
+        match self.config_bucket.get_config(&self.config_name).await {
+            Ok(Some(config)) if config == self.config => {
+                *self.status.write().await = StatusInfo::deployed("");
+                Ok(Vec::new())
+            }
+            Ok(_config) => {
+                debug!(self.config_name, "Putting configuration");
+                *self.status.write().await = StatusInfo::reconciling("Configuration out of sync");
+                Ok(vec![Command::PutConfig(PutConfig {
+                    config_name: self.config_name.clone(),
+                    config: self.config.clone(),
+                })])
+            }
+            Err(e) => {
+                error!(error = %e, "Configscaler failed to fetch configuration");
+                *self.status.write().await = StatusInfo::failed(&e.to_string());
+                Ok(Vec::new())
+            }
+        }
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -88,23 +98,17 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ConfigScaler<S> {
     }
 }
 
-impl<S: ReadStore + Send + Sync> ConfigScaler<S> {
+impl<C: ConfigSource> ConfigScaler<C> {
     /// Construct a new ConfigScaler with specified values
-    pub fn new(
-        store: S,
-        lattice_id: &str,
-        config_name: &str,
-        config: &HashMap<String, String>,
-    ) -> Self {
+    pub fn new(config_bucket: C, config_name: &str, config: &HashMap<String, String>) -> Self {
         // Hash the config to generate a unique id, used to compare scalers for uniqueness when updating
         let mut config_hasher = std::collections::hash_map::DefaultHasher::new();
         BTreeMap::from_iter(config.iter()).hash(&mut config_hasher);
         let id = format!("{config_name}-{}", config_hasher.finish());
 
         Self {
-            store,
+            config_bucket,
             id,
-            lattice_id: lattice_id.to_string(),
             config_name: config_name.to_string(),
             config: config.clone(),
             status: RwLock::new(StatusInfo::reconciling("")),

--- a/src/scaler/configscaler.rs
+++ b/src/scaler/configscaler.rs
@@ -22,6 +22,9 @@ pub struct ConfigScaler<ConfigSource> {
     config_bucket: ConfigSource,
     id: String,
     config_name: String,
+    // NOTE(#263): Introducing storing the entire configuration in-memory has the potential to get
+    // fairly heavy if the configuration is large. We should consider a more efficient way to store
+    // this by fetching configuration from the manifest when it's needed, for example.
     config: HashMap<String, String>,
     status: RwLock<StatusInfo>,
 }

--- a/src/scaler/configscaler.rs
+++ b/src/scaler/configscaler.rs
@@ -1,0 +1,113 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tracing::debug;
+use tracing::instrument;
+use tracing::trace;
+
+use crate::commands::{DeleteConfig, PutConfig};
+use crate::events::ConfigDeleted;
+use crate::server::StatusInfo;
+use crate::{
+    commands::Command, events::Event, model::TraitProperty, scaler::Scaler, storage::ReadStore,
+};
+
+pub struct ConfigScaler<S> {
+    store: S,
+    id: String,
+    lattice_id: String,
+    config_name: String,
+    config: HashMap<String, String>,
+    status: RwLock<StatusInfo>,
+}
+
+#[async_trait]
+impl<S: ReadStore + Send + Sync + Clone> Scaler for ConfigScaler<S> {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn status(&self) -> StatusInfo {
+        let _ = self.reconcile().await;
+        self.status.read().await.to_owned()
+    }
+
+    async fn update_config(&mut self, _config: TraitProperty) -> Result<Vec<Command>> {
+        debug!("ConfigScaler does not support updating config, ignoring");
+        Ok(vec![])
+    }
+
+    #[instrument(level = "trace", skip_all, fields(scaler_id = %self.id))]
+    async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
+        match event {
+            Event::ConfigSet(config_set) => {
+                if config_set.config_name == self.config_name {
+                    // TODO: This will only be handled by one wadm instance, need to either check the store for status
+                    // or send a notification.
+                    *self.status.write().await = StatusInfo::deployed("");
+                }
+            }
+            Event::ConfigDeleted(ConfigDeleted { config_name }) => {
+                if config_name == &self.config_name {
+                    return self.reconcile().await;
+                }
+            }
+            _ => {
+                trace!("ConfigScaler does not support this event, ignoring");
+            }
+        }
+        if let Event::ConfigDeleted(ConfigDeleted { config_name }) = event {
+            if config_name == &self.config_name {
+                return self.reconcile().await;
+            }
+        }
+        Ok(Vec::new())
+    }
+
+    #[instrument(level = "trace", skip_all, scaler_id = %self.id)]
+    async fn reconcile(&self) -> Result<Vec<Command>> {
+        // TODO: Check for config existence in the store
+
+        debug!(self.config_name, "Putting configuration");
+        *self.status.write().await = StatusInfo::reconciling("Putting configuration");
+        Ok(vec![Command::PutConfig(PutConfig {
+            config_name: self.config_name.clone(),
+            config: self.config.clone(),
+        })])
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn cleanup(&self) -> Result<Vec<Command>> {
+        Ok(vec![Command::DeleteConfig(DeleteConfig {
+            config_name: self.config_name.clone(),
+        })])
+    }
+}
+
+impl<S: ReadStore + Send + Sync> ConfigScaler<S> {
+    /// Construct a new ConfigScaler with specified values
+    pub fn new(
+        store: S,
+        lattice_id: &str,
+        config_name: &str,
+        config: &HashMap<String, String>,
+    ) -> Self {
+        // Hash the config to generate a unique id, used to compare scalers for uniqueness when updating
+        let mut config_hasher = std::collections::hash_map::DefaultHasher::new();
+        BTreeMap::from_iter(config.iter()).hash(&mut config_hasher);
+        let id = format!("{config_name}-{}", config_hasher.finish());
+
+        Self {
+            store,
+            id,
+            lattice_id: lattice_id.to_string(),
+            config_name: config_name.to_string(),
+            config: config.clone(),
+            status: RwLock::new(StatusInfo::reconciling("")),
+        }
+    }
+}

--- a/src/scaler/manager.rs
+++ b/src/scaler/manager.rs
@@ -628,7 +628,7 @@ where
                         }
                         (LINK_TRAIT, TraitProperty::Link(p)) => {
                             components.iter().find_map(|component| {
-                                let (source_config_scalers, source_config) = config_to_scalers(
+                                let (mut config_scalers, source_config) = config_to_scalers(
                                     snapshot_data.clone(),
                                     name,
                                     &p.source_config,
@@ -638,10 +638,7 @@ where
                                     name,
                                     &p.target_config,
                                 );
-                                let config_scalers = source_config_scalers
-                                    .into_iter()
-                                    .chain(target_config_scalers.into_iter())
-                                    .collect();
+                                config_scalers.extend(target_config_scalers);
                                 match &component.properties {
                                     Properties::Capability {
                                         properties: CapabilityProperties { id, .. },
@@ -746,7 +743,7 @@ where
                             }
                             (LINK_TRAIT, TraitProperty::Link(p)) => {
                                 components.iter().find_map(|component| {
-                                    let (source_config_scalers, source_config) = config_to_scalers(
+                                    let (mut config_scalers, source_config) = config_to_scalers(
                                         snapshot_data.clone(),
                                         name,
                                         &p.source_config,
@@ -756,10 +753,7 @@ where
                                         name,
                                         &p.target_config,
                                     );
-                                    let config_scalers = source_config_scalers
-                                        .into_iter()
-                                        .chain(target_config_scalers.into_iter())
-                                        .collect();
+                                    config_scalers.extend(target_config_scalers);
                                     match &component.properties {
                                         Properties::Component { properties: cappy }
                                             if component.name == p.target =>

--- a/src/scaler/mod.rs
+++ b/src/scaler/mod.rs
@@ -93,12 +93,12 @@ pub trait Scaler {
 /// The `notifier` is used to publish notifications to add, remove, or recompute
 /// expected events with scalers on other wadm instances, as only one wadm instance
 /// at a time will handle a specific event.
-pub(crate) struct BackoffAwareScaler<T, P, S> {
+pub(crate) struct BackoffAwareScaler<T, P, C> {
     scaler: T,
     notifier: P,
     notify_subject: String,
     model_name: String,
-    required_config: Vec<ConfigScaler<S>>,
+    required_config: Vec<ConfigScaler<C>>,
     /// A list of (success, Option<failure>) events that the scaler is expecting
     #[allow(clippy::type_complexity)]
     expected_events: Arc<RwLock<Vec<(Event, Option<Event>)>>>,
@@ -108,7 +108,7 @@ pub(crate) struct BackoffAwareScaler<T, P, S> {
     cleanup_timeout: std::time::Duration,
 }
 
-impl<T, P, S> BackoffAwareScaler<T, P, S>
+impl<T, P, C> BackoffAwareScaler<T, P, C>
 where
     T: Scaler + Send + Sync,
     P: Publisher + Send + Sync + 'static,
@@ -119,7 +119,7 @@ where
     pub fn new(
         scaler: T,
         notifier: P,
-        required_config: Vec<ConfigScaler<S>>,
+        required_config: Vec<ConfigScaler<C>>,
         notify_subject: &str,
         model_name: &str,
         cleanup_timeout: Option<Duration>,
@@ -363,7 +363,7 @@ where
 /// * `reconcile` calls an internal method that uses a notifier to ensure all Scalers, even
 ///   running on different wadm instances, compute their expected events in response to the
 ///   reconciliation commands in order to "back off".
-impl<T, P, S> Scaler for BackoffAwareScaler<T, P, S>
+impl<T, P, C> Scaler for BackoffAwareScaler<T, P, C>
 where
     T: Scaler + Send + Sync,
     P: Publisher + Send + Sync + 'static,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -636,8 +636,6 @@ impl<P: Publisher> Handler<P> {
             }
         }
 
-        // TODO(#253): Validate that named configurations managed outside of wadm exist?
-
         if !manifests.deploy(req.version) {
             trace!("Requested version does not exist");
             self.send_reply(

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -636,6 +636,8 @@ impl<P: Publisher> Handler<P> {
             }
         }
 
+        // TODO(#253): Validate that named configurations managed outside of wadm exist?
+
         if !manifests.deploy(req.version) {
             trace!("Requested version does not exist");
             self.send_reply(
@@ -1000,16 +1002,6 @@ pub(crate) async fn validate_manifest(manifest: Manifest) -> anyhow::Result<()> 
                 },
         } = &component.properties
         {
-            // TODO: Ensure config exists?
-            // if let Some(data) = capability_config {
-            //     if let Err(e) = serde_json::to_string(data) {
-            //         return Err(anyhow!(
-            //             "Unable to serialize JSON config data for component {}: {e:?}",
-            //             component.name
-            //         ));
-            //     }
-            // }
-
             if let Some(component_id) = id {
                 if !id_registry.insert(component_id.to_string()) {
                     bail!("Duplicate component identifier in manifest: {component_id}");

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -9,9 +9,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use super::StateKind;
-use crate::events::{
-    ActorsStarted, ComponentScaled, HostHeartbeat, HostStarted, ProviderInfo, ProviderStarted,
-};
+use crate::events::{ComponentScaled, HostHeartbeat, HostStarted, ProviderInfo, ProviderStarted};
 
 /// A wasmCloud Capability provider
 // NOTE: We probably aren't going to use this _right now_ so we've kept it pretty minimal. But it is
@@ -170,42 +168,6 @@ impl Component {
 
 impl StateKind for Component {
     const KIND: &'static str = "component";
-}
-
-impl From<ActorsStarted> for Component {
-    fn from(value: ActorsStarted) -> Self {
-        Component {
-            id: value.public_key,
-            name: value.claims.name,
-            issuer: value.claims.issuer,
-            reference: value.image_ref,
-            instances: HashMap::from_iter([(
-                value.host_id,
-                HashSet::from_iter([WadmComponentInfo {
-                    annotations: value.annotations,
-                    count: value.count,
-                }]),
-            )]),
-        }
-    }
-}
-
-impl From<&ActorsStarted> for Component {
-    fn from(value: &ActorsStarted) -> Self {
-        Component {
-            id: value.public_key.clone(),
-            name: value.claims.name.clone(),
-            issuer: value.claims.issuer.clone(),
-            reference: value.image_ref.clone(),
-            instances: HashMap::from_iter([(
-                value.host_id.clone(),
-                HashSet::from_iter([WadmComponentInfo {
-                    annotations: value.annotations.clone(),
-                    count: value.count,
-                }]),
-            )]),
-        }
-    }
 }
 
 impl From<ComponentScaled> for Component {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -7,7 +7,7 @@ use wasmcloud_control_interface::{HostInventory, InterfaceLinkDefinition};
 
 use crate::publisher::Publisher;
 use crate::storage::StateKind;
-use crate::workers::{Claims, ClaimsSource, InventorySource, LinkSource};
+use crate::workers::{Claims, ClaimsSource, ConfigSource, InventorySource, LinkSource};
 
 fn generate_key<T: StateKind>(lattice_id: &str) -> String {
     format!("{}_{lattice_id}", T::KIND)
@@ -108,6 +108,7 @@ pub struct TestLatticeSource {
     pub claims: HashMap<String, Claims>,
     pub inventory: Arc<RwLock<HashMap<String, HostInventory>>>,
     pub links: Vec<InterfaceLinkDefinition>,
+    pub config: HashMap<String, HashMap<String, String>>,
 }
 
 #[async_trait::async_trait]
@@ -128,6 +129,13 @@ impl InventorySource for TestLatticeSource {
 impl LinkSource for TestLatticeSource {
     async fn get_links(&self) -> anyhow::Result<Vec<InterfaceLinkDefinition>> {
         Ok(self.links.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl ConfigSource for TestLatticeSource {
+    async fn get_config(&self, name: &str) -> anyhow::Result<Option<HashMap<String, String>>> {
+        Ok(self.config.get(name).cloned())
     }
 }
 

--- a/src/workers/command.rs
+++ b/src/workers/command.rs
@@ -93,9 +93,9 @@ impl Worker for CommandWorker {
                     .put_config(&put_config.config_name, put_config.config.clone())
                     .await
             }
-            Command::DeleteConfig(config_name) => {
-                trace!("Handling delete config command");
-                self.client.delete_config(config_name).await
+            Command::DeleteConfig(delete_config) => {
+                trace!(command = ?delete_config, "Handling delete config command");
+                self.client.delete_config(&delete_config.config_name).await
             }
         }
         .map_err(|e| anyhow::anyhow!("{e:?}"));

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -945,7 +945,10 @@ where
 
 /// Helper that runs any iterable of futures and returns a list of commands and the proper result to
 /// use as a response (Ok if there were no errors, all of the errors combined otherwise)
-async fn get_commands_and_result<Fut, I>(futs: I, error_message: &str) -> (Vec<Command>, Result<()>)
+pub(crate) async fn get_commands_and_result<Fut, I>(
+    futs: I,
+    error_message: &str,
+) -> (Vec<Command>, Result<()>)
 where
     Fut: futures::Future<Output = Result<Vec<Command>>>,
     I: IntoIterator<Item = Fut>,

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -30,7 +30,7 @@ pub struct EventWorker<StateStore, C: Clone, P: Clone> {
 impl<StateStore, C, P> EventWorker<StateStore, C, P>
 where
     StateStore: Store + Send + Sync + Clone + 'static,
-    C: ClaimsSource + InventorySource + LinkSource + Clone + Send + Sync + 'static,
+    C: ClaimsSource + InventorySource + LinkSource + ConfigSource + Clone + Send + Sync + 'static,
     P: Publisher + Clone + Send + Sync + 'static,
 {
     /// Creates a new event worker configured to use the given store and control interface client for fetching state
@@ -766,8 +766,7 @@ where
             scaler_status(&scalers).await
         } else {
             StatusInfo::reconciling(&format!(
-                "Event {event} modified app \"{}\" state, running compensating commands",
-                name.to_owned(),
+                "Event {event} modified app \"{name}\" state, running compensating commands"
             ))
         };
         trace!(?status, "Setting status");
@@ -835,7 +834,7 @@ where
 impl<StateStore, C, P> Worker for EventWorker<StateStore, C, P>
 where
     StateStore: Store + Send + Sync + Clone + 'static,
-    C: ClaimsSource + InventorySource + LinkSource + Clone + Send + Sync + 'static,
+    C: ClaimsSource + InventorySource + LinkSource + ConfigSource + Clone + Send + Sync + 'static,
     P: Publisher + Clone + Send + Sync + 'static,
 {
     type Message = Event;

--- a/src/workers/event.rs
+++ b/src/workers/event.rs
@@ -918,9 +918,11 @@ where
             // to make sure we don't forget to handle them when new events are added.
             Event::LinkdefSet(_)
             | Event::LinkdefDeleted(_)
+            | Event::ConfigSet(_)
+            | Event::ConfigDeleted(_)
             | Event::ProviderStartFailed(_)
             | Event::ComponentScaleFailed(_) => {
-                trace!("Got event we don't care about. Skipping");
+                trace!("Got event we don't care about. Not modifying state.");
                 Ok(None)
             }
         };

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -7,5 +7,6 @@ mod event;
 mod event_helpers;
 
 pub use command::CommandWorker;
+pub(crate) use event::get_commands_and_result;
 pub use event::EventWorker;
 pub use event_helpers::*;

--- a/test/data/complex.yaml
+++ b/test/data/complex.yaml
@@ -16,6 +16,7 @@ spec:
           - name: defaultcode
             properties:
               http: "404"
+          - name: blobby-default-configuration-values
       traits:
         - type: spreadscaler
           properties:

--- a/test/data/complex.yaml
+++ b/test/data/complex.yaml
@@ -4,7 +4,7 @@ metadata:
   name: complex
   annotations:
     version: v0.0.1
-    description: "This is my CRUDdy complex blobby app"
+    description: "This is my CRUDdy complex blobby app with all configuration possibilities"
 spec:
   components:
     - name: blobby
@@ -12,6 +12,10 @@ spec:
       properties:
         image: wasmcloud.azurecr.io/blobby:0.1.0
         id: littleblobbytables
+        config:
+          - name: defaultcode
+            properties:
+              http: "404"
       traits:
         - type: spreadscaler
           properties:
@@ -31,11 +35,10 @@ spec:
             namespace: wasi
             package: blobstore
             interfaces: [blobstore]
-            # TODO(#253): enable config
-            # target_config:
-            #   - name: rootfs
-            #     properties:
-            #       root: /tmp
+            target_config:
+              - name: rootfs
+                properties:
+                  root: /tmp
 
     - name: httpserver
       type: capability
@@ -61,17 +64,20 @@ spec:
             namespace: wasi
             package: http
             interfaces: [incoming-handler]
-            # TODO(#253): enable config
-            # source_config:
-            #   - name: httpaddr
-            #     properties:
-            #       address: 0.0.0.0:8081
+            source_config:
+              - name: httpaddr
+                properties:
+                  address: 0.0.0.0:8081
 
     - name: fileserver
       type: capability
       properties:
         image: ghcr.io/wasmcloud/blobstore-fs:0.6.0
         id: fileserver
+        config:
+          - name: defaultfs
+            properties:
+              root: /tmp/blobby
       traits:
         - type: spreadscaler
           properties:

--- a/test/data/events.json
+++ b/test/data/events.json
@@ -172,6 +172,24 @@
     }
   },
   {
+    "specversion": "1.0",
+    "id": "018ed364-f3c1-cb14-347c-e737d792480d",
+    "type": "com.wasmcloud.lattice.config_set",
+    "source": "NCWKTSXV56OENKKOWIUKNUPZH3GOAFX3ZZSIFYEFYBZRWYUNOLE3S475",
+    "datacontenttype": "application/json",
+    "time": "2024-04-12T17:39:52.385642Z",
+    "data": { "config_name": "my-config" }
+  },
+  {
+    "specversion": "1.0",
+    "id": "018ed365-0780-bccb-821b-9398b80982e5",
+    "type": "com.wasmcloud.lattice.config_deleted",
+    "source": "NCWKTSXV56OENKKOWIUKNUPZH3GOAFX3ZZSIFYEFYBZRWYUNOLE3S475",
+    "datacontenttype": "application/json",
+    "time": "2024-04-12T17:39:57.440160Z",
+    "data": { "config_name": "my-config" }
+  },
+  {
     "data": {
       "host_id": "NB6PMW4RGLBP3NAVUVO2IH34VFJFSX7LF7TJOQCDU4GGUGF3P57SZLPX",
       "provider_id": "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M",

--- a/test/data/lotta_actors.yaml
+++ b/test/data/lotta_actors.yaml
@@ -30,8 +30,7 @@ spec:
             namespace: wasi
             package: http
             interfaces: [incoming-handler]
-            # TODO(#253): enable config
-            # source_config:
-            #   - name: httpaddr
-            #     properties:
-            #       address: 0.0.0.0:8080
+            source_config:
+              - name: httpaddr
+                properties:
+                  address: 0.0.0.0:8080

--- a/test/data/simple.yaml
+++ b/test/data/simple.yaml
@@ -32,8 +32,7 @@ spec:
             namespace: wasi
             package: http
             interfaces: [incoming-handler]
-            # TODO(#253): enable config
-            # source_config:
-            #   - name: httpaddr
-            #     properties:
-            #       address: 0.0.0.0:8080
+            source_config:
+              - name: httpaddr
+                properties:
+                  address: 0.0.0.0:8080

--- a/tests/e2e_multiple_hosts.rs
+++ b/tests/e2e_multiple_hosts.rs
@@ -295,6 +295,16 @@ async fn test_complex_app(client_info: &ClientInfo) {
         "Shouldn't have errored when creating manifest: {resp:?}"
     );
 
+    // Put configuration that's mentioned in manifest but without properties
+    client_info
+        .ctl_client("default")
+        .put_config(
+            "blobby-default-configuration-values",
+            HashMap::from_iter([("littleblobby".to_string(), "tables".to_string())]),
+        )
+        .await
+        .expect("should be able to put blobby config");
+
     // Deploy manifest
     let resp = client_info
         .deploy_manifest("complex", None, None, None)


### PR DESCRIPTION
I would recommend taking a look at this PR commit by commit, as removing an old event, adding support for a new event, and adding configuration management are very different. If desired, I can split these out into separate PRs.

## Feature or Problem
This PR implements configuration management in wadm with the use of a `ConfigScaler`. Any scalers that depend on configuration will first delegate to their set of `ConfigScaler`s to reconcile and handle events, so that all configuration can be in place, and then the component/provider/link scaler will be able to reach desired state. This is implemented making heavier use of the BackoffAwareScaler (rename pending) and will be nice when we get around to #253.

This is specifically ordered to put all configuration first before running resources as this configuration is required at start/link time.

Configuration that is managed by wadm uses a separate naming scheme (same as component ID) of `{manifest_name}-{config_name}`. This is so that it's impossible for different manifests in a lattice to specify the same simple configuration (e.g. `default-url`) and conflict.

- [ ] The only outstanding question in the PR (marked by a TODO) is if we should validate that external configuration that's specified in the manifest before we deploy the manifest itself. My gut says that it would be a nice validation step, but it does introduce a few significant refactors in the `Handler` including giving it the permission to query the control interface. I think this can be addressed by a followup

## Related Issues
Fixes #252

## Release Information
v0.11.0-alpha.4

## Consumer Impact
Followers of the wasmCloud documentation will no longer need to put their own configuration before deploying the manifest.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Added comprehensive config scaler unit test to ensure we're reacting properly to events and setting status.

### Acceptance or Integration
Modified existing multiple hosts integration test to ensure that the config scaler is creating configuration for components, providers, link source and link target.

### Manual Verification
The above unit tests and integration test were first validated manually 😄 
