### PR TITLE
feat(wadm)!: set cleanup interval to 60s

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,11 +124,11 @@ struct Args {
     state_bucket: String,
 
     /// The amount of time in seconds to give for hosts to fail to heartbeat and be removed from the
-    /// store. By default, this is 120s because it is 4x the host heartbeat interval
+    /// store. By default, this is 60s because it is 2x the host heartbeat interval
     #[arg(
         long = "cleanup-interval",
         env = "WADM_CLEANUP_INTERVAL",
-        default_value = "120"
+        default_value = "60"
     )]
     cleanup_interval: u64,
 


### PR DESCRIPTION
## Feature or Problem
In the case where state reports a host but it's actually no longer running, I think we should wait only 60 seconds before considering it disconnected. This gives enough time to miss a heartbeat, but if you miss two then the scalers should recalculate.

Open to thoughts here & if there's a smarter way to do this. This mostly affects the development cycle where you are launching and tearing down wadm repeatedly. However, I would rather set configuration in an environment where hosts are known to often be disconnected to a higher value than have to configure this down for regular applications.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
