### PR TITLE
chore: Pull in slightly older version of regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3642,7 +3642,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wadm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/wasmcloud/wadm"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 
 [features]
 default = []
@@ -66,7 +66,9 @@ opentelemetry-otlp = { version = "0.10", features = [
     "reqwest-client",
 ] }
 rand = { version = "0.8", features = ["small_rng"] }
-regex = "1.11.0"
+# NOTE(thomastaylor312): Pinning this temporarily to 1.10 due to transitive dependency with oci
+# crates that are pinned to 1.10
+regex = "~1.10"
 schemars = "0.8"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = "1"
@@ -82,9 +84,9 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 ulid = { version = "1", features = ["serde"] }
 utoipa = "4"
 uuid = "1"
-wadm = { version = "0.17.0", path = "./crates/wadm" }
-wadm-client = { version = "0.6.0", path = "./crates/wadm-client" }
-wadm-types = { version = "0.6.0", path = "./crates/wadm-types" }
+wadm = { version = "0.17.1", path = "./crates/wadm" }
+wadm-client = { version = "0.6.1", path = "./crates/wadm-client" }
+wadm-types = { version = "0.6.1", path = "./crates/wadm-types" }
 wasmcloud-control-interface = { version = "2.2.0" }
 wasmcloud-secrets-types = "0.2.0"
 wit-bindgen-wrpc = { version = "0.3.7", default-features = false }

--- a/crates/wadm-client/Cargo.toml
+++ b/crates/wadm-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-client"
 description = "A client library for interacting with the wadm API"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-types"
 description = "Types and validators for the wadm API"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]


### PR DESCRIPTION
Because transitive deps suck. We need this so we can update the OCI deps in the main host