### PR TITLE
feat: regex matching for scaler requirements

### DIFF
--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -722,6 +722,12 @@ mod test {
             weight: Some(20),
         };
         spread_vec.push(spread_item);
+        let spread_item = Spread {
+            name: "northcoast".to_string(),
+            requirements: BTreeMap::from([("zone".to_string(), "([a-z]{2}-north-([0-9])".to_string())]),
+            weight: Some(40),
+        };
+        spread_vec.push(spread_item);
         let mut trait_vec: Vec<Trait> = Vec::new();
         let spreadscalerprop = SpreadScalerProperty {
             instances: 4,
@@ -783,6 +789,12 @@ mod test {
         let spread_item = Spread {
             name: "haslights".to_string(),
             requirements: BTreeMap::from([("zone".to_string(), "enabled".to_string())]),
+            weight: Some(DEFAULT_SPREAD_WEIGHT),
+        };
+        spread_vec.push(spread_item);
+        let spread_item = Spread {
+            name: "hascloud".to_string(),
+            requirements: BTreeMap::from([("cloud".to_string(), "^[a-z]+$".to_string())]),
             weight: Some(DEFAULT_SPREAD_WEIGHT),
         };
         spread_vec.push(spread_item);

--- a/crates/wadm/src/scaler/daemonscaler/provider.rs
+++ b/crates/wadm/src/scaler/daemonscaler/provider.rs
@@ -606,7 +606,6 @@ mod test {
         );
 
         let mut commands = spreadscaler.reconcile().await?;
-        println!("Provider: {:?}", commands);
         assert_eq!(commands.len(), 2);
         // Sort to enable predictable test
         commands.sort_unstable_by(|a, b| match (a, b) {

--- a/oam/simple1.json
+++ b/oam/simple1.json
@@ -26,12 +26,19 @@
                   "requirements": {
                     "zone": "us-east-1"
                   },
-                  "weight": 80
+                  "weight": 60
                 },
                 {
                   "name": "westcoast",
                   "requirements": {
                     "zone": "us-west-1"
+                  },
+                  "weight": 20
+                },
+                {
+                  "name": "eithercoast",
+                  "requirements": {
+                    "zone": "us-([a-z]{4})-1"
                   },
                   "weight": 20
                 }
@@ -75,6 +82,12 @@
                   "name": "haslights",
                   "requirements": {
                     "ledenabled": "true"
+                  }
+                },
+                {
+                  "name": "hascloud",
+                  "requirements": {
+                    "cloud": "^[a-z]+$"
                   }
                 }
               ]

--- a/oam/simple1.yaml
+++ b/oam/simple1.yaml
@@ -18,10 +18,14 @@ spec:
               - name: eastcoast
                 requirements:
                   zone: us-east-1
-                weight: 80
+                weight: 60
               - name: westcoast
                 requirements:
                   zone: us-west-1
+                weight: 20
+              - name: eithercoast
+                requirements:
+                  zone: us-([a-z]{4})-1
                 weight: 20
 
     - name: webcap
@@ -50,3 +54,6 @@ spec:
               - name: haslights
                 requirements:
                   ledenabled: "true"
+              - name: hascloud
+                requirements:
+                  cloud: ^[a-z]+$

--- a/oam/simple2.yaml
+++ b/oam/simple2.yaml
@@ -18,10 +18,14 @@ spec:
               - name: eastcoast
                 requirements:
                   zone: us-east-1
-                weight: 80
+                weight: 60
               - name: westcoast
                 requirements:
                   zone: us-west-1
+                weight: 20
+              - name: eithercoast
+                requirements:
+                  zone: us-([a-z]+)-1
                 weight: 20
 
     - name: webcap
@@ -53,3 +57,6 @@ spec:
               - name: haslights
                 requirements:
                   ledenabled: "true"
+              - name: hascloud
+                requirements:
+                  cloud: ^[a-z]+$

--- a/tests/fixtures/manifests/regex_spread.yaml
+++ b/tests/fixtures/manifests/regex_spread.yaml
@@ -1,0 +1,54 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: regex-spread
+  annotations:
+    description: 'This is my app'
+spec:
+  policies:
+    - name: test-policy
+      type: test
+      properties:
+        test: "data"
+  components:
+    - name: hello
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 5
+            spread:
+              - name: eastcoast
+                requirements:
+                  region: us-[a-z]{6}-east
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.21.0
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 5
+            spread:
+              - name: eastcoast
+                requirements:
+                  region: us-[a-z]{6}-east
+                weight: 40
+              - name: westcoast
+                requirements:
+                  region: us-taylor-[a-z]{4}
+                weight: 40
+              - name: the-moon
+                requirements:
+                  region: ^[a-z]+$
+                weight: 20
+        - type: link
+          properties:
+            target:
+              name: hello
+            namespace: wasi
+            package: http
+            interfaces: ['incoming-handler']


### PR DESCRIPTION
## Feature or Problem
This features allows for scaler configurations to match a regex expression rather than the exact label value. All spread requirements will now be treated as regex with (most) existing wadm files being backwards compatible in matching the labels. This gives more flexible deployment and can be used in addition to leaf nodes to keep traffic within the same area.

## Related Issues
- #419 

## Consumer Impact
- escape characters may need to be used with hosts which contain regex-specific characters (e.g. *, +, ? ...). For example to match the label `star-*` you would need the regex `star-\*`

### Unit Test(s)
- existing unit tests remain untouched to ensure backwards compatability
- additional unit tests for both component and provider
- additional e2e test for regex matching
- additional serialisation and deserialisation tests

### Manual Verification
- various wadm files tested on a simple 4 host setup