### PR TITLE
fix(types): Fixes validation for wasi:keyvalue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "wadm-cli"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.14.0"
+version.workspace = true
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/wasmcloud/wadm"
+
+[workspace.package]
+version = "0.14.1"
 
 [features]
 default = []

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-types"
 description = "Types and validators for the wadm API"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm-types/src/bindings.rs
+++ b/crates/wadm-types/src/bindings.rs
@@ -65,7 +65,7 @@ impl From<Policy> for wadm::types::Policy {
     fn from(policy: Policy) -> Self {
         wadm::types::Policy {
             name: policy.name,
-            properties: policy.properties.into_iter().map(|p| p.into()).collect(),
+            properties: policy.properties.into_iter().collect(),
             type_: policy.policy_type,
         }
     }
@@ -368,7 +368,7 @@ impl From<wadm::types::Policy> for Policy {
     fn from(policy: wadm::types::Policy) -> Self {
         Policy {
             name: policy.name,
-            properties: policy.properties.into_iter().map(|p| p.into()).collect(),
+            properties: policy.properties.into_iter().collect(),
             policy_type: policy.type_,
         }
     }

--- a/crates/wadm-types/src/validation.rs
+++ b/crates/wadm-types/src/validation.rs
@@ -60,7 +60,12 @@ fn get_known_interface_lookup() -> &'static KnownInterfaceLookup {
                     ("config".into(), HashMap::from([("runtime".into(), ())])),
                     (
                         "keyvalue".into(),
-                        HashMap::from([("atomics".into(), ()), ("store".into(), ())]),
+                        HashMap::from([
+                            ("atomics".into(), ()),
+                            ("store".into(), ()),
+                            ("batch".into(), ()),
+                            ("watch".into(), ()),
+                        ]),
                     ),
                     (
                         "http".into(),

--- a/crates/wadm/Cargo.toml
+++ b/crates/wadm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm"
 description = "wasmCloud Application Deployment Manager: A tool for running Wasm applications in wasmCloud"
-version = "0.14.0"
+version.workspace = true
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
Our validation was erroneously rejecting things that were using the batch or watch interfaces for wasi keyvalue. Also fixes some things with versioning so we don't have to change it everywhere all the time
