### PR TITLE
feat(state): retry state updates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          default: true
           components: clippy, rustfmt
 
       # Cache: rust

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ ifeq ($(shell nc $(NC_FLAGS) -w1 127.0.0.1 4222 || echo fail),fail)
 	@# Reenable this once we've enabled all tests
 	@# RUST_BACKTRACE=1 $(CARGO) test --test e2e_multitenant --features _e2e_tests --  --nocapture 
 	RUST_BACKTRACE=1 $(CARGO) test --test e2e_multiple_hosts --features _e2e_tests --  --nocapture 
-	@# RUST_BACKTRACE=1 $(CARGO) test --test e2e_upgrades --features _e2e_tests --  --nocapture 
+	RUST_BACKTRACE=1 $(CARGO) test --test e2e_upgrades --features _e2e_tests --  --nocapture 
 else
 	@echo "WARN: Not running e2e tests. NATS must not be currently running"
 	exit 1

--- a/crates/wadm/src/test_util.rs
+++ b/crates/wadm/src/test_util.rs
@@ -58,7 +58,7 @@ impl crate::storage::ReadStore for TestStore {
 impl crate::storage::Store for TestStore {
     async fn store_many<T, D>(&self, lattice_id: &str, data: D) -> Result<(), Self::Error>
     where
-        T: Serialize + DeserializeOwned + StateKind + Send,
+        T: Serialize + DeserializeOwned + StateKind + Send + Sync + Clone,
         D: IntoIterator<Item = (String, T)> + Send,
     {
         let key = generate_key::<T>(lattice_id);
@@ -79,7 +79,7 @@ impl crate::storage::Store for TestStore {
 
     async fn delete_many<T, D, K>(&self, lattice_id: &str, data: D) -> Result<(), Self::Error>
     where
-        T: Serialize + DeserializeOwned + StateKind + Send,
+        T: Serialize + DeserializeOwned + StateKind + Send + Sync,
         D: IntoIterator<Item = K> + Send,
         K: AsRef<str>,
     {

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -31,7 +31,7 @@ async fn test_commands() {
         .get_hosts()
         .await
         .expect("should get hosts back")
-        .get(0)
+        .first()
         .as_ref()
         .expect("Should be able to find hosts")
         .response
@@ -347,7 +347,7 @@ async fn test_annotation_stop() {
         .get_hosts()
         .await
         .unwrap()
-        .get(0)
+        .first()
         .expect("Should be able to find hosts")
         .response
         .as_ref()

--- a/tests/e2e_upgrades.rs
+++ b/tests/e2e_upgrades.rs
@@ -149,7 +149,7 @@ async fn test_upgrade(client_info: &ClientInfo) {
             })
             .context("Should have http link with hello")?;
         if let Err(e) = check_config(
-            &client_info.ctl_client("default"),
+            client_info.ctl_client("default"),
             &http_link.source_config[0],
             &HashMap::from_iter([("address".to_string(), "0.0.0.0:8080".to_string())]),
         )
@@ -171,7 +171,7 @@ async fn test_upgrade(client_info: &ClientInfo) {
             })
             .context("Should have http link with dog-fetcher")?;
         if let Err(e) = check_config(
-            &client_info.ctl_client("default"),
+            client_info.ctl_client("default"),
             &dog_link.source_config[0],
             &HashMap::from_iter([("address".to_string(), "0.0.0.0:8081".to_string())]),
         )
@@ -193,7 +193,7 @@ async fn test_upgrade(client_info: &ClientInfo) {
             })
             .context("Should have redis link with kvcounter")?;
         if let Err(e) = check_config(
-            &client_info.ctl_client("default"),
+            client_info.ctl_client("default"),
             &kv_link.target_config[0],
             &HashMap::from_iter([("URL".to_string(), "redis://127.0.0.1:6379".to_string())]),
         )


### PR DESCRIPTION
This adds retries for putting state into a bucket. It is fairly basic but it gets the job done. We had to add a few more constraints to the `Store` trait to handle the retries (such as cloning data).