### PR TITLE
fix: detect spread scaler requirements violation

### DIFF
--- a/crates/wadm/src/scaler/spreadscaler/mod.rs
+++ b/crates/wadm/src/scaler/spreadscaler/mod.rs
@@ -1789,8 +1789,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn can_detect_spread_requirements_violation_1() -> Result<()> {
-        let lattice_id = "spread_requirements_violation";
+    async fn can_detect_spread_requirement_conflicts_1() -> Result<()> {
+        let lattice_id = "spread_requirement_conflicts";
         let component_reference = "fakecloud.azurecr.io/echo:0.1.0".to_string();
         let component_id = "fakecloud_azurecr_io_echo_0_1_0".to_string();
         let component_name = "fakecomponent".to_string();
@@ -1922,7 +1922,7 @@ mod test {
         assert_eq!(status.status_type, StatusType::Failed,);
         println!("{:?}", status);
         assert!(status.message.contains(&format!(
-            "Spread requirement violation: {} spread requires {} instances",
+            "Spread requirement conflicts: {} spread requires {} instances",
             "realcloud", 6
         )));
 
@@ -1930,8 +1930,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn can_detect_spread_requirements_violation_2() -> Result<()> {
-        let lattice_id = "spread_requirements_violation";
+    async fn can_detect_spread_requirement_conflicts_2() -> Result<()> {
+        let lattice_id = "spread_requirement_conflicts";
         let component_reference = "fakecloud.azurecr.io/echo:0.1.0";
         let component_id = "fakecloud_azurecr_io_echo_0_1_0";
         let component_name = "fakecomponent";
@@ -2135,7 +2135,7 @@ mod test {
         assert_eq!(status.status_type, StatusType::Failed,);
         println!("{:?}", status);
         assert!(status.message.contains(&format!(
-            "Spread requirement violation: {} spread requires {} instances",
+            "Spread requirement conflicts: {} spread requires {} instances",
             "realcloud", 6
         )));
 

--- a/crates/wadm/src/scaler/spreadscaler/mod.rs
+++ b/crates/wadm/src/scaler/spreadscaler/mod.rs
@@ -565,7 +565,7 @@ fn detect_spread_requirement_violations(
     for (spread_name, (projected_count, target_count)) in spread_instances {
         if projected_count != target_count {
             violations.push(format!(
-                "Spread requirement violation: {} spread requires {} instances vs {} computed from reconcialiation commands", 
+                "Spread requirement violation: {} spread requires {} instances vs {} computed from reconciliation commands", 
                 spread_name, target_count, projected_count
             ));
         }

--- a/tests/command_worker_integration.rs
+++ b/tests/command_worker_integration.rs
@@ -353,14 +353,7 @@ async fn test_annotation_stop() {
     // acts on _everything_. We could technically move this back down after the initial scale up of
     // the managed components after https://github.com/wasmCloud/wasmCloud/issues/746 is resolved
     ctl_client
-        .scale_component(
-            host_id,
-            HELLO_IMAGE_REF,
-            "unmanaged-hello",
-            1,
-            None,
-            vec![],
-        )
+        .scale_component(host_id, HELLO_IMAGE_REF, "unmanaged-hello", 1, None, vec![])
         .await
         .unwrap();
 


### PR DESCRIPTION
## Feature or Problem
A `ComponentSpreadScaler` config may have a set of requirements which cannot fully be satisfied so the deployment status remains as "Reconciling".

## Related Issues
#432 

## Release Information
`next`

## Consumer Impact
This is an enhancement/correctness change. It should have no adverse effect on existing functionality. This change prevents potential `Heisenbugs` where `wadm` could potentially operate on faulty instance spread without any detection.

## Testing
All existing tests (unit and e2e) are functional

### Unit Test(s)
Added two test cases `can_detect_spread_requirements_violation_1` and `can_detect_spread_requirements_violation_2`
