### PR TITLE
fix(scalers): put link for component as target

### DIFF
--- a/crates/wadm/src/scaler/spreadscaler/link.rs
+++ b/crates/wadm/src/scaler/spreadscaler/link.rs
@@ -91,7 +91,7 @@ where
     async fn handle_event(&self, event: &Event) -> Result<Vec<Command>> {
         match event {
             // Trigger linkdef creation if this component starts and belongs to this model
-            Event::ComponentScaled(evt) if evt.component_id == self.config.source_id => {
+            Event::ComponentScaled(evt) if evt.component_id == self.config.source_id || evt.component_id == self.config.target => {
                 self.reconcile().await
             }
             Event::ProviderHealthCheckPassed(ProviderHealthCheckPassed {


### PR DESCRIPTION
## Feature or Problem
This PR adds a very simple additional check in the link scaler to ensure that if a component starts that is involved in a link where it's the target of the link, it will trigger creation of the link.

This is pretty much just a logical error to not include this.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
