### PR TITLE
chore: Use normal cargo build on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,30 +24,35 @@ jobs:
         config:
           - {
               runnerOs: 'ubuntu-latest',
+              buildCommand: 'cargo zigbuild',
               target: 'x86_64-unknown-linux-musl',
               uploadArtifactSuffix: 'linux-amd64',
               buildOutputPath: 'target/x86_64-unknown-linux-musl/release/wadm',
             }
           - {
               runnerOs: 'ubuntu-latest',
+              buildCommand: 'cargo zigbuild',
               target: 'aarch64-unknown-linux-musl',
               uploadArtifactSuffix: 'linux-aarch64',
               buildOutputPath: 'target/aarch64-unknown-linux-musl/release/wadm',
             }
           - {
               runnerOs: 'macos-14',
+              buildCommand: 'cargo zigbuild',
               target: 'x86_64-apple-darwin',
               uploadArtifactSuffix: 'macos-amd64',
               buildOutputPath: 'target/x86_64-apple-darwin/release/wadm',
             }
           - {
               runnerOs: 'macos-14',
+              buildCommand: 'cargo zigbuild',
               target: 'aarch64-apple-darwin',
               uploadArtifactSuffix: 'macos-aarch64',
               buildOutputPath: 'target/aarch64-apple-darwin/release/wadm',
             }
           - {
               runnerOs: 'windows-latest',
+              buildCommand: 'cargo build',
               target: 'x86_64-pc-windows-msvc',
               uploadArtifactSuffix: 'windows-amd64',
               buildOutputPath: 'target/x86_64-pc-windows-msvc/release/wadm.exe',
@@ -86,7 +91,7 @@ jobs:
 
       - name: Build wadm
         run: |
-          cargo zigbuild --release --bin wadm --target ${{ matrix.config.target }}
+          ${{ matrix.config.buildCommand }} --release --bin wadm --target ${{ matrix.config.target }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Feature or Problem

#421 inadvertently broke Windows builds, which I suspect is related to switching to zigbuild for cross-compilation.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
