### PR TITLE
feat(reuseProviders): Allow capability providers to be reused across components

### DIFF
--- a/crates/wadm/src/server/handlers.rs
+++ b/crates/wadm/src/server/handlers.rs
@@ -600,37 +600,6 @@ impl<P: Publisher> Handler<P> {
             }
         }
 
-        // Compare if any of the provider refs in the staged model are duplicates
-        for component in staged_model.spec.components.iter() {
-            if let Properties::Capability {
-                properties:
-                    CapabilityProperties {
-                        image: image_name, ..
-                    },
-            } = &component.properties
-            {
-                if let Some((ref_link, ref_version)) = parse_image_ref(image_name) {
-                    if let Some((old_version, old_manifest_name)) =
-                        existing_provider_refs.get(&ref_link)
-                    {
-                        if old_version != &ref_version {
-                            error!(
-                                "Provider {image_name} is already deployed with a different version in {old_manifest_name}.",
-                            );
-                            self.send_error(
-                                msg.reply,
-                                format!(
-                                "Provider {image_name} is already deployed with a different version in {old_manifest_name}."
-                            ),
-                            )
-                            .await;
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-
         if !manifests.deploy(req.version) {
             trace!("Requested version does not exist");
             self.send_reply(


### PR DESCRIPTION

## Feature or Problem
Update wasmcloud deployment manager to allow reuse of capability providers across deployments.

## Related Issues
(https://github.com/wasmCloud/wadm/issues/296)

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
