### PR TITLE
fix: copy backend key to top level in a generated config value

### DIFF
--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use schemars::JsonSchema;
 use serde::{de, Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};

--- a/crates/wadm-types/src/validation.rs
+++ b/crates/wadm-types/src/validation.rs
@@ -534,6 +534,18 @@ fn check_secrets_mapped_to_policies(manifest: &Manifest) -> Vec<ValidationFailur
                     ),
                 ))
             }
+            if policies[&secret.source.policy]
+                .properties
+                .contains_key("backend")
+            {
+                failures.push(ValidationFailure::new(
+                    ValidationFailureLevel::Error,
+                    format!(
+                        "secret '{}' is mapped to policy '{}' which does not include a 'backend' property",
+                        secret.name, secret.source.policy
+                    ),
+                ))
+            }
         }
     }
     failures


### PR DESCRIPTION
## Feature or Problem
It turns out that it is easier to parse a serialized secrets value if we have the `backend` key at the top level instead of nested in string-encoded JSON. This moves that value out of the policy properties value that the secrets scaler serializes into a config value and instead stores it as a top level key.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
0.13.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
