### PR TITLE
feat(validation): add manifest validation

### DIFF
--- a/src/model/validation.rs
+++ b/src/model/validation.rs
@@ -1,0 +1,435 @@
+//! Logic for model ([`Manifest`]) validation
+//!
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use anyhow::{Context as _, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::model::{LinkProperty, Manifest, TraitProperty, LATEST_VERSION};
+
+/// A namespace -> package -> interface lookup
+type KnownInterfaceLookup = HashMap<String, HashMap<String, HashMap<String, ()>>>;
+
+/// Hard-coded list of known namespaces/packages and the interfaces they contain.
+///
+/// Using an interface that is *not* on this list is not an error --
+/// custom interfaces are expected to not be on this list, but when using
+/// a known namespace and package, interfaces should generally be well known.
+static KNOWN_INTERFACE_LOOKUP: OnceLock<KnownInterfaceLookup> = OnceLock::new();
+
+/// Get the static list of known interfaces
+fn get_known_interface_lookup() -> &'static KnownInterfaceLookup {
+    KNOWN_INTERFACE_LOOKUP.get_or_init(|| {
+        HashMap::from([
+            (
+                "wrpc".into(),
+                HashMap::from([
+                    (
+                        "blobstore".into(),
+                        HashMap::from([("blobstore".into(), ())]),
+                    ),
+                    (
+                        "keyvalue".into(),
+                        HashMap::from([("atomics".into(), ()), ("store".into(), ())]),
+                    ),
+                    (
+                        "http".into(),
+                        HashMap::from([
+                            ("incoming-handler".into(), ()),
+                            ("outgoing-handler".into(), ()),
+                        ]),
+                    ),
+                ]),
+            ),
+            (
+                "wasi".into(),
+                HashMap::from([
+                    (
+                        "blobstore".into(),
+                        HashMap::from([("blobstore".into(), ())]),
+                    ),
+                    ("config".into(), HashMap::from([("runtime".into(), ())])),
+                    (
+                        "keyvalue".into(),
+                        HashMap::from([("atomics".into(), ()), ("store".into(), ())]),
+                    ),
+                    (
+                        "http".into(),
+                        HashMap::from([
+                            ("incoming-handler".into(), ()),
+                            ("outgoing-handler".into(), ()),
+                        ]),
+                    ),
+                    ("logging".into(), HashMap::from([("logging".into(), ())])),
+                ]),
+            ),
+            (
+                "wasmcloud".into(),
+                HashMap::from([(
+                    "messaging".into(),
+                    HashMap::from([("consumer".into(), ()), ("handler".into(), ())]),
+                )]),
+            ),
+        ])
+    })
+}
+
+static MANIFEST_NAME_REGEX_STR: &str = r"^[-\w]+$";
+static MANIFEST_NAME_REGEX: OnceLock<Regex> = OnceLock::new();
+
+/// Retrieve regular expression which manifest names must match, compiled to a usable [`Regex`]
+fn get_manifest_name_regex() -> &'static Regex {
+    MANIFEST_NAME_REGEX.get_or_init(|| {
+        Regex::new(MANIFEST_NAME_REGEX_STR)
+            .context("failed to parse manifest name regex")
+            .unwrap()
+    })
+}
+
+/// Check whether a manifest name matches requirements, returning all validation errors
+pub fn validate_manifest_name(name: &str) -> impl ValidationOutput {
+    let mut errors = Vec::new();
+    if !get_manifest_name_regex().is_match(name) {
+        errors.push(ValidationFailure::new(
+            ValidationFailureLevel::Error,
+            format!("manifest name [{name}] is not allowed (should match regex [{MANIFEST_NAME_REGEX_STR}])"),
+        ))
+    }
+    errors
+}
+
+/// Check whether a manifest name matches requirements
+pub fn is_valid_manifest_name(name: &str) -> bool {
+    validate_manifest_name(name).valid()
+}
+
+/// Check whether a manifest version is valid, returning all validation errors
+pub fn validate_manifest_version(version: &str) -> impl ValidationOutput {
+    let mut errors = Vec::new();
+    if version == LATEST_VERSION {
+        errors.push(ValidationFailure::new(
+            ValidationFailureLevel::Error,
+            format!("{LATEST_VERSION} is not allowed in wadm"),
+        ))
+    }
+    errors
+}
+
+/// Check whether a manifest version is valid requirements
+pub fn is_valid_manifest_version(version: &str) -> bool {
+    validate_manifest_version(version).valid()
+}
+
+/// Check whether a known grouping of namespace, package and interface are valid.
+/// A grouping must be both known/expected and invalid to fail this test (ex. a typo).
+///
+/// NOTE: what is considered a valid interface known to the host depends explicitly on
+/// the wasmCloud host and wasmCloud project goals/implementation. This information is
+/// subject to change.
+fn is_invalid_known_interface(
+    namespace: &str,
+    package: &str,
+    interface: &str,
+) -> Vec<ValidationFailure> {
+    let known_interfaces = get_known_interface_lookup();
+    let Some(pkg_lookup) = known_interfaces.get(namespace) else {
+        // This namespace isn't known, so it may be a custom interface
+        return vec![];
+    };
+    let Some(iface_lookup) = pkg_lookup.get(package) else {
+        // Unknown package inside a known interface we control is probably a bug
+        return vec![ValidationFailure::new(
+            ValidationFailureLevel::Warning,
+            format!("unrecognized interface [{namespace}:{package}/{interface}]"),
+        )];
+    };
+    // Unknown interface inside known namespace and package is probably a bug
+    if !iface_lookup.contains_key(interface) {
+        // Unknown package inside a known interface we control is probably a bug
+        return vec![ValidationFailure::new(
+            ValidationFailureLevel::Error,
+            format!("unrecognized interface [{namespace}:{package}/{interface}]"),
+        )];
+    }
+
+    Vec::new()
+}
+
+/// Level of a failure related to validation
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ValidationFailureLevel {
+    #[default]
+    Warning,
+    Error,
+}
+
+impl core::fmt::Display for ValidationFailureLevel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Warning => "warning",
+                Self::Error => "error",
+            }
+        )
+    }
+}
+
+/// Failure detailing a validation failure, normally indicating a failure
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ValidationFailure {
+    pub level: ValidationFailureLevel,
+    pub msg: String,
+}
+
+impl ValidationFailure {
+    fn new(level: ValidationFailureLevel, msg: String) -> Self {
+        ValidationFailure { level, msg }
+    }
+}
+
+impl core::fmt::Display for ValidationFailure {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "[{}] {}", self.level, self.msg)
+    }
+}
+
+/// Things that support output validation
+pub trait ValidationOutput {
+    /// Whether the object is valid
+    fn valid(&self) -> bool;
+    /// Warnings returned (if any) during validation
+    fn warnings(&self) -> Vec<&ValidationFailure>;
+    /// The errors returned by the validation
+    fn errors(&self) -> Vec<&ValidationFailure>;
+}
+
+/// Default implementation for a list of concrete [`ValidationFailure`]s
+impl ValidationOutput for [ValidationFailure] {
+    fn valid(&self) -> bool {
+        self.errors().is_empty()
+    }
+    fn warnings(&self) -> Vec<&ValidationFailure> {
+        self.iter()
+            .filter(|m| m.level == ValidationFailureLevel::Warning)
+            .collect()
+    }
+    fn errors(&self) -> Vec<&ValidationFailure> {
+        self.iter()
+            .filter(|m| m.level == ValidationFailureLevel::Error)
+            .collect()
+    }
+}
+
+/// Default implementation for a list of concrete [`ValidationFailure`]s
+impl ValidationOutput for Vec<ValidationFailure> {
+    fn valid(&self) -> bool {
+        self.as_slice().valid()
+    }
+    fn warnings(&self) -> Vec<&ValidationFailure> {
+        self.iter()
+            .filter(|m| m.level == ValidationFailureLevel::Warning)
+            .collect()
+    }
+    fn errors(&self) -> Vec<&ValidationFailure> {
+        self.iter()
+            .filter(|m| m.level == ValidationFailureLevel::Error)
+            .collect()
+    }
+}
+
+/// Validate a WADM application manifest, returning a list of validation failures
+///
+/// At present this can check for:
+/// - unsupported interfaces (i.e. typos, etc)
+/// - unknown packages under known namespaces
+/// - "dangling" links (missing components)
+///
+/// Since `[ValidationFailure]` implements `ValidationOutput`, you can call `valid()` and other
+/// trait methods on it:
+///
+/// ```rust,ignore
+/// let messages = validate_manifest(some_path).await?;
+/// let valid = messages.valid();
+/// ```
+///
+/// # Arguments
+///
+/// * `path` - Path to the Manifest that will be read into memory and validated
+pub async fn validate_manifest_file(
+    path: impl AsRef<Path>,
+) -> Result<(Manifest, Vec<ValidationFailure>)> {
+    let content = tokio::fs::read_to_string(path.as_ref())
+        .await
+        .with_context(|| format!("failed to read manifest @ [{}]", path.as_ref().display()))?;
+
+    validate_manifest_bytes(&content).await.with_context(|| {
+        format!(
+            "failed to parse YAML manifest [{}]",
+            path.as_ref().display()
+        )
+    })
+}
+
+/// Validate a lsit of bytes that represents a  WADM application manifest
+///
+/// # Arguments
+///
+/// * `content` - YAML content  to the Manifest that will be read into memory and validated
+pub async fn validate_manifest_bytes(
+    content: impl AsRef<[u8]>,
+) -> Result<(Manifest, Vec<ValidationFailure>)> {
+    let manifest =
+        serde_yaml::from_slice(content.as_ref()).context("failed to parse manifest content")?;
+    let failures = validate_manifest(&manifest).await?;
+    Ok((manifest, failures))
+}
+
+/// Validate a WADM application manifest, returning a list of validation failures
+///
+/// At present this can check for:
+/// - unsupported interfaces (i.e. typos, etc)
+/// - unknown packages under known namespaces
+/// - "dangling" links (missing components)
+///
+/// Since `[ValidationFailure]` implements `ValidationOutput`, you can call `valid()` and other
+/// trait methods on it:
+///
+/// ```rust,ignore
+/// let messages = validate_manifest(some_path).await?;
+/// let valid = messages.valid();
+/// ```
+///
+/// # Arguments
+///
+/// * `manifest` - The [`Manifest`] that should be validated
+pub async fn validate_manifest(manifest: &Manifest) -> Result<Vec<ValidationFailure>> {
+    // Check for known failures with the manifest
+    let mut failures = Vec::new();
+    failures.extend(
+        validate_manifest_name(&manifest.metadata.name)
+            .errors()
+            .into_iter()
+            .cloned(),
+    );
+    failures.extend(
+        validate_manifest_version(manifest.version())
+            .errors()
+            .into_iter()
+            .cloned(),
+    );
+    failures.extend(check_misnamed_interfaces(manifest));
+    failures.extend(check_dangling_links(manifest));
+    Ok(failures)
+}
+
+/// Check for misnamed host-supported interfaces in the manifest
+fn check_misnamed_interfaces(manifest: &Manifest) -> Vec<ValidationFailure> {
+    let mut failures = Vec::new();
+    for link_trait in manifest.links() {
+        if let TraitProperty::Link(LinkProperty {
+            namespace,
+            package,
+            interfaces,
+            ..
+        }) = &link_trait.properties
+        {
+            for interface in interfaces {
+                failures.extend(is_invalid_known_interface(namespace, package, interface))
+            }
+        }
+    }
+
+    failures
+}
+
+/// Check for "dangling" links, which contain targets that are not specified elsewhere in the
+/// WADM manifest.
+///
+/// A problem of this type only constitutes a warning, because it is possible that the manifest
+/// does not *completely* specify targets (they may be deployed/managed external to WADM or in a separte
+/// manifest).
+fn check_dangling_links(manifest: &Manifest) -> Vec<ValidationFailure> {
+    let lookup = manifest.component_lookup();
+    let mut failures = Vec::new();
+    for link_trait in manifest.links() {
+        match &link_trait.properties {
+            TraitProperty::Custom(obj) => {
+                // Ensure target property it present
+                match obj["target"].as_str() {
+                    // If target is present, ensure it's pointing to a known component
+                    Some(target) if !lookup.contains_key(&String::from(target)) => {
+                        failures.push(ValidationFailure::new(
+                            ValidationFailureLevel::Warning,
+                            format!("custom link target [{target}] is not a listed component"),
+                        ))
+                    }
+                    // For all keys where the the component is in the lookup we can do nothing
+                    Some(_) => {}
+                    // if target property is not present, note that it is missing
+                    None => failures.push(ValidationFailure::new(
+                        ValidationFailureLevel::Error,
+                        "custom link is missing 'target' property".into(),
+                    )),
+                }
+            }
+
+            TraitProperty::Link(LinkProperty { name, target, .. }) => {
+                let link_identifier = name
+                    .as_ref()
+                    .map(|n| format!("(name [{n}])"))
+                    .unwrap_or_else(|| format!("(target [{target}])"));
+                if !lookup.contains_key(target) {
+                    failures.push(ValidationFailure::new(
+                        ValidationFailureLevel::Warning,
+                        format!(
+                            "link {link_identifier} target [{target}] is not a listed component"
+                        ),
+                    ))
+                }
+            }
+
+            _ => unreachable!("manifest.links() should only return links"),
+        }
+    }
+
+    failures
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_manifest_name;
+
+    const VALID_MANIFEST_NAMES: [&str; 4] = [
+        "mymanifest",
+        "my-manifest",
+        "my_manifest",
+        "mymanifest-v2-v3-final",
+    ];
+
+    const INVALID_MANIFEST_NAMES: [&str; 2] = ["my.manifest", "my manifest"];
+
+    /// Ensure valid manifest names pass
+    #[test]
+    fn manifest_names_valid() {
+        // Acceptable manifest names
+        for valid in VALID_MANIFEST_NAMES {
+            assert!(is_valid_manifest_name(valid));
+        }
+    }
+
+    /// Ensure invalid manifest names fail
+    #[test]
+    fn manifest_names_invalid() {
+        for invalid in INVALID_MANIFEST_NAMES {
+            assert!(!is_valid_manifest_name(invalid))
+        }
+    }
+}

--- a/src/scaler/spreadscaler/mod.rs
+++ b/src/scaler/spreadscaler/mod.rs
@@ -366,9 +366,7 @@ pub(crate) fn compute_ineligible_hosts<'a>(
     // Find all host IDs that are eligible for any spread
     let eligible_ids = spreads
         .iter()
-        .flat_map(|spread| {
-            eligible_hosts(all_hosts, spread).into_keys()
-        })
+        .flat_map(|spread| eligible_hosts(all_hosts, spread).into_keys())
         .collect::<HashSet<_>>();
 
     // Filter out all hosts that are eligible for any spread, leaving only ineligible hosts
@@ -1568,7 +1566,8 @@ mod test {
 
     #[tokio::test]
     async fn can_calculate_ineligible_hosts() {
-        let spreads = [Spread {
+        let spreads = [
+            Spread {
                 name: "SimpleOne".to_string(),
                 requirements: BTreeMap::from_iter([("region".to_string(), "east".to_string())]),
                 weight: Some(75),
@@ -1577,7 +1576,8 @@ mod test {
                 name: "SimpleTwo".to_string(),
                 requirements: BTreeMap::from_iter([("resilient".to_string(), "true".to_string())]),
                 weight: Some(25),
-            }];
+            },
+        ];
 
         let hosts = HashMap::from_iter([
             (

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -4,15 +4,16 @@ use anyhow::{anyhow, bail, ensure};
 use async_nats::{jetstream::stream::Stream, Client, Message, Subject};
 use base64::{engine::general_purpose::STANDARD as B64decoder, Engine};
 use jsonschema::{paths::PathChunk, Draft, JSONSchema};
-use regex::Regex;
 use serde_json::json;
 use tokio::sync::OnceCell;
 use tracing::{debug, error, instrument, log::warn, trace};
 
 use crate::{
     model::{
-        internal::StoredManifest, CapabilityProperties, ComponentProperties, LinkProperty,
-        Manifest, Properties, Trait, TraitProperty, LATEST_VERSION,
+        internal::StoredManifest,
+        validation::{is_valid_manifest_name, validate_manifest_version, ValidationOutput},
+        CapabilityProperties, ComponentProperties, LinkProperty, Manifest, Properties, Trait,
+        TraitProperty, LATEST_VERSION,
     },
     publisher::Publisher,
     server::StatusType,
@@ -25,7 +26,6 @@ use super::{
     StatusResponse, StatusResult, UndeployModelRequest, VersionInfo, VersionResponse,
 };
 const JSON_SCHEMA: &str = include_str!("../../oam/oam.schema.json");
-static MANIFEST_NAME_REGEX: OnceCell<Regex> = OnceCell::const_new();
 static JSON_SCHEMA_VALUE: OnceCell<serde_json::Value> = OnceCell::const_new();
 static OAM_JSON_SCHEMA: OnceCell<JSONSchema> = OnceCell::const_new();
 
@@ -54,22 +54,26 @@ impl<P: Publisher> Handler<P> {
             "Manifest is valid. Fetching current manifests from store"
         );
 
-        if manifest.version() == LATEST_VERSION {
+        let manifest_validation_output = validate_manifest_version(manifest.version());
+        let manifest_validation_errors = manifest_validation_output.errors();
+        if !manifest_validation_errors.is_empty() {
             self.send_error(
                 msg.reply,
-                format!("A manifest with a version {LATEST_VERSION} is not allowed in wadm"),
+                format!(
+                    "invalid manifest version, errors: {:#?}",
+                    manifest_validation_errors
+                        .iter()
+                        .map(|e| e.msg.clone())
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                ),
             )
             .await;
             return;
         }
 
         let manifest_name = manifest.metadata.name.trim().to_string();
-        if !MANIFEST_NAME_REGEX
-            // SAFETY: We know this is valid Regex
-            .get_or_init(|| async { Regex::new(r"^[-\w]+$").unwrap() })
-            .await
-            .is_match(&manifest_name)
-        {
+        if !is_valid_manifest_name(&manifest_name) {
             self.send_error(
                 msg.reply,
                 format!(
@@ -1209,30 +1213,6 @@ mod test {
         .await
         .context("failed to validate long image ref")?;
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn manifest_name_regex_works() {
-        let regex = super::MANIFEST_NAME_REGEX
-            .get_or_init(|| async { regex::Regex::new(r"^[-\w]+$").unwrap() })
-            .await;
-
-        // Acceptable manifest names
-        let word = "mymanifest";
-        let word_with_dash = "my-manifest";
-        let word_with_underscore = "my_manifest";
-        let word_with_numbers = "mymanifest-v2-v3-final";
-
-        assert!(regex.is_match(word));
-        assert!(regex.is_match(word_with_dash));
-        assert!(regex.is_match(word_with_underscore));
-        assert!(regex.is_match(word_with_numbers));
-
-        // Not acceptable manifest names
-        let word_with_period = "my.manifest";
-        let word_with_space = "my manifest";
-        assert!(!regex.is_match(word_with_period));
-        assert!(!regex.is_match(word_with_space));
     }
 
     #[tokio::test]

--- a/tests/fixtures/manifests/custom-interface.wadm.yaml
+++ b/tests/fixtures/manifests/custom-interface.wadm.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: custom-interface
+  annotations:
+    version: v0.0.1
+    description: A component with a completely custom interface
+spec:
+  components:
+    - name: counter
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-keyvalue-counter:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: link
+          properties:
+            target: kvredis
+            namespace: my-wasi
+            package: my-keyvalue
+            interfaces: [my-atomics]
+
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0

--- a/tests/fixtures/manifests/dangling-link.wadm.yaml
+++ b/tests/fixtures/manifests/dangling-link.wadm.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: dangling-link
+  annotations:
+    version: v0.0.1
+    description: Manifest with a dangling link
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-hello-world:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: link
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080

--- a/tests/fixtures/manifests/misnamed-interface.wadm.yaml
+++ b/tests/fixtures/manifests/misnamed-interface.wadm.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: misnamed-interface
+  annotations:
+    version: v0.0.1
+    description: A component with a misnamed interface
+spec:
+  components:
+    - name: counter
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-keyvalue-counter:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: link
+          properties:
+            target: kvredis
+            namespace: wasi
+            package: keyvalue
+            interfaces: [atomic] # BUG: should be 'atomics'
+
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0

--- a/tests/fixtures/manifests/simple.wadm.yaml
+++ b/tests/fixtures/manifests/simple.wadm.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: sample
+  annotations:
+    version: v0.0.1
+    description: Sample manifest that passes
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-hello-world:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1

--- a/tests/fixtures/manifests/unknown-package.wadm.yaml
+++ b/tests/fixtures/manifests/unknown-package.wadm.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: unknown-package
+  annotations:
+    version: v0.0.1
+    description: A component with an unknown package
+spec:
+  components:
+    - name: counter
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-keyvalue-counter:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: link
+          properties:
+            target: kvredis
+            namespace: wasi
+            package: keyvalues # BUG: should be 'keyvalue'
+            interfaces: [atomics]
+
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,0 +1,93 @@
+use anyhow::{Context as _, Result};
+
+use wadm::model::validation::{validate_manifest_file, ValidationFailureLevel, ValidationOutput};
+
+/// Ensure that valid YAML manifests are valid
+#[tokio::test]
+async fn validate_pass() -> Result<()> {
+    assert!(
+        validate_manifest_file("./tests/fixtures/manifests/simple.wadm.yaml")
+            .await?
+            .1
+            .valid()
+    );
+    Ok(())
+}
+
+/// Ensure that we can detect dangling links
+#[tokio::test]
+async fn validate_dangling_links() -> Result<()> {
+    let (_manifest, failures) =
+        validate_manifest_file("./tests/fixtures/manifests/dangling-link.wadm.yaml")
+            .await
+            .context("failed to validate manifest")?;
+    assert!(
+        !failures.is_empty()
+            && failures
+                .iter()
+                .all(|f| f.level == ValidationFailureLevel::Warning),
+        "failures present, all warnings"
+    );
+    assert!(
+        failures.valid(),
+        "manifest should be valid (missing targets could be managed externally)"
+    );
+    Ok(())
+}
+
+/// Ensure that we can detect misnamed interfaces
+#[tokio::test]
+async fn validate_misnamed_interface() -> Result<()> {
+    let (_manifest, failures) =
+        validate_manifest_file("./tests/fixtures/manifests/misnamed-interface.wadm.yaml")
+            .await
+            .context("failed to validate manifest")?;
+    assert!(
+        !failures.is_empty()
+            && failures
+                .iter()
+                .all(|f| f.level == ValidationFailureLevel::Error),
+        "failures present, all errors"
+    );
+    assert!(
+        !failures.valid(),
+        "manifest should be invalid (misnamed interface w/ right namespace & package is probably a bug)"
+    );
+    Ok(())
+}
+
+/// Ensure that we can detect unknown packages under known namespaces
+#[tokio::test]
+async fn validate_unknown_package() -> Result<()> {
+    let (_manifest, failures) =
+        validate_manifest_file("./tests/fixtures/manifests/unknown-package.wadm.yaml")
+            .await
+            .context("failed to validate manifest")?;
+    assert!(
+        !failures.is_empty()
+            && failures
+                .iter()
+                .all(|f| f.level == ValidationFailureLevel::Warning),
+        "failures present, all errors"
+    );
+    assert!(
+        failures.valid(),
+        "manifest should be valid (unknown package under a known interface is a warning)"
+    );
+    Ok(())
+}
+
+/// Ensure that we allow through custom interface
+#[tokio::test]
+async fn validate_custom_interface() -> Result<()> {
+    let (_manifest, failures) =
+        validate_manifest_file("./tests/fixtures/manifests/custom-interface.wadm.yaml")
+            .await
+            .context("failed to validate manifest")?;
+    assert!(failures.is_empty(), "no failures");
+    assert!(
+        failures.valid(),
+        "manifest is valid (custom namespace is default-allowed)"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit adds validation functions along with utility accessors to `Manifest` to enable checking WADM manifests for common errors.

As the validation functions are exposed they can be used by downstream crates (ex. `wash`) to validate WADM manifests or try to catch errors *before* a manifest is used.

This is up for review in draft state so we can talk about the design -- if it looks good, I'll do the following:
- [x] Finish adding all the known interfaces

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

https://github.com/wasmCloud/wasmCloud/issues/2009

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

Unit tests with fixtures have been added

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
