### PR TITLE
fix(server): wash app delete command returns success for invalid application name

### DIFF
--- a/tests/api_model_operations.rs
+++ b/tests/api_model_operations.rs
@@ -452,7 +452,7 @@ async fn test_delete_noop() {
         .expect("should have created a nats client");
     let test_server = setup_server("delete_noop", nats_client).await;
 
-    // Delete something that doesn't exist
+    // Delete a model that doesn't exist
     let resp: DeleteModelResponse = test_server
         .get_response(
             "default.model.del.my-example-app",
@@ -469,7 +469,21 @@ async fn test_delete_noop() {
     );
     assert!(!resp.message.is_empty(), "Should have a message set");
 
-    // Delete a non-existent version
+    let resp: DeleteModelResponse = test_server
+        .get_response(
+            "default.model.del.my-example-app",
+            serde_json::to_vec(&DeleteModelRequest {
+                version: None,
+            }).unwrap(),
+            None,
+    )
+    .await;
+    assert!(
+        matches!(resp.result, DeleteResult::Noop),
+        "Should have gotten noop response for already deleted model"
+    );
+
+    // Delete a non-existent version for an existing model
     let raw = tokio::fs::read("./oam/sqldbpostgres.yaml")
         .await
         .expect("Unable to load file");


### PR DESCRIPTION
## Feature or Problem

If an incorrect model name is passed without a version to the `wash app del <app_name>` command, it still outputs a success message ("Deleted application: <app_name>") even though this app does not exist.

## Related Issues

closes #502 

## Release Information

This PR fixes a non-critical issue. It can therefore be safely included in the next version.

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

This PR adapts the lookup logic for deletion requests, so that also for non-existing models a `DeleteResult::Noop` result is returned if no version is specified. This changes the current return value (which is `DeleteResult::Deleted`).

Currently, the documented and recommended way to delete applications is to use the wadm-client crate. The wadm-client create [interprets both delete results as a success](https://docs.rs/wadm-client/latest/wadm_client/struct.Client.html#method.delete_manifest):

```rust
        match body.result {
            DeleteResult::Error => Err(ClientError::ApiError(body.message)),
            DeleteResult::Noop => Ok(false),
            DeleteResult::Deleted => Ok(true),
        }
```

The `wash` CLI uses the wadm-client crate internally and outputs based on the contained result value (`true` or `false`) different output messages.

## Testing

### Unit Test(s)

No unit tests have been added or updated.

### Acceptance or Integration

An additional test case was added to the `test_delete_noop` integration test (covering the deletion of a non-existing model without specifying a version).
