### PR TITLE
fix(server): Added validation for duplicated link config names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -3603,7 +3603,7 @@ dependencies = [
  "nkeys",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "wadm-types",
 ]

--- a/crates/wadm-types/src/validation.rs
+++ b/crates/wadm-types/src/validation.rs
@@ -692,10 +692,6 @@ pub fn validate_link_configs(manifest: &Manifest) -> Vec<ValidationFailure> {
     let mut link_config_names = HashSet::new();
     for link_trait in manifest.links() {
         if let TraitProperty::Link(LinkProperty {
-            name: _name,
-            namespace: _namespace,
-            package: _package,
-            interfaces: _interfaces,
             target,
             source,
             ..

--- a/tests/fixtures/manifests/duplicate_link_config_names.wadm.yaml
+++ b/tests/fixtures/manifests/duplicate_link_config_names.wadm.yaml
@@ -1,0 +1,78 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-example-app
+  annotations:
+    description: "This is my app"
+spec:
+  components:
+    - name: userinfo1
+      type: component
+      properties:
+        image: wasmcloud.azurecr.io/fake:1
+      traits:
+        - type: link
+          properties:
+            namespace: wasi
+            package: keyvalue
+            interfaces: [atomics, store]
+            target:
+              name: kvredis
+              config:
+                - name: redis-url
+
+    - name: userinfo2
+      type: component
+      properties:
+        image: wasmcloud.azurecr.io/fake:1
+      traits:
+        - type: link
+          properties:
+            namespace: wasi
+            package: keyvalue
+            interfaces: [atomics, store]
+            target:
+              name: kvredis
+              config:
+                - name: redis-url
+
+    - name: webcap1
+      type: capability
+      properties:
+        id: httpserver1
+        image: wasmcloud.azurecr.io/httpserver:0.13.1
+      traits:
+        - type: link
+          properties:
+            namespace: wasi
+            package: http
+            interfaces: ["incoming-handler"]
+            target:
+              name: userinfo1
+            source:
+              config:
+                - name: default-port
+                - name: alternate-port
+                - name: alternate-port
+
+    - name: webcap2
+      type: capability
+      properties:
+        id: httpserver2
+        image: wasmcloud.azurecr.io/httpserver:0.14.1
+      traits:
+        - type: link
+          properties:
+            target:
+              name: userinfo2
+            namespace: wasi
+            package: http
+            interfaces: ["incoming-handler"]
+            source:
+              config:
+                - name: default-port
+
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.1

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -118,3 +118,26 @@ async fn validate_policy() -> Result<()> {
     assert!(failures.valid(), "manifest is valid");
     Ok(())
 }
+
+/// Ensure that we can detect duplicated link config names
+#[tokio::test]
+async fn validate_link_config_names() -> Result<()> {
+    let (_manifest, failures) =
+        validate_manifest_file("./tests/fixtures/manifests/duplicate_link_config_names.wadm.yaml")
+            .await
+            .context("failed to validate manifest")?;
+        let expected_errors = 3;
+        assert!(
+            !failures.is_empty()
+                && failures
+                    .iter()
+                    .all(|f| f.level == ValidationFailureLevel::Error)
+                && failures.len() == expected_errors,
+            "expected {} errors because manifest contains {} duplicated link config names, instead {} errors were found", expected_errors, expected_errors, failures.len().to_string()
+        );
+        assert!(
+            !failures.valid(),
+            "manifest should be invalid (duplicated link config names lead to a dead loop)"
+        );
+    Ok(())
+}


### PR DESCRIPTION
## Feature or Problem

If an application manifest is applied in which several link configurations have the same name, this leads to a dead loop.

## Related Issues

closes #478

## Release Information

This PR fixes a problem without making any breaking changes. It can therefore be safely included in the next version.

## Consumer Impact

This PR introduces an additional validation logic that prevents users to apply invalid manifests. If the manifest is valid, nothing changes for the users.

Additionally, it is planned to modify the `BackoffWrapper` and introduce an exponentially increasing delay for a retry in case of an error, which introduces longer feedback loops for (debugging) users.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration

An additional test case has been added for the new validation logic.

> **Note:** Further tests may be added as part of the “BackoffWrapper” modification.
