### PR TITLE
fix/fetch stream status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,12 +3642,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
- "base64 0.22.1",
  "bytes",
  "chrono",
  "cloudevents-sdk",
@@ -3677,12 +3676,11 @@ dependencies = [
 
 [[package]]
 name = "wadm-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
- "base64 0.22.1",
  "chrono",
  "clap",
  "futures",
@@ -3732,7 +3730,6 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
- "base64 0.22.1",
  "bytes",
  "chrono",
  "cloudevents-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/wasmcloud/wadm"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 
 [features]
 default = []
@@ -49,7 +49,6 @@ wadm-types = { workspace = true }
 anyhow = "1"
 async-nats = "0.36"
 async-trait = "0.1"
-base64 = "0.22.1"
 bytes = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "cargo", "env"] }
@@ -91,7 +90,6 @@ wasmcloud-secrets-types = "0.2.0"
 wit-bindgen-wrpc = { version = "0.3.7", default-features = false }
 
 [dev-dependencies]
-base64 = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -17,7 +17,6 @@ serde_yaml = { workspace = true }
 anyhow = { workspace = true }
 async-nats = { workspace = true }
 async-trait = { workspace = true }
-base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 cloudevents-sdk = { workspace = true }

--- a/crates/wadm/Cargo.toml
+++ b/crates/wadm/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/wasmcloud/wadm"
 anyhow = { workspace = true }
 async-nats = { workspace = true }
 async-trait = { workspace = true }
-base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 cloudevents-sdk = { workspace = true }

--- a/crates/wadm/src/server/handlers.rs
+++ b/crates/wadm/src/server/handlers.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use anyhow::anyhow;
 use async_nats::{jetstream::stream::Stream, Client, Message, Subject};
-use base64::{engine::general_purpose::STANDARD as B64decoder, Engine};
 use serde_json::json;
 use tracing::{debug, error, instrument, trace};
 use wadm_types::api::{ModelSummary, StatusInfo, StatusType};
@@ -933,12 +932,9 @@ impl<P: Publisher> Handler<P> {
             .status_stream
             .get_last_raw_message_by_subject(&format!("wadm.status.{lattice_id}.{name}",))
             .await
-            .map(|raw| {
-                B64decoder
-                    .decode(raw.payload)
-                    .map(|b| serde_json::from_slice::<Status>(&b))
-            }) {
-            Ok(Ok(Ok(status))) => Some(status),
+            .map(|status_msg| serde_json::from_slice::<Status>(&status_msg.payload))
+        {
+            Ok(Ok(status)) => Some(status),
             // Application status doesn't exist or is invalid, assuming undeployed
             _ => None,
         }


### PR DESCRIPTION
- **fix(wadm): deserialize, not decode, stream status**
- **chore: bump 0.16.1, remove base64 dep**

## Feature or Problem
This PR fixes an issue that we fixed in tests, but not in the handler code, for fetching status from the latest async-nats release.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
