### PR TITLE
fix(wadm-types): Address RUSTSEC-2024-0370

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,30 +2134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,9 +3572,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "8861811f7213bb866cd02319acb69a15b0ef8ca46874e805bd92d488c779036a"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
@@ -3608,11 +3584,10 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
+checksum = "5fadf94f07d67df4b15e6490dd9a9d59d7374849413e7f137eafe52fdcbd0db5"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.68",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ tracing-futures = "0.2"
 tracing-opentelemetry = { version = "0.17" }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 ulid = { version = "1", features = ["serde"] }
-utoipa = "4"
+utoipa = "5"
 uuid = "1"
 wadm = { version = "0.17.1", path = "./crates/wadm" }
 wadm-client = { version = "0.6.1", path = "./crates/wadm-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ utoipa = "5"
 uuid = "1"
 wadm = { version = "0.17.1", path = "./crates/wadm" }
 wadm-client = { version = "0.6.1", path = "./crates/wadm-client" }
-wadm-types = { version = "0.6.1", path = "./crates/wadm-types" }
+wadm-types = { version = "0.7.0", path = "./crates/wadm-types" }
 wasmcloud-control-interface = { version = "2.2.0" }
 wasmcloud-secrets-types = "0.2.0"
 wit-bindgen-wrpc = { version = "0.3.7", default-features = false }

--- a/crates/wadm-types/Cargo.toml
+++ b/crates/wadm-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadm-types"
 description = "Types and validators for the wadm API"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["wasmCloud Team"]
 keywords = ["webassembly", "wasmcloud", "wadm"]

--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use schemars::JsonSchema;
 use serde::{de, Deserialize, Serialize};
+use utoipa::ToSchema;
 
 pub mod api;
 #[cfg(feature = "wit")]
@@ -37,7 +38,7 @@ pub const LINK_TRAIT: &str = "link";
 pub const LATEST_VERSION: &str = "latest";
 
 /// Manifest file based on the Open Application Model (OAM) specification for declaratively managing wasmCloud applications
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, utoipa::ToSchema, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
     /// The OAM version of the manifest
@@ -171,7 +172,7 @@ impl Manifest {
 }
 
 /// The metadata describing the manifest
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 pub struct Metadata {
     /// The name of the manifest. This must be unique per lattice
     pub name: String,
@@ -184,7 +185,7 @@ pub struct Metadata {
 }
 
 /// A representation of an OAM specification
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 pub struct Specification {
     /// The list of components for describing an application
     pub components: Vec<Component>,
@@ -197,7 +198,7 @@ pub struct Specification {
 }
 
 /// A policy definition
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 pub struct Policy {
     /// The name of this policy
     pub name: String,
@@ -209,7 +210,7 @@ pub struct Policy {
 }
 
 /// A component definition
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 // TODO: figure out why this can't be uncommented
 // #[serde(deny_unknown_fields)]
 pub struct Component {
@@ -258,7 +259,7 @@ impl Component {
 }
 
 /// Properties that can be defined for a component
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(tag = "type")]
 pub enum Properties {
     #[serde(rename = "component", alias = "actor")]
@@ -267,7 +268,7 @@ pub enum Properties {
     Capability { properties: CapabilityProperties },
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentProperties {
     /// The image reference to use. Required unless the component is a shared component
@@ -292,7 +293,7 @@ pub struct ComponentProperties {
     pub secrets: Vec<SecretProperty>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default, ToSchema, JsonSchema)]
 pub struct ConfigDefinition {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub config: Vec<ConfigProperty>,
@@ -300,7 +301,7 @@ pub struct ConfigDefinition {
     pub secrets: Vec<SecretProperty>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, ToSchema, JsonSchema)]
 pub struct SecretProperty {
     /// The name of the secret. This is used by a reference by the component or capability to
     /// get the secret value as a resource.
@@ -310,7 +311,7 @@ pub struct SecretProperty {
     pub properties: SecretSourceProperty,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, ToSchema, JsonSchema)]
 pub struct SecretSourceProperty {
     /// The policy to use for retrieving the secret.
     pub policy: String,
@@ -325,7 +326,7 @@ pub struct SecretSourceProperty {
     pub version: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CapabilityProperties {
     /// The image reference to use. Required unless the component is a shared component
@@ -350,7 +351,7 @@ pub struct CapabilityProperties {
     pub secrets: Vec<SecretProperty>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 pub struct SharedApplicationComponentProperties {
     /// The name of the shared application
     pub name: String,
@@ -358,7 +359,7 @@ pub struct SharedApplicationComponentProperties {
     pub component: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Trait {
     /// The type of trait specified. This should be a unique string for the type of scaler. As we
@@ -405,7 +406,7 @@ impl Trait {
 }
 
 /// Properties for defining traits
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum TraitProperty {
@@ -449,7 +450,7 @@ impl From<SpreadScalerProperty> for TraitProperty {
 ///
 /// Will result in two config scalers being created, one with the name `basic-kv` and one with the
 /// name `default-port`. Wadm will not resolve collisions with configuration names between manifests.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigProperty {
     /// Name of the config to ensure exists
@@ -469,7 +470,7 @@ impl PartialEq<ConfigProperty> for String {
 }
 
 /// Properties for links
-#[derive(Debug, Serialize, Clone, PartialEq, Eq, JsonSchema, Default)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, ToSchema, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LinkProperty {
     /// WIT namespace for the link
@@ -569,7 +570,7 @@ impl<'de> Deserialize<'de> for LinkProperty {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default, ToSchema, JsonSchema)]
 pub struct TargetConfig {
     /// The target this link applies to. This should be the name of a component in the manifest
     pub name: String,
@@ -586,7 +587,7 @@ impl PartialEq<TargetConfig> for String {
 }
 
 /// Properties for spread scalers
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SpreadScalerProperty {
     /// Number of instances to spread across matching requirements
@@ -598,7 +599,7 @@ pub struct SpreadScalerProperty {
 }
 
 /// Configuration for various spreading requirements
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Spread {
     /// The name of this spread requirement


### PR DESCRIPTION
## Feature or Problem

This upgrades `utoipa-gen` from `4.3.0` to `5.1.1`, which drops the dependency on `proc-macro-error` in order to address https://rustsec.org/advisories/RUSTSEC-2024-0370.html

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
