### PR TITLE
chore(dx): remove deprecated crates extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,7 @@
 			},
 			"extensions": [
 				"rust-lang.rust-analyzer",
-				"tamasfe.even-better-toml",
-				"serayuzgur.crates"
+				"tamasfe.even-better-toml"
 			]
 		}
 	},


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

The [crates extension](https://marketplace.visualstudio.com/items?itemName=serayuzgur.crates) is now deprecated in favor of Dependi, but I'm not sure we need an extension for this at all!

Just in case people agree, putting up a PR to 

This PR replaces the dependency management extension [crates](https://marketplace.visualstudio.com/items?itemName=serayuzgur.crates) with dependi. 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
