### PR TITLE
feat(*)!: surface application errors in status

### DIFF
--- a/crates/wadm/src/events/types.rs
+++ b/crates/wadm/src/events/types.rs
@@ -302,7 +302,6 @@ pub struct ComponentScaled {
     pub claims: Option<ComponentClaims>,
     pub image_ref: String,
     pub max_instances: usize,
-    // TODO: Once we update to the 1.0 release candidate, this will be component_id
     pub component_id: String,
     #[serde(default)]
     pub host_id: String,
@@ -321,7 +320,6 @@ pub struct ComponentScaleFailed {
     pub claims: Option<ComponentClaims>,
     pub image_ref: String,
     pub max_instances: usize,
-    // TODO: Once we update to the 1.0 release candidate, this will be component_id
     pub component_id: String,
     #[serde(default)]
     pub host_id: String,
@@ -463,7 +461,6 @@ event_impl!(ConfigDeleted, "com.wasmcloud.lattice.config_deleted");
 pub struct HostStarted {
     pub labels: HashMap<String, String>,
     pub friendly_name: String,
-    // TODO: Parse as nkey?
     #[serde(default)]
     pub id: String,
 }
@@ -478,7 +475,6 @@ event_impl!(
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct HostStopped {
     pub labels: HashMap<String, String>,
-    // TODO: Parse as nkey?
     #[serde(default)]
     pub id: String,
 }

--- a/crates/wadm/src/scaler/manager.rs
+++ b/crates/wadm/src/scaler/manager.rs
@@ -42,7 +42,7 @@ use super::{
         link::{LinkScaler, LinkScalerConfig},
         provider::{ProviderSpreadConfig, ProviderSpreadScaler},
     },
-    BackoffScaler,
+    BackoffWrapper,
 };
 
 pub type BoxedScaler = Box<dyn Scaler + Send + Sync + 'static>;
@@ -504,7 +504,7 @@ where
                                 // wrapped ones (which is good from a Rust API point of view). If
                                 // this starts to become a problem, we can revisit how we handle
                                 // this (probably by requiring that this struct always wraps any
-                                // scaler in the backoff scaler and using custom methods from that
+                                // scaler in the backoff wrapper and using custom methods from that
                                 // type)
                                 Notifications::RegisterExpectedEvents{ name, scaler_id, triggering_event } => {
                                     trace!(%name, "Computing and registering expected events for manifest");
@@ -606,7 +606,7 @@ where
                     config_names.append(&mut secret_names.clone());
                     match (trt.trait_type.as_str(), &trt.properties) {
                         (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                            Some(Box::new(BackoffScaler::new(
+                            Some(Box::new(BackoffWrapper::new(
                                 ComponentSpreadScaler::new(
                                     snapshot_data.clone(),
                                     props.image.to_owned(),
@@ -626,7 +626,7 @@ where
                             )) as BoxedScaler)
                         }
                         (DAEMONSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                            Some(Box::new(BackoffScaler::new(
+                            Some(Box::new(BackoffWrapper::new(
                                 ComponentDaemonScaler::new(
                                     snapshot_data.clone(),
                                     props.image.to_owned(),
@@ -682,7 +682,7 @@ where
                                     | Properties::Component {
                                         properties: ComponentProperties { id, .. },
                                     } if component.name == p.target.name => {
-                                        Some(Box::new(BackoffScaler::new(
+                                        Some(Box::new(BackoffWrapper::new(
                                             LinkScaler::new(
                                                 snapshot_data.clone(),
                                                 LinkScalerConfig {
@@ -740,7 +740,7 @@ where
                                 );
                                 config_names.append(&mut secret_names.clone());
 
-                                Some(Box::new(BackoffScaler::new(
+                                Some(Box::new(BackoffWrapper::new(
                                     ProviderSpreadScaler::new(
                                         snapshot_data.clone(),
                                         ProviderSpreadConfig {
@@ -773,7 +773,7 @@ where
                                     policies,
                                 );
                                 config_names.append(&mut secret_names.clone());
-                                Some(Box::new(BackoffScaler::new(
+                                Some(Box::new(BackoffWrapper::new(
                                     ProviderDaemonScaler::new(
                                         snapshot_data.clone(),
                                         ProviderSpreadConfig {
@@ -834,7 +834,7 @@ where
                                         Properties::Component { properties: cappy }
                                             if component.name == p.target.name =>
                                         {
-                                            Some(Box::new(BackoffScaler::new(
+                                            Some(Box::new(BackoffWrapper::new(
                                                 LinkScaler::new(
                                                     snapshot_data.clone(),
                                                     LinkScalerConfig {
@@ -883,7 +883,7 @@ where
                         secrets_to_scalers(snapshot_data.clone(), name, &props.secrets, policies);
                     config_names.append(&mut secret_names.clone());
 
-                    scalers.push(Box::new(BackoffScaler::new(
+                    scalers.push(Box::new(BackoffWrapper::new(
                         ProviderSpreadScaler::new(
                             snapshot_data.clone(),
                             ProviderSpreadConfig {

--- a/crates/wadm/src/scaler/manager.rs
+++ b/crates/wadm/src/scaler/manager.rs
@@ -42,7 +42,7 @@ use super::{
         link::{LinkScaler, LinkScalerConfig},
         provider::{ProviderSpreadConfig, ProviderSpreadScaler},
     },
-    BackoffAwareScaler,
+    BackoffScaler,
 };
 
 pub type BoxedScaler = Box<dyn Scaler + Send + Sync + 'static>;
@@ -606,7 +606,7 @@ where
                     config_names.append(&mut secret_names.clone());
                     match (trt.trait_type.as_str(), &trt.properties) {
                         (SPREADSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                            Some(Box::new(BackoffAwareScaler::new(
+                            Some(Box::new(BackoffScaler::new(
                                 ComponentSpreadScaler::new(
                                     snapshot_data.clone(),
                                     props.image.to_owned(),
@@ -626,7 +626,7 @@ where
                             )) as BoxedScaler)
                         }
                         (DAEMONSCALER_TRAIT, TraitProperty::SpreadScaler(p)) => {
-                            Some(Box::new(BackoffAwareScaler::new(
+                            Some(Box::new(BackoffScaler::new(
                                 ComponentDaemonScaler::new(
                                     snapshot_data.clone(),
                                     props.image.to_owned(),
@@ -682,7 +682,7 @@ where
                                     | Properties::Component {
                                         properties: ComponentProperties { id, .. },
                                     } if component.name == p.target.name => {
-                                        Some(Box::new(BackoffAwareScaler::new(
+                                        Some(Box::new(BackoffScaler::new(
                                             LinkScaler::new(
                                                 snapshot_data.clone(),
                                                 LinkScalerConfig {
@@ -740,7 +740,7 @@ where
                                 );
                                 config_names.append(&mut secret_names.clone());
 
-                                Some(Box::new(BackoffAwareScaler::new(
+                                Some(Box::new(BackoffScaler::new(
                                     ProviderSpreadScaler::new(
                                         snapshot_data.clone(),
                                         ProviderSpreadConfig {
@@ -773,7 +773,7 @@ where
                                     policies,
                                 );
                                 config_names.append(&mut secret_names.clone());
-                                Some(Box::new(BackoffAwareScaler::new(
+                                Some(Box::new(BackoffScaler::new(
                                     ProviderDaemonScaler::new(
                                         snapshot_data.clone(),
                                         ProviderSpreadConfig {
@@ -834,7 +834,7 @@ where
                                         Properties::Component { properties: cappy }
                                             if component.name == p.target.name =>
                                         {
-                                            Some(Box::new(BackoffAwareScaler::new(
+                                            Some(Box::new(BackoffScaler::new(
                                                 LinkScaler::new(
                                                     snapshot_data.clone(),
                                                     LinkScalerConfig {
@@ -883,7 +883,7 @@ where
                         secrets_to_scalers(snapshot_data.clone(), name, &props.secrets, policies);
                     config_names.append(&mut secret_names.clone());
 
-                    scalers.push(Box::new(BackoffAwareScaler::new(
+                    scalers.push(Box::new(BackoffScaler::new(
                         ProviderSpreadScaler::new(
                             snapshot_data.clone(),
                             ProviderSpreadConfig {

--- a/crates/wadm/src/scaler/mod.rs
+++ b/crates/wadm/src/scaler/mod.rs
@@ -488,15 +488,49 @@ fn evt_matches_expected(incoming: &Event, expected: &Event) -> bool {
         (
             Event::ProviderStartFailed(ProviderStartFailed {
                 provider_id: p1,
+                provider_ref: i1,
                 host_id: h1,
                 ..
             }),
             Event::ProviderStartFailed(ProviderStartFailed {
                 provider_id: p2,
+                provider_ref: i2,
                 host_id: h2,
                 ..
             }),
-        ) => p1 == p2 && h1 == h2,
+        ) => p1 == p2 && h1 == h2 && i1 == i2,
+        (
+            Event::ComponentScaled(ComponentScaled {
+                annotations: a1,
+                image_ref: i1,
+                component_id: c1,
+                host_id: h1,
+                ..
+            }),
+            Event::ComponentScaled(ComponentScaled {
+                annotations: a2,
+                image_ref: i2,
+                component_id: c2,
+                host_id: h2,
+                ..
+            }),
+        ) => a1 == a2 && i1 == i2 && c1 == c2 && h1 == h2,
+        (
+            Event::ComponentScaleFailed(ComponentScaleFailed {
+                annotations: a1,
+                image_ref: i1,
+                component_id: c1,
+                host_id: h1,
+                ..
+            }),
+            Event::ComponentScaleFailed(ComponentScaleFailed {
+                annotations: a2,
+                image_ref: i2,
+                component_id: c2,
+                host_id: h2,
+                ..
+            }),
+        ) => a1 == a2 && i1 == i2 && c1 == c2 && h1 == h2,
         _ => false,
     }
 }


### PR DESCRIPTION
## Feature or Problem
This PR adds an additional field to the `BackoffWrapper` (previously BackoffAwareScaler) that can store a failed message received by wadm in response to a command. Commands in wasmCloud, particularly the ScaleComponentCommand and StartProvider command have corresponding events that indicate whether it successfully scaled/started or it failed. In this PR, I used the same structure that we already used for notifying scalers of events that should come in to also interpret whether or not a newly received event was actually a failure to process the command. In the case where the event was a failure, we now store the status in the `BackoffWrapper` and report that status for 5 seconds, effectively backing off that scaler from additional reconciliation or status reporting until that status is cleared.

As mentioned in some comments, a followup PR fully fixing #253 should be done as well that exponentially backs this off up to a ceiling duration. In order to keep the discussion focused, I scoped this PR to just the logic that pulls the failed message off of the event.

Requesting the status of an application that, for example, refers to a provider that doesn't exist, will look like this:
```json
{
  "result": "ok",
  "message": "Successfully fetched status for application rust-hello-world",
  "status": {
    "status": {
      "type": "failed",
      "message": "Scaling component on 1 host(s), failed to fetch provider: failed to fetch provider under OCI reference `ghcr.io/wasmcloud/http-server:0.22.1`: failed to fetch OCI path: failed to fetch OCI bytes: Registry error: url https://ghcr.io/v2/wasmcloud/http-server/manifests/0.22.1, envelope: OCI API errors: [OCI API error: manifest unknown]"
    },
    "scalers": [
      {
        "id": "3cc1670aad7ffbdaaa599b1fd2bfbe5877d6df9b57729ee68d89afd8b8a4e2fc",
        "kind": "SpreadScaler",
        "name": "rust_hello_world-http_component",
        "status": {
          "type": "reconciling",
          "message": "Scaling component on 1 host(s)"
        }
      },
      {
        "id": "ea010c3726e248ef3c112bf31f9ed1af75d7127438f43576ff66626890ae74e2",
        "kind": "LinkScaler",
        "name": "rust_hello_world-httpserver -(wasi:http)-> rust_hello_world-http_component",
        "status": {
          "type": "deployed"
        }
      },
      {
        "id": "bd2f7d542c821c5e50fead647f590c86e5c6bf35e75b7cd05fabb40c803e7727",
        "kind": "SpreadScaler",
        "name": "rust_hello_world-httpserver",
        "status": {
          "type": "failed",
          "message": "failed to fetch provider: failed to fetch provider under OCI reference `ghcr.io/wasmcloud/http-server:0.22.1`: failed to fetch OCI path: failed to fetch OCI bytes: Registry error: url https://ghcr.io/v2/wasmcloud/http-server/manifests/0.22.1, envelope: OCI API errors: [OCI API error: manifest unknown]"
        }
      }
    ],
    "version": "",
    "components": []
  }
}
```

## Related Issues
Lays the ground work for #253 

## Release Information
wadm 0.14.0

## Consumer Impact
This didn't require any over-the-wire breaking changes, but operators should ensure that all of their wadm instances are updated to use this version. Running this version and an older version of wadm may result in inconsistent statuses, as the newer wadm scalers will understand backing off status but the older ones will not.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I manually verified this worked for a provider reference, but there's more testing to be done around the general functionality.