### PR TITLE
Fix rendering WADM_NATS_CREDS_FILE when creds secret is provided

### DIFF
--- a/charts/wadm/Chart.yaml
+++ b/charts/wadm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.1"
+version: "0.2.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wadm/templates/_helpers.tpl
+++ b/charts/wadm/templates/_helpers.tpl
@@ -51,7 +51,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "wadm.nats.auth" -}}
-{{- if .secretName }}
+{{- if  .Values.wadm.config.nats.creds.secretName -}}
 - name: WADM_NATS_CREDS_FILE
   value: {{ include "wadm.nats.creds_file_path" . | quote }}
 {{- else if and .Values.wadm.config.nats.creds.jwt .Values.wadm.config.nats.creds.seed -}}
@@ -63,7 +63,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "wadm.nats.creds_file_path" }}
-{{- if .Values.wadm.config.nats.creds.secretName }}
+{{- if .Values.wadm.config.nats.creds.secretName -}}
 /etc/nats-creds/nats.creds
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Feature or Problem

A refactoring resulted in the `WADM_NATS_CREDS_FILE` not being added when a `creds.secretName` is presented, which in turn results in the secret being correctly mounted, but not actually being used by wadm.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
