### PR TITLE
Add manifest validation check for "duplicate" links

### DIFF
--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -36,6 +36,8 @@ pub const LINK_TRAIT: &str = "link";
 /// The string used for indicating a latest version. It is explicitly forbidden to use as a version
 /// for a manifest
 pub const LATEST_VERSION: &str = "latest";
+/// The default link name
+pub const DEFAULT_LINK_NAME: &str = "default";
 
 /// Manifest file based on the Open Application Model (OAM) specification for declaratively managing wasmCloud applications
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]

--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -258,6 +258,11 @@ impl Component {
         };
         secrets
     }
+
+    /// Returns only links in the component
+    fn links(&self) -> impl Iterator<Item = &Trait> {
+        self.traits.iter().flatten().filter(|t| t.is_link())
+    }
 }
 
 /// Properties that can be defined for a component

--- a/crates/wadm-types/src/validation.rs
+++ b/crates/wadm-types/src/validation.rs
@@ -729,8 +729,8 @@ pub fn is_valid_label_name(name: &str) -> bool {
 /// are considered duplicate links.
 fn check_duplicate_links(manifest: &Manifest) -> Vec<ValidationFailure> {
     let mut failures = Vec::new();
-    let mut link_ids = HashSet::new();
     for component in manifest.components() {
+        let mut link_ids = HashSet::new();
         for link in component.links() {
             if let TraitProperty::Link(LinkProperty {
                 name,
@@ -740,7 +740,6 @@ fn check_duplicate_links(manifest: &Manifest) -> Vec<ValidationFailure> {
             }) = &link.properties
             {
                 if !link_ids.insert((
-                    component.name.clone(),
                     name.clone()
                         .unwrap_or_else(|| DEFAULT_LINK_NAME.to_string()),
                     namespace,

--- a/crates/wadm/src/server/handlers.rs
+++ b/crates/wadm/src/server/handlers.rs
@@ -1115,7 +1115,7 @@ mod test {
             Ok(()) => panic!("Should have detected duplicate links"),
             Err(e) => assert!(e
                 .to_string()
-                .contains("Duplicate links found inside component")),
+                .contains("Duplicate link found inside component")),
         }
     }
 

--- a/crates/wadm/src/server/handlers.rs
+++ b/crates/wadm/src/server/handlers.rs
@@ -1107,6 +1107,16 @@ mod test {
                 .to_string()
                 .contains("The following capability component(s) are missing from the manifest: ")),
         }
+
+        let manifest = deserialize_yaml("../../tests/fixtures/manifests/duplicate_links.yaml")
+            .expect("Should be able to parse");
+
+        match validate_manifest(&manifest).await {
+            Ok(()) => panic!("Should have detected duplicate links"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Duplicate links found inside component")),
+        }
     }
 
     /// Ensure that a long image ref in a manifest works,

--- a/tests/fixtures/manifests/duplicate_links.yaml
+++ b/tests/fixtures/manifests/duplicate_links.yaml
@@ -1,0 +1,49 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: test-link-name-uniqueness
+  annotations:
+    description: 'test'
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 1
+    - name: http-component-two
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 1
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.22.0
+      traits:
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8080
+        - type: link
+          properties:
+            target: http-component-two
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http-two
+                properties:
+                  address: 127.0.0.1:8081


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Added a manifest validation check for "duplicate" links.

Multiple links from the same source with the same name, namespace and package are considered duplicate links.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
- #445 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
- Manifests that previously passed validation checks will not pass validation checks anymore if they contain duplicate links

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
- Modified the manifest validation tests to include a duplicate links test

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
- verified the output for possible cases