### PR TITLE
feat(client)!: return name and version from deploy model

### DIFF
--- a/crates/wadm-types/src/api.rs
+++ b/crates/wadm-types/src/api.rs
@@ -123,6 +123,10 @@ pub struct DeployModelResponse {
     pub result: DeployResult,
     #[serde(default)]
     pub message: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 /// All possible outcomes of a deploy operation


### PR DESCRIPTION
## Feature or Problem
This PR is a simple fix to return the name and version of a deployed manifest with the DeployModelResponse, which assists with the data that clients can use to know what version was deployed even if one wasn't supplied.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
