### PR TITLE
fix(wadm): attach lattice/multitenant to consumer metadata

### DIFF
--- a/crates/wadm/src/consumers/mod.rs
+++ b/crates/wadm/src/consumers/mod.rs
@@ -16,6 +16,9 @@ pub mod manager;
 /// The default time given for a command to ack. This is longer than events due to the possible need for more processing time
 pub const DEFAULT_ACK_TIME: Duration = Duration::from_secs(2);
 
+pub const LATTICE_METADATA_KEY: &str = "lattice";
+pub const MULTITENANT_METADATA_KEY: &str = "multitenant_prefix";
+
 pub use commands::*;
 pub use events::*;
 


### PR DESCRIPTION
## Feature or Problem
This PR resolves a comment we had in the codebase for waiting for NATS 2.10, by attaching the lattice and multitenant prefix to the consumer instead of trying to always derive it from the consumer name.

This is entirely backwards compatible, and the metadata will just be ignored if the consumer already exists. Deleting the consumer and restarting wadm is all you need to bring it in so this will likely happen naturally.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next wadm

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
