### PR TITLE
fix: remove serial from tests

### DIFF
--- a/crates/wadm/src/server/handlers.rs
+++ b/crates/wadm/src/server/handlers.rs
@@ -896,11 +896,11 @@ mod test {
     #[tokio::test]
     async fn test_manifest_validation() {
         let correct_manifest =
-            deserialize_yaml("./oam/simple1.yaml").expect("Should be able to parse");
+            deserialize_yaml("oam/simple1.yaml").expect("Should be able to parse");
 
         assert!(validate_manifest(correct_manifest).await.is_ok());
 
-        let manifest = deserialize_yaml("./test/data/incorrect_component.yaml")
+        let manifest = deserialize_yaml("test/data/incorrect_component.yaml")
             .expect("Should be able to parse");
 
         match validate_manifest(manifest).await {
@@ -912,7 +912,7 @@ mod test {
             }
         }
 
-        let manifest = deserialize_yaml("./test/data/duplicate_component.yaml")
+        let manifest = deserialize_yaml("test/data/duplicate_component.yaml")
             .expect("Should be able to parse");
 
         match validate_manifest(manifest).await {
@@ -923,7 +923,7 @@ mod test {
         }
 
         let manifest =
-            deserialize_yaml("./test/data/duplicate_id1.yaml").expect("Should be able to parse");
+            deserialize_yaml("test/data/duplicate_id1.yaml").expect("Should be able to parse");
 
         match validate_manifest(manifest).await {
             Ok(()) => {
@@ -935,7 +935,7 @@ mod test {
         }
 
         let manifest =
-            deserialize_yaml("./test/data/duplicate_id2.yaml").expect("Should be able to parse");
+            deserialize_yaml("test/data/duplicate_id2.yaml").expect("Should be able to parse");
 
         match validate_manifest(manifest).await {
             Ok(()) => panic!("Should have detected duplicate component ID in component properties"),
@@ -944,7 +944,9 @@ mod test {
                 .contains("Duplicate component identifier in manifest")),
         }
 
-        let manifest = deserialize_yaml("./test/data/missing_capability_component.yaml")
+        let manifest = deserialize_yaml("test/data/duplicate_linkdef.yaml")
+            .expect("Should be able to parse");
+        let manifest = deserialize_yaml("test/data/missing_capability_component.yaml")
             .expect("Should be able to parse");
 
         match validate_manifest(manifest).await {
@@ -960,7 +962,7 @@ mod test {
     #[tokio::test]
     async fn manifest_name_long_image_ref() -> Result<()> {
         validate_manifest(
-            deserialize_yaml("./test/data/long_image_refs.yaml")
+            deserialize_yaml("test/data/long_image_refs.yaml")
                 .context("failed to deserialize YAML")?,
         )
         .await

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
 use futures::StreamExt;
-use serial_test::serial;
 
 use wadm::{
     commands::*, consumers::manager::Worker, workers::CommandWorker, MANAGED_BY_ANNOTATION,
@@ -14,9 +13,6 @@ use helpers::{
 };
 
 #[tokio::test]
-// TODO: Run in parallel once https://github.com/wasmCloud/wash/issues/402 is fixed. Please
-// note this test should probably be changed to an e2e test as the order of events is somewhat flaky
-#[serial]
 async fn test_commands() {
     let config = TestWashConfig::random().await.unwrap();
     let _guard = setup_test_wash(&config).await;
@@ -323,9 +319,6 @@ async fn test_commands() {
 }
 
 #[tokio::test]
-// TODO: Run in parallel once https://github.com/wasmCloud/wash/issues/402 is fixed. Please
-// note this test should probably be changed to an e2e test as the order of events is somewhat flaky
-#[serial]
 async fn test_annotation_stop() {
     // This test is a sanity check that we only stop annotated components
     let config = TestWashConfig::random().await.unwrap();


### PR DESCRIPTION
Remove serial now that the doc'd bug for why serial has been fixed.

Additionally use project scoped paths instead of relative paths to enable easier gdb and vscode debugging.
