### PR TITLE
fix: Provider state handling from 0.82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/src/events/data.rs
+++ b/src/events/data.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 /// and Hash since it can serve as a key
 #[derive(Debug, Serialize, Deserialize, Default, Clone, Eq)]
 pub struct ProviderInfo {
+    #[serde(alias = "public_key")]
     pub provider_id: String,
+    #[serde(default)]
     pub provider_ref: String,
     #[serde(default)]
     pub annotations: BTreeMap<String, String>,


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where state stored by an older version of wadm+wasmcloud(0.82) would cause trouble in event handling by repeatedly nacking failing to deserialize an event.

## Related Issues
Fixes #269

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
