### PR TITLE
chore: Update the Github Action to set correct tag for the Docker Image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,11 +218,11 @@ jobs:
       - name: Set the formatted release version for the docker tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          echo "DOCKER_TAG_RELEASE_VERSION=${GITHUB_REF/refs\/tags\/v/}" >> ${{ env.RELEASE_VERSION }}
+          echo "RELEASE_VERSION_DOCKER_TAG=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
 
       - name: test_stuff_2
         run: |
-          echo "${{ env.DOCKER_TAG_RELEASE_VERSION }}"
+          echo "${{ env.RELEASE_VERSION_DOCKER_TAG }}"
 
       - name: Build and push (tag)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,10 +220,6 @@ jobs:
         run: |
           echo "RELEASE_VERSION_DOCKER_TAG=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
 
-      - name: test_stuff_2
-        run: |
-          echo "${{ env.RELEASE_VERSION_DOCKER_TAG }}"
-
       - name: Build and push (tag)
         uses: docker/build-push-action@v6
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,10 +215,14 @@ jobs:
         run: |
           echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>$GITHUB_ENV
 
+      - name: Set the formatted release version for the docker tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "DOCKER_TAG_RELEASE_VERSION=${GITHUB_REF/refs\/tags\/v/}" >> ${{ env.RELEASE_VERSION }}
+
       - name: test_stuff_2
-        run: | 
-          echo "ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}"
-          echo "test:${{ env.RELEASE_VERSION#v }}"
+        run: |
+          echo "${{ env.DOCKER_TAG_RELEASE_VERSION }}"
 
       - name: Build and push (tag)
         uses: docker/build-push-action@v6
@@ -231,6 +235,7 @@ jobs:
             BIN_ARM64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
             BIN_AMD64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
           tags: ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}
+
 
       - name: Build and push wolfi (tag)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,34 +29,34 @@ jobs:
               uploadArtifactSuffix: 'linux-amd64',
               buildOutputPath: 'target/x86_64-unknown-linux-musl/release/wadm',
             }
-          - {
-              runnerOs: 'ubuntu-latest',
-              buildCommand: 'cargo zigbuild',
-              target: 'aarch64-unknown-linux-musl',
-              uploadArtifactSuffix: 'linux-aarch64',
-              buildOutputPath: 'target/aarch64-unknown-linux-musl/release/wadm',
-            }
-          - {
-              runnerOs: 'macos-14',
-              buildCommand: 'cargo zigbuild',
-              target: 'x86_64-apple-darwin',
-              uploadArtifactSuffix: 'macos-amd64',
-              buildOutputPath: 'target/x86_64-apple-darwin/release/wadm',
-            }
-          - {
-              runnerOs: 'macos-14',
-              buildCommand: 'cargo zigbuild',
-              target: 'aarch64-apple-darwin',
-              uploadArtifactSuffix: 'macos-aarch64',
-              buildOutputPath: 'target/aarch64-apple-darwin/release/wadm',
-            }
-          - {
-              runnerOs: 'windows-latest',
-              buildCommand: 'cargo build',
-              target: 'x86_64-pc-windows-msvc',
-              uploadArtifactSuffix: 'windows-amd64',
-              buildOutputPath: 'target/x86_64-pc-windows-msvc/release/wadm.exe',
-            }
+#          - {
+#              runnerOs: 'ubuntu-latest',
+#              buildCommand: 'cargo zigbuild',
+#              target: 'aarch64-unknown-linux-musl',
+#              uploadArtifactSuffix: 'linux-aarch64',
+#              buildOutputPath: 'target/aarch64-unknown-linux-musl/release/wadm',
+#            }
+#          - {
+#              runnerOs: 'macos-14',
+#              buildCommand: 'cargo zigbuild',
+#              target: 'x86_64-apple-darwin',
+#              uploadArtifactSuffix: 'macos-amd64',
+#              buildOutputPath: 'target/x86_64-apple-darwin/release/wadm',
+#            }
+#          - {
+#              runnerOs: 'macos-14',
+#              buildCommand: 'cargo zigbuild',
+#              target: 'aarch64-apple-darwin',
+#              uploadArtifactSuffix: 'macos-aarch64',
+#              buildOutputPath: 'target/aarch64-apple-darwin/release/wadm',
+#            }
+#          - {
+#              runnerOs: 'windows-latest',
+#              buildCommand: 'cargo build',
+#              target: 'x86_64-pc-windows-msvc',
+#              uploadArtifactSuffix: 'windows-amd64',
+#              buildOutputPath: 'target/x86_64-pc-windows-msvc/release/wadm.exe',
+#            }
     steps:
       - uses: actions/checkout@v4
 
@@ -122,53 +122,53 @@ jobs:
             sha256sum "${tarball}" >> SHA256SUMS
           done
 
-      - name: Create github release
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false
-          draft: false
-          files: |
-            SHA256SUMS
-            wadm-${{ env.RELEASE_VERSION }}-linux-aarch64.tar.gz
-            wadm-${{ env.RELEASE_VERSION }}-linux-amd64.tar.gz
-            wadm-${{ env.RELEASE_VERSION }}-macos-aarch64.tar.gz
-            wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
-            wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
+#      - name: Create github release
+#        uses: softprops/action-gh-release@v2
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          prerelease: false
+#          draft: false
+#          files: |
+#            SHA256SUMS
+#            wadm-${{ env.RELEASE_VERSION }}-linux-aarch64.tar.gz
+#            wadm-${{ env.RELEASE_VERSION }}-linux-amd64.tar.gz
+#            wadm-${{ env.RELEASE_VERSION }}-macos-aarch64.tar.gz
+#            wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
+#            wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
 
-  crate:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/types-v') || startsWith(github.ref, 'refs/tags/client-v') }}
-    name: Publish crate
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install latest Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Cargo login
-        run: |
-          cargo login ${{ secrets.CRATES_TOKEN }}
-
-      - name: Cargo publish wadm-types
-        if: ${{ startsWith(github.ref, 'refs/tags/types-v') }}
-        working-directory: ./crates/wadm-types
-        run: |
-          cargo publish
-
-      - name: Cargo publish wadm lib
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        working-directory: ./crates/wadm
-        run: |
-          cargo publish
-
-      - name: Cargo publish wadm-client
-        if: ${{ startsWith(github.ref, 'refs/tags/client-v') }}
-        working-directory: ./crates/wadm-client
-        run: |
-          cargo publish
+#  crate:
+#    if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/types-v') || startsWith(github.ref, 'refs/tags/client-v') }}
+#    name: Publish crate
+#    runs-on: ubuntu-latest
+#    needs: build
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Install latest Rust stable toolchain
+#        uses: dtolnay/rust-toolchain@stable
+#        with:
+#          toolchain: stable
+#
+#      - name: Cargo login
+#        run: |
+#          cargo login ${{ secrets.CRATES_TOKEN }}
+#
+#      - name: Cargo publish wadm-types
+#        if: ${{ startsWith(github.ref, 'refs/tags/types-v') }}
+#        working-directory: ./crates/wadm-types
+#        run: |
+#          cargo publish
+#
+#      - name: Cargo publish wadm lib
+#        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+#        working-directory: ./crates/wadm
+#        run: |
+#          cargo publish
+#
+#      - name: Cargo publish wadm-client
+#        if: ${{ startsWith(github.ref, 'refs/tags/client-v') }}
+#        working-directory: ./crates/wadm-client
+#        run: |
+#          cargo publish
 
   docker-image:
     name: Build and push docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,10 @@ jobs:
       - name: Set the formatted release version for the docker tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          echo "RELEASE_VERSION_DOCKER_TAG=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION_DOCKER_TAG=${RELEASE_VERSION#v}" >> $GITHUB_ENV
+
+      - name: Test run
+        run: echo "${{ env.RELEASE_VERSION_DOCKER_TAG }}"
 
       - name: Build and push (tag)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,9 +247,9 @@ jobs:
             BIN_ARM64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
             BIN_AMD64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
           tags: | 
-            ghcr.io/${{ env.OWNER }}/wadm:latest-wolfi,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}-wolfi,
-            ghcr.io/${{ env.OWNER }}/wadm:latest-wolfi,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION_DOCKER_TAG }}-wolfi
-            
+            ghcr.io/${{ env.OWNER }}/wadm:latest-wolfi
+            ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}-wolfi
+            ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION_DOCKER_TAG }}-wolfi
 
       - name: Build and push (main)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,39 +136,39 @@ jobs:
             wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
             wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
 
-#  crate:
-#    if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/types-v') || startsWith(github.ref, 'refs/tags/client-v') }}
-#    name: Publish crate
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Install latest Rust stable toolchain
-#        uses: dtolnay/rust-toolchain@stable
-#        with:
-#          toolchain: stable
-#
-#      - name: Cargo login
-#        run: |
-#          cargo login ${{ secrets.CRATES_TOKEN }}
-#
-#      - name: Cargo publish wadm-types
-#        if: ${{ startsWith(github.ref, 'refs/tags/types-v') }}
-#        working-directory: ./crates/wadm-types
-#        run: |
-#          cargo publish
-#
-#      - name: Cargo publish wadm lib
-#        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-#        working-directory: ./crates/wadm
-#        run: |
-#          cargo publish
-#
-#      - name: Cargo publish wadm-client
-#        if: ${{ startsWith(github.ref, 'refs/tags/client-v') }}
-#        working-directory: ./crates/wadm-client
-#        run: |
-#          cargo publish
+  crate:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/types-v') || startsWith(github.ref, 'refs/tags/client-v') }}
+    name: Publish crate
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install latest Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cargo login
+        run: |
+          cargo login ${{ secrets.CRATES_TOKEN }}
+
+      - name: Cargo publish wadm-types
+        if: ${{ startsWith(github.ref, 'refs/tags/types-v') }}
+        working-directory: ./crates/wadm-types
+        run: |
+          cargo publish
+
+      - name: Cargo publish wadm lib
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: ./crates/wadm
+        run: |
+          cargo publish
+
+      - name: Cargo publish wadm-client
+        if: ${{ startsWith(github.ref, 'refs/tags/client-v') }}
+        working-directory: ./crates/wadm-client
+        run: |
+          cargo publish
 
   docker-image:
     name: Build and push docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,10 @@ jobs:
         run: |
           echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>$GITHUB_ENV
 
+      - name: test_stuff
+        run: | 
+          echo "ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}"
+
       - name: Build and push (tag)
         uses: docker/build-push-action@v6
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,9 +231,9 @@ jobs:
             BIN_ARM64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
             BIN_AMD64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
           tags: | 
-            ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }},
-            ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION_DOCKER_TAG }}
-
+            ghcr.io/${{ env.OWNER }}/wadm:latest
+            ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }},
+            ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION_DOCKER_TAG }}
 
       - name: Build and push wolfi (tag)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: test_stuff_2
         run: | 
           echo "ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}"
-          echo "${{ env.RELEASE_VERSION#v }}"
+          echo "test:${{ env.RELEASE_VERSION#v }}"
 
       - name: Build and push (tag)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,34 +29,34 @@ jobs:
               uploadArtifactSuffix: 'linux-amd64',
               buildOutputPath: 'target/x86_64-unknown-linux-musl/release/wadm',
             }
-#          - {
-#              runnerOs: 'ubuntu-latest',
-#              buildCommand: 'cargo zigbuild',
-#              target: 'aarch64-unknown-linux-musl',
-#              uploadArtifactSuffix: 'linux-aarch64',
-#              buildOutputPath: 'target/aarch64-unknown-linux-musl/release/wadm',
-#            }
-#          - {
-#              runnerOs: 'macos-14',
-#              buildCommand: 'cargo zigbuild',
-#              target: 'x86_64-apple-darwin',
-#              uploadArtifactSuffix: 'macos-amd64',
-#              buildOutputPath: 'target/x86_64-apple-darwin/release/wadm',
-#            }
-#          - {
-#              runnerOs: 'macos-14',
-#              buildCommand: 'cargo zigbuild',
-#              target: 'aarch64-apple-darwin',
-#              uploadArtifactSuffix: 'macos-aarch64',
-#              buildOutputPath: 'target/aarch64-apple-darwin/release/wadm',
-#            }
-#          - {
-#              runnerOs: 'windows-latest',
-#              buildCommand: 'cargo build',
-#              target: 'x86_64-pc-windows-msvc',
-#              uploadArtifactSuffix: 'windows-amd64',
-#              buildOutputPath: 'target/x86_64-pc-windows-msvc/release/wadm.exe',
-#            }
+          - {
+              runnerOs: 'ubuntu-latest',
+              buildCommand: 'cargo zigbuild',
+              target: 'aarch64-unknown-linux-musl',
+              uploadArtifactSuffix: 'linux-aarch64',
+              buildOutputPath: 'target/aarch64-unknown-linux-musl/release/wadm',
+            }
+          - {
+              runnerOs: 'macos-14',
+              buildCommand: 'cargo zigbuild',
+              target: 'x86_64-apple-darwin',
+              uploadArtifactSuffix: 'macos-amd64',
+              buildOutputPath: 'target/x86_64-apple-darwin/release/wadm',
+            }
+          - {
+              runnerOs: 'macos-14',
+              buildCommand: 'cargo zigbuild',
+              target: 'aarch64-apple-darwin',
+              uploadArtifactSuffix: 'macos-aarch64',
+              buildOutputPath: 'target/aarch64-apple-darwin/release/wadm',
+            }
+          - {
+              runnerOs: 'windows-latest',
+              buildCommand: 'cargo build',
+              target: 'x86_64-pc-windows-msvc',
+              uploadArtifactSuffix: 'windows-amd64',
+              buildOutputPath: 'target/x86_64-pc-windows-msvc/release/wadm.exe',
+            }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,19 +122,19 @@ jobs:
             sha256sum "${tarball}" >> SHA256SUMS
           done
 
-#      - name: Create github release
-#        uses: softprops/action-gh-release@v2
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          prerelease: false
-#          draft: false
-#          files: |
-#            SHA256SUMS
-#            wadm-${{ env.RELEASE_VERSION }}-linux-aarch64.tar.gz
-#            wadm-${{ env.RELEASE_VERSION }}-linux-amd64.tar.gz
-#            wadm-${{ env.RELEASE_VERSION }}-macos-aarch64.tar.gz
-#            wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
-#            wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
+      - name: Create github release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+          draft: false
+          files: |
+            SHA256SUMS
+            wadm-${{ env.RELEASE_VERSION }}-linux-aarch64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-linux-amd64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-macos-aarch64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-macos-amd64.tar.gz
+            wadm-${{ env.RELEASE_VERSION }}-windows-amd64.tar.gz
 
 #  crate:
 #    if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/types-v') || startsWith(github.ref, 'refs/tags/client-v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,7 @@ jobs:
       - name: test_stuff_2
         run: | 
           echo "ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}"
+          echo "${{ env.RELEASE_VERSION#v }}"
 
       - name: Build and push (tag)
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>$GITHUB_ENV
 
-      - name: test_stuff
+      - name: test_stuff_2
         run: | 
           echo "ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,9 +220,6 @@ jobs:
         run: |
           echo "RELEASE_VERSION_DOCKER_TAG=${RELEASE_VERSION#v}" >> $GITHUB_ENV
 
-      - name: Test run
-        run: echo "${{ env.RELEASE_VERSION_DOCKER_TAG }}"
-
       - name: Build and push (tag)
         uses: docker/build-push-action@v6
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,9 @@ jobs:
           build-args: |
             BIN_ARM64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
             BIN_AMD64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
-          tags: ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}
+          tags: | 
+            ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }},
+            ghcr.io/${{ env.OWNER }}/wadm:latest,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION_DOCKER_TAG }}
 
 
       - name: Build and push wolfi (tag)
@@ -244,7 +246,10 @@ jobs:
           build-args: |
             BIN_ARM64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-aarch64
             BIN_AMD64=./artifacts/wadm-${{ env.RELEASE_VERSION }}-linux-amd64
-          tags: ghcr.io/${{ env.OWNER }}/wadm:latest-wolfi,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}-wolfi
+          tags: | 
+            ghcr.io/${{ env.OWNER }}/wadm:latest-wolfi,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION }}-wolfi,
+            ghcr.io/${{ env.OWNER }}/wadm:latest-wolfi,ghcr.io/${{ env.OWNER }}/wadm:${{ env.RELEASE_VERSION_DOCKER_TAG }}-wolfi
+            
 
       - name: Build and push (main)
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The PR adds support for adding the the release version tag without "v" { 0.10.0 instead of v0.10.0} to the docker images (including wolfi).

I have not removed the existing tagging logic as mentioned in the issue(needs to be keep for some time before complete migration to use the new format).

Closes #465

Note:
The specific approach suggested in [here in the issue](https://github.com/wasmCloud/wadm/issues/465#issuecomment-2442654942), doesn't work as Github Action doesn't allow[ inline string manipulation in expressions](https://stackoverflow.com/questions/62627931/github-actions-expression-functions-string-manipulation).

### Testing
Github Action Run with correctly formatted tag: https://github.com/sp6370/wadm_/actions/runs/11905116268/job/33175286269