### PR TITLE
fix(charts): align replicas value

### DIFF
--- a/charts/wadm/Chart.yaml
+++ b/charts/wadm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.3"
+version: "0.2.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wadm/templates/deployment.yaml
+++ b/charts/wadm/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "wadm.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "wadm.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Rendering this chart without this fix results in an empty field for replicas.


## Feature or Problem
replicasCount doesn't exist as a value so the resulting yaml looks like:
```yaml
spec:
  replicas: 
  selector:
```

Opted to align with the `values.yaml` which is generally treated as the primary API for a chart and thus avoids a breaking change rev.