### PR TITLE
ci(release): use native macos arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_dispatch: # Allow manual creation of artifacts without a release
 
 jobs:
@@ -21,34 +21,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-13',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/release/',
             }
     steps:
       - uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install latest Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
-        if: matrix.config.arch != 'aarch64'
+        if: matrix.config.arch != 'aarch64' || startsWith(matrix.config.os, 'macos')
         with:
           toolchain: stable
           components: clippy, rustfmt
@@ -93,31 +93,19 @@ jobs:
 
       - name: Install latest Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
-        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        with:
-          toolchain: stable
-          components: clippy, rustfmt
-          target: aarch64-apple-darwin
-
-      - name: Install latest Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
         with:
           toolchain: stable
           components: clippy, rustfmt
           target: aarch64-unknown-linux-gnu
 
-      - name: build release
-        if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release --bin wadm --features cli"
+      - name: build release (amd64 linux, macos, windows)
+        if: matrix.config.arch != 'aarch64' || startsWith(matrix.config.os, 'macos')
+        run: 'cargo build --release --bin wadm --features cli'
 
-      - name: build release
-        if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --bin wadm --features cli --target aarch64-apple-darwin"
-
-      - name: build release
+      - name: build release (arm64 linux)
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --bin wadm --features cli --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --bin wadm --features cli --target aarch64-unknown-linux-gnu'
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where the github runner `macos-latest` is now natively on arm64, so we need to pin to macos-13 in order to build amd64. This does simplify our release process, and natively building on the arm64 machine is great.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

## Related Issues
https://github.com/wasmCloud/wasmCloud/issues/2134

## Release Information
Re-release wadm v0.11.1. I plan to cherry-pick this commit from the v0.11.1 tag to re-release this

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
