### PR TITLE
fix(wadm): update reaper to allow for latency

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,11 +124,11 @@ struct Args {
     state_bucket: String,
 
     /// The amount of time in seconds to give for hosts to fail to heartbeat and be removed from the
-    /// store. By default, this is 60s because it is 2x the host heartbeat interval
+    /// store. By default, this is 70s because it is 2x the host heartbeat interval plus a little padding
     #[arg(
         long = "cleanup-interval",
         env = "WADM_CLEANUP_INTERVAL",
-        default_value = "60"
+        default_value = "70"
     )]
     cleanup_interval: u64,
 


### PR DESCRIPTION
## Feature or Problem
This PR slightly bumps the 60s cleanup interval to 70s, since the reaper will divide that by 2 and then expect to see an event in that interval. Bumping to 70s allows for 5 seconds of wiggle room to miss a heartbeat, while waiting 70s certainly means that a host missed 2 heartbeats.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
