### PR TITLE
chore: Revise the default NATS Server address logic

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -2,6 +2,7 @@ name: chart
 
 env:
   HELM_VERSION: v3.14.0
+  CHART_TESTING_NAMESPACE: chart-testing
 
 on:
   push:
@@ -56,11 +57,15 @@ jobs:
         run: |
           helm repo add nats https://nats-io.github.io/k8s/helm/charts/
           helm repo update
-          helm install nats nats/nats -f charts/wadm/ci/nats.yaml
+          helm install nats nats/nats -f charts/wadm/ci/nats.yaml --namespace ${{ env.CHART_TESTING_NAMESPACE }} --create-namespace
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing install / same namespace
         run: |
-          ct install --config charts/wadm/ct.yaml
+          ct install --config charts/wadm/ct.yaml --namespace ${{ env.CHART_TESTING_NAMESPACE }}
+
+      - name: Run chart-testing install / across namespaces
+        run: |
+          ct install --config charts/wadm/ct.yaml --helm-extra-set-args "--set=wadm.config.nats.server=nats://nats-headless.${{ env.CHART_TESTING_NAMESPACE }}.svc.cluster.local"
 
   publish:
     if: ${{ startsWith(github.ref, 'refs/tags/chart-v') }}

--- a/charts/wadm/Chart.yaml
+++ b/charts/wadm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.6"
+version: "0.2.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wadm/ci/ct-install-values.yaml
+++ b/charts/wadm/ci/ct-install-values.yaml
@@ -1,4 +1,0 @@
-wadm:
-  config:
-    nats:
-      server: "nats.default.svc.cluster.local:4222"

--- a/charts/wadm/templates/_helpers.tpl
+++ b/charts/wadm/templates/_helpers.tpl
@@ -50,6 +50,15 @@ app.kubernetes.io/name: {{ include "wadm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{- define "wadm.nats.server" -}}
+- name: WADM_NATS_SERVER
+{{- if .Values.wadm.config.nats.server }}
+  value: {{ .Values.wadm.config.nats.server | quote }}
+{{- else }}
+  value: nats-headless.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}
+{{- end }}
+
 {{- define "wadm.nats.auth" -}}
 {{- if  .Values.wadm.config.nats.creds.secretName -}}
 - name: WADM_NATS_CREDS_FILE

--- a/charts/wadm/templates/deployment.yaml
+++ b/charts/wadm/templates/deployment.yaml
@@ -34,8 +34,7 @@ spec:
           image: "{{ .Values.wadm.image.repository }}:{{ .Values.wadm.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.wadm.image.pullPolicy }}
           env:
-            - name: WADM_NATS_SERVER
-              value: {{ .Values.wadm.config.nats.server | quote }}
+          {{- include "wadm.nats.server" . | nindent 12 }}
           {{- include "wadm.nats.auth" . | nindent 12 }}
           {{- if .Values.wadm.config.nats.tlsCaFile }}
             - name: WADM_NATS_TLS_CA_FILE

--- a/charts/wadm/values.yaml
+++ b/charts/wadm/values.yaml
@@ -14,7 +14,7 @@ wadm:
     hostId: ""
     logLevel: ""
     nats:
-      server: "127.0.0.1:4222"
+      server: ""
       jetstreamDomain: ""
       tlsCaFile: ""
       creds:


### PR DESCRIPTION
## Feature or Problem

As it turns out, `127.0.0.1:4222` isn't a terribly helpful default.

Instead, the most common scenario we see today is one where wadm is installed in the same namespace as the NATS Servers running in the cluster, so we should simply attempt to use that address instead.

This behavior can still be overridden as before, by providing a value via `wadm.config.nats.server`


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
