### PR TITLE
chore: remove beta, pin to stable version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,7 +2980,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.13.0-beta.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-cli"
-version = "0.13.0-beta.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-client"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-cli"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.13.0-beta.2"
+version = "0.13.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]
@@ -80,9 +80,9 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 ulid = { version = "1", features = ["serde"] }
 utoipa = "4"
 uuid = "1"
-wadm = { version = "0.13.0-beta.2", path = "./crates/wadm" }
-wadm-client = { version = "0.2.0-beta.2", path = "./crates/wadm-client" }
-wadm-types = { version = "0.2.0-beta.2", path = "./crates/wadm-types" }
+wadm = { version = "0.13.0", path = "./crates/wadm" }
+wadm-client = { version = "0.2.0", path = "./crates/wadm-client" }
+wadm-types = { version = "0.2.0", path = "./crates/wadm-types" }
 wasmcloud-control-interface = "1.0.0"
 wasmcloud-secrets-types = "0.2.0"
 wit-bindgen-wrpc = { version = "0.3.7", default-features = false }

--- a/crates/wadm-client/Cargo.toml
+++ b/crates/wadm-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-client"
 description = "A client library for interacting with the wadm API"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-types"
 description = "Types and validators for the wadm API"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm/Cargo.toml
+++ b/crates/wadm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.13.0-beta.2"
+version = "0.13.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
## Feature or Problem
This PR removes the beta tags, which probably should've been RCs, to prepare wadm for an 0.13.0 release.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wadm 0.13.0
types, client 0.2.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
