### PR TITLE
fix(server): deprecate and replace model.list operation with model.get

### DIFF
--- a/crates/wadm-types/src/api.rs
+++ b/crates/wadm-types/src/api.rs
@@ -23,6 +23,14 @@ pub struct GetModelResponse {
     pub manifest: Option<Manifest>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListModelsResponse {
+    pub result: GetResult,
+    #[serde(default)]
+    pub message: String,
+    pub models: Vec<ModelSummary>,
+}
+
 /// Possible outcomes of a get request
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/crates/wadm/src/scaler/mod.rs
+++ b/crates/wadm/src/scaler/mod.rs
@@ -237,11 +237,11 @@ where
             trace!(failed_event, "Scaler received event that it was expecting");
             if failed_event {
                 let failed_message = match event {
-                    Event::ProviderStartFailed(evt) => &evt.error,
-                    Event::ComponentScaleFailed(evt) => &evt.error,
-                    _ => &format!("Received a failed event of type '{}'", event.raw_type()),
+                    Event::ProviderStartFailed(evt) => evt.error.clone(),
+                    Event::ComponentScaleFailed(evt) => evt.error.clone(),
+                    _ => format!("Received a failed event of type '{}'", event.raw_type()),
                 };
-                *self.backoff_status.write().await = Some(StatusInfo::failed(failed_message));
+                *self.backoff_status.write().await = Some(StatusInfo::failed(&failed_message));
                 // TODO(#253): Here we could refer to a stored previous duration and increase it
                 self.set_timed_status_cleanup(std::time::Duration::from_secs(5))
                     .await;

--- a/crates/wadm/src/server/handlers.rs
+++ b/crates/wadm/src/server/handlers.rs
@@ -11,8 +11,8 @@ use wadm_types::{
     api::{
         DeleteModelRequest, DeleteModelResponse, DeleteResult, DeployModelRequest,
         DeployModelResponse, DeployResult, GetModelRequest, GetModelResponse, GetResult,
-        PutModelResponse, PutResult, Status, StatusResponse, StatusResult, UndeployModelRequest,
-        VersionInfo, VersionResponse,
+        ListModelsResponse, PutModelResponse, PutResult, Status, StatusResponse, StatusResult,
+        UndeployModelRequest, VersionInfo, VersionResponse,
     },
     CapabilityProperties, Manifest, Properties,
 };
@@ -260,11 +260,17 @@ impl<P: Publisher> Handler<P> {
             summary_from_manifest_status(manifest, status)
         });
 
-        let data: Vec<ModelSummary> = futures::future::join_all(application_summaries).await;
+        let models: Vec<ModelSummary> = futures::future::join_all(application_summaries).await;
+
+        let reply = ListModelsResponse {
+            result: GetResult::Success,
+            message: "Successfully fetched list of applications".to_string(),
+            models,
+        };
 
         // NOTE: We _just_ deserialized this from the store above and then manually constructed it,
         // so we should be just fine. Just in case though, we unwrap to default
-        self.send_reply(msg.reply, serde_json::to_vec(&data).unwrap_or_default())
+        self.send_reply(msg.reply, serde_json::to_vec(&reply).unwrap_or_default())
             .await
     }
 

--- a/crates/wadm/src/server/mod.rs
+++ b/crates/wadm/src/server/mod.rs
@@ -118,7 +118,10 @@ impl<P: Publisher> Server<P> {
                     category: "model",
                     operation: "list",
                     object_name: None,
-                } => self.handler.list_models(msg, account_id, lattice_id).await,
+                } => {
+                    warn!("Received deprecated subject: model.list. Please use model.get instead");
+                    self.handler.list_models(msg, account_id, lattice_id).await
+                }
                 ParsedSubject {
                     account_id,
                     lattice_id,
@@ -130,6 +133,13 @@ impl<P: Publisher> Server<P> {
                         .get_model(msg, account_id, lattice_id, name)
                         .await
                 }
+                ParsedSubject {
+                    account_id,
+                    lattice_id,
+                    category: "model",
+                    operation: "get",
+                    object_name: None,
+                } => self.handler.list_models(msg, account_id, lattice_id).await,
                 ParsedSubject {
                     account_id,
                     lattice_id,

--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -183,8 +183,8 @@ async fn test_crud_operations() {
     );
 
     // Now check that the data returned is correct
-    let resp: Vec<ModelSummary> = test_server
-        .get_response("default.model.list", Vec::new(), None)
+    let ListModelsResponse { models: resp, .. } = test_server
+        .get_response("default.model.get", Vec::new(), None)
         .await;
 
     assert_eq!(resp.len(), 2, "Should have two models in storage");
@@ -230,8 +230,8 @@ async fn test_crud_operations() {
     assert_put_response(resp, PutResult::NewVersion, "v0.0.3", 3);
 
     // Make sure we still only have 2 manifests
-    let resp: Vec<ModelSummary> = test_server
-        .get_response("default.model.list", Vec::new(), None)
+    let ListModelsResponse { models: resp, .. } = test_server
+        .get_response("default.model.get", Vec::new(), None)
         .await;
 
     assert_eq!(resp.len(), 2, "Should still have two models in storage");


### PR DESCRIPTION
## Feature or Problem
fix response object for `model.list` operation so that it is consistent with response objects of other operations.

## Related Issues
#278 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
deprecated and existing model operation. `model.list` still works but (1) has a deprecation warning message & returns an updated response object that is not compatible with current/previous one.

## Testing
all existing tests pass. no regression
