### PR TITLE
release: Bump wadm-client and wadm-types to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,8 +83,8 @@ ulid = { version = "1", features = ["serde"] }
 utoipa = "4"
 uuid = "1"
 wadm = { version = "0.16.0", path = "./crates/wadm" }
-wadm-client = { version = "0.5.0", path = "./crates/wadm-client" }
-wadm-types = { version = "0.5.0", path = "./crates/wadm-types" }
+wadm-client = { version = "0.6.0", path = "./crates/wadm-client" }
+wadm-types = { version = "0.6.0", path = "./crates/wadm-types" }
 wasmcloud-control-interface = { version = "2.2.0" }
 wasmcloud-secrets-types = "0.2.0"
 wit-bindgen-wrpc = { version = "0.3.7", default-features = false }

--- a/crates/wadm-client/Cargo.toml
+++ b/crates/wadm-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-client"
 description = "A client library for interacting with the wadm API"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-types"
 description = "Types and validators for the wadm API"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
## Feature or Problem

This brings the wasmcloud-control-interface up to `2.2.0` for these two crates.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
