### PR TITLE
chore: Migrate more tests over to using testcontainers for setup

### DIFF
--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -77,7 +77,7 @@ impl TestServer {
     }
 }
 
-async fn setup_server(id: String, client: async_nats::Client) -> TestServer {
+async fn setup_server(id: &str, client: async_nats::Client) -> TestServer {
     let store = helpers::create_test_store_with_client(&id, client.clone()).await;
 
     let context = jetstream::new(client.clone());
@@ -109,7 +109,7 @@ async fn setup_server(id: String, client: async_nats::Client) -> TestServer {
     let server = Server::new(
         store,
         client.clone(),
-        Some(&id),
+        Some(id),
         false,
         status_stream,
         ManifestNotifier::new(&prefix, client.clone()),
@@ -123,7 +123,7 @@ async fn setup_server(id: String, client: async_nats::Client) -> TestServer {
         .expect("Unable to set up subscription");
 
     TestServer {
-        prefix: id,
+        prefix: id.to_owned(),
         handle: tokio::spawn(server.serve()),
         client,
         notify,
@@ -139,7 +139,7 @@ async fn test_crud_operations() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let test_server = setup_server("crud_operations".to_owned(), nats_client).await;
+    let test_server = setup_server("crud_operations", nats_client).await;
 
     // First test with a raw file (a common operation)
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -381,7 +381,7 @@ async fn test_bad_requests() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let test_server = setup_server("bad_requests".to_owned(), nats_client).await;
+    let test_server = setup_server("bad_requests", nats_client).await;
 
     // Duplicate version
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -450,7 +450,7 @@ async fn test_delete_noop() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let test_server = setup_server("delete_noop".to_owned(), nats_client).await;
+    let test_server = setup_server("delete_noop", nats_client).await;
 
     // Delete something that doesn't exist
     let resp: DeleteModelResponse = test_server
@@ -505,7 +505,7 @@ async fn test_invalid_topics() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let test_server = setup_server("invalid_topics".to_owned(), nats_client).await;
+    let test_server = setup_server("invalid_topics", nats_client).await;
 
     // Put in a manifest to make sure we have something that could be fetched if we aren't handing
     // invalid topics correctly
@@ -584,7 +584,7 @@ async fn test_manifest_parsing() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let test_server = setup_server("manifest_parsing".to_owned(), nats_client).await;
+    let test_server = setup_server("manifest_parsing", nats_client).await;
 
     // Test json manifest with no hint
     let raw = tokio::fs::read("./oam/simple1.json")
@@ -652,7 +652,7 @@ async fn test_deploy() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let mut test_server = setup_server("deploy_ops".to_owned(), nats_client).await;
+    let mut test_server = setup_server("deploy_ops", nats_client).await;
 
     // Create a manifest with 2 versions
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -827,7 +827,7 @@ async fn test_delete_deploy() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let mut test_server = setup_server("deploy_delete".to_owned(), nats_client).await;
+    let mut test_server = setup_server("deploy_delete", nats_client).await;
 
     // Create a manifest with 2 versions
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -922,7 +922,7 @@ async fn test_status() {
         .nats_client()
         .await
         .expect("should have created a nats client");
-    let test_server = setup_server("status".to_owned(), nats_client).await;
+    let test_server = setup_server("status", nats_client).await;
 
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
         .await

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use async_nats::{jetstream, Subscriber};
 use futures::StreamExt;
+use helpers::setup_env;
 use serde::de::DeserializeOwned;
 use wadm::server::*;
 use wadm_types::{api::*, *};
@@ -76,11 +77,8 @@ impl TestServer {
     }
 }
 
-async fn setup_server(id: String) -> TestServer {
-    let client = async_nats::connect("127.0.0.1:4222")
-        .await
-        .expect("Should be able to connect to NATS");
-    let store = helpers::create_test_store_with_client(client.clone(), id.clone()).await;
+async fn setup_server(id: String, client: async_nats::Client) -> TestServer {
+    let store = helpers::create_test_store_with_client(&id, client.clone()).await;
 
     let context = jetstream::new(client.clone());
     let status_stream = context
@@ -134,7 +132,14 @@ async fn setup_server(id: String) -> TestServer {
 
 #[tokio::test]
 async fn test_crud_operations() {
-    let test_server = setup_server("crud_operations".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let test_server = setup_server("crud_operations".to_owned(), nats_client).await;
 
     // First test with a raw file (a common operation)
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -369,7 +374,15 @@ async fn test_crud_operations() {
 
 #[tokio::test]
 async fn test_bad_requests() {
-    let test_server = setup_server("bad_requests".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let test_server = setup_server("bad_requests".to_owned(), nats_client).await;
+
     // Duplicate version
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
         .await
@@ -430,7 +443,14 @@ async fn test_bad_requests() {
 
 #[tokio::test]
 async fn test_delete_noop() {
-    let test_server = setup_server("delete_noop".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let test_server = setup_server("delete_noop".to_owned(), nats_client).await;
 
     // Delete something that doesn't exist
     let resp: DeleteModelResponse = test_server
@@ -478,7 +498,14 @@ async fn test_delete_noop() {
 
 #[tokio::test]
 async fn test_invalid_topics() {
-    let test_server = setup_server("invalid_topics".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let test_server = setup_server("invalid_topics".to_owned(), nats_client).await;
 
     // Put in a manifest to make sure we have something that could be fetched if we aren't handing
     // invalid topics correctly
@@ -550,7 +577,14 @@ async fn test_invalid_topics() {
 
 #[tokio::test]
 async fn test_manifest_parsing() {
-    let test_server = setup_server("manifest_parsing".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let test_server = setup_server("manifest_parsing".to_owned(), nats_client).await;
 
     // Test json manifest with no hint
     let raw = tokio::fs::read("./oam/simple1.json")
@@ -611,7 +645,14 @@ async fn test_manifest_parsing() {
 
 #[tokio::test]
 async fn test_deploy() {
-    let mut test_server = setup_server("deploy_ops".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let mut test_server = setup_server("deploy_ops".to_owned(), nats_client).await;
 
     // Create a manifest with 2 versions
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -779,7 +820,14 @@ async fn test_deploy() {
 
 #[tokio::test]
 async fn test_delete_deploy() {
-    let mut test_server = setup_server("deploy_delete".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let mut test_server = setup_server("deploy_delete".to_owned(), nats_client).await;
 
     // Create a manifest with 2 versions
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
@@ -867,7 +915,14 @@ async fn test_delete_deploy() {
 
 #[tokio::test]
 async fn test_status() {
-    let test_server = setup_server("status".to_owned()).await;
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let test_server = setup_server("status".to_owned(), nats_client).await;
 
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
         .await

--- a/tests/command_consumer_integration.rs
+++ b/tests/command_consumer_integration.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use futures::TryStreamExt;
-use serial_test::serial;
 use tokio::time::{timeout, Duration};
 
 use wadm::commands::*;
@@ -148,7 +147,6 @@ async fn test_consumer_stream() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_nack_and_rereceive() {
     let env = setup_env()
         .await

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
 use futures::StreamExt;
-use serial_test::serial;
 
 use wadm::{
     commands::*, consumers::manager::Worker, workers::CommandWorker, MANAGED_BY_ANNOTATION,
@@ -14,9 +13,6 @@ use helpers::{
 };
 
 #[tokio::test]
-// TODO: Run in parallel once https://github.com/wasmCloud/wash/issues/402 is fixed. Please
-// note this test should probably be changed to an e2e test as the order of events is somewhat flaky
-#[serial]
 async fn test_commands() {
     let env = setup_env()
         .await
@@ -328,7 +324,6 @@ async fn test_commands() {
 #[tokio::test]
 // TODO: Run in parallel once https://github.com/wasmCloud/wash/issues/402 is fixed. Please
 // note this test should probably be changed to an e2e test as the order of events is somewhat flaky
-#[serial]
 async fn test_annotation_stop() {
     // This test is a sanity check that we only stop annotated components
     let env = setup_env()

--- a/tests/event_consumer_integration.rs
+++ b/tests/event_consumer_integration.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use futures::{Stream, TryStreamExt};
-use serial_test::serial;
 use tokio::time::{timeout, Duration};
 
 use wadm::{
@@ -76,9 +75,6 @@ struct HostResponse {
 }
 
 #[tokio::test]
-// TODO: Run in parallel once https://github.com/wasmCloud/wash/issues/402 is fixed. Please
-// note this test should probably be changed to an e2e test as the order of events is somewhat flaky
-#[serial]
 async fn test_event_stream() -> Result<()> {
     let env = setup_env()
         .await
@@ -291,11 +287,9 @@ async fn test_event_stream() -> Result<()> {
 }
 
 #[tokio::test]
-// TODO: Run in parallel once https://github.com/wasmCloud/wash/issues/402 is fixed. This
-// does work when you run it individually. Please note that there is problems when running this
-// against 0.60+ hosts as the KV bucket for linkdefs makes it so that all those linkdefs are emitted
+// Please note that there is problems when running this against 0.60+ hosts as
+// the KV bucket for linkdefs makes it so that all those linkdefs are emitted
 // as published events when the host starts
-#[serial]
 async fn test_nack_and_rereceive() -> Result<()> {
     let env = setup_env()
         .await

--- a/tests/storage_nats_kv.rs
+++ b/tests/storage_nats_kv.rs
@@ -12,11 +12,19 @@ use wadm::{
 
 mod helpers;
 
-use helpers::create_test_store;
+use helpers::{create_test_store_with_client, setup_env};
 
 #[tokio::test]
 async fn test_round_trip() {
-    let store = NatsKvStore::new(create_test_store("round_trip_test".to_string()).await);
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let store =
+        NatsKvStore::new(create_test_store_with_client("round_trip_test", nats_client).await);
 
     let lattice_id = "roundtrip";
 
@@ -169,7 +177,14 @@ async fn test_round_trip() {
 
 #[tokio::test]
 async fn test_no_data() {
-    let store = NatsKvStore::new(create_test_store("nodata_test".to_string()).await);
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let store = NatsKvStore::new(create_test_store_with_client("nodata_test", nats_client).await);
 
     let lattice_id = "nodata";
 
@@ -199,7 +214,15 @@ async fn test_no_data() {
 
 #[tokio::test]
 async fn test_multiple_lattice() {
-    let store = NatsKvStore::new(create_test_store("multiple_lattice_test".to_string()).await);
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let store =
+        NatsKvStore::new(create_test_store_with_client("multiple_lattice_test", nats_client).await);
 
     let lattice_id1 = "multiple_lattice";
     let lattice_id2 = "other_lattice";
@@ -278,7 +301,15 @@ async fn test_multiple_lattice() {
 
 #[tokio::test]
 async fn test_store_and_delete_many() {
-    let store = NatsKvStore::new(create_test_store("store_many_test".to_string()).await);
+    let env = setup_env()
+        .await
+        .expect("should have set up the test environment");
+    let nats_client = env
+        .nats_client()
+        .await
+        .expect("should have created a nats client");
+    let store =
+        NatsKvStore::new(create_test_store_with_client("store_many_test", nats_client).await);
 
     let lattice_id = "storemany";
 


### PR DESCRIPTION
## Feature or Problem

Since #367 introduced a `testcontainers`-based setup for the test environment, which provides some nice properties over running a shared NATS server, we should adopt it for more tests.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
