### PR TITLE
chore: Swap wolfi-base source to cgr.dev instead of Docker Hub

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM chainguard/wolfi-base:latest AS base
+FROM cgr.dev/chainguard/wolfi-base:latest AS base
 
 FROM base AS base-amd64
 ARG BIN_AMD64


### PR DESCRIPTION
## Feature or Problem

Comparing our current `wolfi-base` source (Docker Hub):
```shell
$ grype chainguard/wolfi-base:latest        
 ✔ Loaded image                                                                                                                                                                                                                                chainguard/wolfi-base:latest
 ✔ Parsed image                                                                                                                                                                                     sha256:4bf8e6d0fe675b9cfdb4e5942f1b34247c14384d0901efcc5b5299321f787f61
 ✔ Cataloged contents                                                                                                                                                                                      e5aef9274058c1848de0aaf8a6ba93b38f5f6182bf486f4ac2dd155b239f98a5
   ├── ✔ Packages                        [14 packages]  
   ├── ✔ File digests                    [100 files]  
   ├── ✔ File metadata                   [100 locations]  
   └── ✔ Executables                     [26 executables]  
 ✔ Scanned for vulnerabilities     [4 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible (4 unknown)
   └── by status:   4 fixed, 0 not-fixed, 0 ignored 
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY        SEVERITY 
libcrypto3  3.3.2-r0   3.3.2-r2  apk   GHSA-q764-r57m-9wp9  Unknown   
libcrypto3  3.3.2-r0   3.3.2-r2  apk   CVE-2024-9143        Unknown   
libssl3     3.3.2-r0   3.3.2-r2  apk   GHSA-q764-r57m-9wp9  Unknown   
libssl3     3.3.2-r0   3.3.2-r2  apk   CVE-2024-9143        Unknown
```

To Chainguard's own registry:
```shell
$ grype cgr.dev/chainguard/wolfi-base:latest
 ✔ Loaded image                                                                                                                                                                                                                        cgr.dev/chainguard/wolfi-base:latest
 ✔ Parsed image                                                                                                                                                                                     sha256:0ac015c613171719d465a544fbb99ed7492305c0c17ed54430e761c29d1aa2eb
 ✔ Cataloged contents                                                                                                                                                                                      7e1fcf67571a37585f60792096ee425981997766c552d95f4996407daf2a1aeb
   ├── ✔ Packages                        [14 packages]  
   ├── ✔ File digests                    [100 files]  
   ├── ✔ File metadata                   [100 locations]  
   └── ✔ Executables                     [26 executables]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 no
```

There's clearly some incentivizing going on.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
