### PR TITLE
fix(handler): backwards compat list

### DIFF
--- a/crates/wadm/src/server/mod.rs
+++ b/crates/wadm/src/server/mod.rs
@@ -120,7 +120,9 @@ impl<P: Publisher> Server<P> {
                     object_name: None,
                 } => {
                     warn!("Received deprecated subject: model.list. Please use model.get instead");
-                    self.handler.list_models(msg, account_id, lattice_id).await
+                    self.handler
+                        .list_models_deprecated(msg, account_id, lattice_id)
+                        .await
                 }
                 ParsedSubject {
                     account_id,


### PR DESCRIPTION
## Feature or Problem
When moving to the new list operation, we also changed the type. This change ensures that older clients will, for one minor version, still be able to list applications and newer clients can migrate.

The function added in this PR, and the `list` operation handler, can be removed once we release the next version of wadm.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
```
➜ wash app put ./host_stop.yaml

Put application "host-stop", version "01J8G0DW1YWTT3N8ETMSPC6V82"

on fix/deprecated-model-list 🛁 wash v0.33.0 
/private/var/folders/rf/kgpfv4t9437cj3h3c77vglrr0000gn/T/tmp.cAIkxdl8WR/tests/fixtures/manifests ➜ wash app list

                                             
  Name        Deployed Version   Status      
  host-stop   N/A                Undeployed  
    └ This is my app
```