### PR TITLE
release: v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-cli"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-cli"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]
@@ -80,9 +80,9 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 ulid = { version = "1", features = ["serde"] }
 utoipa = "4"
 uuid = "1"
-wadm = { version = "0.13.0", path = "./crates/wadm" }
-wadm-client = { version = "0.2.0", path = "./crates/wadm-client" }
-wadm-types = { version = "0.2.0", path = "./crates/wadm-types" }
+wadm = { version = "0.14.0", path = "./crates/wadm" }
+wadm-client = { version = "0.3.0", path = "./crates/wadm-client" }
+wadm-types = { version = "0.3.0", path = "./crates/wadm-types" }
 wasmcloud-control-interface = "1.0.0"
 wasmcloud-secrets-types = "0.2.0"
 wit-bindgen-wrpc = { version = "0.3.7", default-features = false }

--- a/crates/wadm-client/Cargo.toml
+++ b/crates/wadm-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-client"
 description = "A client library for interacting with the wadm API"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-types"
 description = "Types and validators for the wadm API"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm/Cargo.toml
+++ b/crates/wadm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
## Feature or Problem
This PR sets up a v0.14.0 release of wadm.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
wadm v0.14.0
client v0.3.0
types v0.3.0

# Sample changelog for release

## [Unreleased](https://github.com/wasmCloud/wadm/compare/v0.13.1...HEAD) (2024-08-20)

### Features

* **scaler:** backoff when failed event received
([7e03d06](https://github.com/wasmCloud/wadm/commit/7e03d060b311fdf73602675371efe114096a117f))
* **scaler:** implement component scale corresponding event
([f123736](https://github.com/wasmCloud/wadm/commit/f1237363c12c4ea7614badb8cfc4ceac50fc39dc))
* **scaler:** add kind and name methods
([066e50e](https://github.com/wasmCloud/wadm/commit/066e50e4eb3d284cebbb63271781f52b4297d783))
* **observer:** observe lattice on manifest publish
([19cbd5a](https://github.com/wasmCloud/wadm/commit/19cbd5a44d967f5cb5849f140004feb4022bf33d))
* **wadm:** detail status per scaler
([172db98](https://github.com/wasmCloud/wadm/commit/172db98f1e83ac33c060e9b2ac542244e5f49269))
* **scaler:** add human_friendly_name method
([72170e9](https://github.com/wasmCloud/wadm/commit/72170e9a8e25f1fdd5b542b8fe542ff290952f0e))
* **wadm:** set cleanup interval to 60s
([43ba037](https://github.com/wasmCloud/wadm/commit/43ba03790a56d3f05b98398c3cf369e65cd5cdf9))
* **client:** return name and version from deploy model
([392347d](https://github.com/wasmCloud/wadm/commit/392347dfe99d03f8a96f311d08b3d33d68192696))

### Fixes

* **charts:** align replicas value (#382)
([5def02c](https://github.com/wasmCloud/wadm/commit/5def02caaf76bccb53a2317a629dba38956a8838)),
closes [#382](https://github.com/wasmCloud/wadm/issues/382)
* **scalers:** put link for component as target
([2d6327b](https://github.com/wasmCloud/wadm/commit/2d6327b943e05494f7d63d439dcfb2d78930b7ab))
* **server:** use backwards compatible undeployed
([c295cf0](https://github.com/wasmCloud/wadm/commit/c295cf0e337a04235baf7f6f3e8ab7f0cbad6fbc))
* **bindings:** add waiting status
([e2764c7](https://github.com/wasmCloud/wadm/commit/e2764c720bb100af9bed72fca4202f7b90bfe8a4))
* **scalers:** report status properly after reconcile
([6f4abcf](https://github.com/wasmCloud/wadm/commit/6f4abcf389f7b3a0d4487fefd8f5b63f753f84ed))
* **wadm:** update reaper to allow for latency
([ffe20a6](https://github.com/wasmCloud/wadm/commit/ffe20a61779449ffa97be706ae65d3f51bd658a2))
* **scalers:** remove scalers upon notification
([8d8adfe](https://github.com/wasmCloud/wadm/commit/8d8adfe54eb6f99f2800fe5e8aedfdfa657cfbb4))
* **wadm:** attach lattice/multitenant to consumer metadata
([c6c481f](https://github.com/wasmCloud/wadm/commit/c6c481f930328c1b90aa34a0c132ad6ab65718ba))
* **wit:** update bindings to types 0.2.0
([50d2b76](https://github.com/wasmCloud/wadm/commit/50d2b76213dcb3fe060d9c56b1ec6b51200d8c6b))

