### PR TITLE
fix(chart): reference the correct value for the Jetstream domain

### DIFF
--- a/charts/wadm/Chart.yaml
+++ b/charts/wadm/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.7"
+version: "0.2.8"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.14.0"
+appVersion: "v0.17.0"

--- a/charts/wadm/templates/deployment.yaml
+++ b/charts/wadm/templates/deployment.yaml
@@ -56,9 +56,9 @@ spec:
             - name: WADM_TRACING_ENDPOINT
               value: {{ .Values.wadm.config.tracingEndpoint | quote }}
           {{- end }}
-          {{- if .Values.wadm.config.jetstreamDomain }}
+          {{- if .Values.wadm.config.nats.jetstreamDomain }}
             - name: WADM_JETSTREAM_DOMAIN
-              value: {{ .Values.wadm.config.jetstreamDomain | quote }}
+              value: {{ .Values.wadm.config.nats.jetstreamDomain | quote }}
           {{- end }}
           {{- if .Values.wadm.config.maxJobs }}
             - name: WADM_MAX_JOBS


### PR DESCRIPTION
## Feature or Problem
Pull the `jetstreamDomain` value from `config.wadm.nats.jetstreamDomain` instead of from `config.wadm.jetstreamDomain` since that is what we define in the values file. It is also a more logical way to group the value than what the chart was expecting.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
Next chart release

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
