### PR TITLE
fix(wadm): ensure custom traits are not spread or link traits

### DIFF
--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -307,6 +307,11 @@ impl Trait {
         self.trait_type == LINK_TRAIT
     }
 
+    /// Check if a trait is a scaler
+    pub fn is_scaler(&self) -> bool {
+        self.trait_type == SPREADSCALER_TRAIT || self.trait_type == DAEMONSCALER_TRAIT
+    }
+
     /// Helper that creates a new spreadscaler type trait with the given properties
     pub fn new_spreadscaler(props: SpreadScalerProperty) -> Trait {
         Trait {
@@ -348,11 +353,11 @@ impl From<SpreadScalerProperty> for TraitProperty {
     }
 }
 
-impl From<serde_json::Value> for TraitProperty {
-    fn from(value: serde_json::Value) -> Self {
-        Self::Custom(value)
-    }
-}
+// impl From<serde_json::Value> for TraitProperty {
+//     fn from(value: serde_json::Value) -> Self {
+//         Self::Custom(value)
+//     }
+// }
 
 /// Properties for the config list associated with components, providers, and links
 ///

--- a/tests/fixtures/manifests/dangling-link.wadm.yaml
+++ b/tests/fixtures/manifests/dangling-link.wadm.yaml
@@ -18,7 +18,8 @@ spec:
             instances: 1
         - type: link
           properties:
+            namespace: wasi
+            package: http
+            interfaces: [outgoing-handler]
             target:
-              name: httpserver
-            values:
-              address: 0.0.0.0:8080
+              name: httpclient

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -25,13 +25,11 @@ async fn validate_dangling_links() -> Result<()> {
         !failures.is_empty()
             && failures
                 .iter()
-                .all(|f| f.level == ValidationFailureLevel::Warning),
-        "failures present, all warnings"
+                .all(|f| f.level == ValidationFailureLevel::Warning
+                    || f.level == ValidationFailureLevel::Error),
+        "failures present, all warnings or errors"
     );
-    assert!(
-        failures.valid(),
-        "manifest should be valid (missing targets could be managed externally)"
-    );
+    assert!(!failures.valid(), "manifest should not be valid");
     Ok(())
 }
 


### PR DESCRIPTION
## Feature or Problem
This PR seeks to catch a fairly frustrating issue where you incorrectly format a spreadscaler, daemonscaler, or link trait and all of a sudden it seems that it won't deploy. This can happen when the deserialization falls through to the Custom trait.

This PR denies any trait from having a type `spreadscaler`, `daemonscaler`, or `link` and deserialize as a custom trait. All other custom traits are supported just fine.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
