### PR TITLE
Reflect unhealthy providers in application status

### DIFF
--- a/crates/wadm-types/src/bindings.rs
+++ b/crates/wadm-types/src/bindings.rs
@@ -272,6 +272,7 @@ impl From<StatusType> for wadm::types::StatusType {
             StatusType::Deployed => wadm::types::StatusType::Deployed,
             StatusType::Failed => wadm::types::StatusType::Failed,
             StatusType::Waiting => wadm::types::StatusType::Waiting,
+            StatusType::Unhealthy => wadm::types::StatusType::Unhealthy
         }
     }
 }
@@ -286,6 +287,7 @@ impl From<wadm::types::StatusType> for StatusType {
             wadm::types::StatusType::Deployed => StatusType::Deployed,
             wadm::types::StatusType::Failed => StatusType::Failed,
             wadm::types::StatusType::Waiting => StatusType::Waiting,
+            wadm::types::StatusType::Unhealthy => StatusType::Unhealthy
         }
     }
 }

--- a/crates/wadm-types/src/bindings.rs
+++ b/crates/wadm-types/src/bindings.rs
@@ -272,7 +272,7 @@ impl From<StatusType> for wadm::types::StatusType {
             StatusType::Deployed => wadm::types::StatusType::Deployed,
             StatusType::Failed => wadm::types::StatusType::Failed,
             StatusType::Waiting => wadm::types::StatusType::Waiting,
-            StatusType::Unhealthy => wadm::types::StatusType::Unhealthy
+            StatusType::Unhealthy => wadm::types::StatusType::Unhealthy,
         }
     }
 }
@@ -287,7 +287,7 @@ impl From<wadm::types::StatusType> for StatusType {
             wadm::types::StatusType::Deployed => StatusType::Deployed,
             wadm::types::StatusType::Failed => StatusType::Failed,
             wadm::types::StatusType::Waiting => StatusType::Waiting,
-            wadm::types::StatusType::Unhealthy => StatusType::Unhealthy
+            wadm::types::StatusType::Unhealthy => StatusType::Unhealthy,
         }
     }
 }

--- a/crates/wadm-types/wit/deps/wadm/types.wit
+++ b/crates/wadm-types/wit/deps/wadm/types.wit
@@ -73,6 +73,7 @@ interface types {
         deployed,
         failed,
         waiting,
+        unhealthy,
     }
 
     enum deploy-result {

--- a/crates/wadm/src/scaler/daemonscaler/provider.rs
+++ b/crates/wadm/src/scaler/daemonscaler/provider.rs
@@ -122,15 +122,31 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
                 });
                 let status = self.status.read().await.to_owned();
                 // update health status of scaler
-                if let Some(status) = match (status.status_type, unhealthy_providers > 0) {
+                if let Some(status) = match (status, unhealthy_providers > 0) {
                     // scaler is deployed but contains unhealthy providers
-                    (StatusType::Deployed, true) => Some(StatusInfo::unhealthy(&format!(
+                    (
+                        StatusInfo {
+                            status_type: StatusType::Deployed,
+                            ..
+                        },
+                        true,
+                    ) => Some(StatusInfo::failed(&format!(
                         "Unhealthy provider on {} host(s)",
                         unhealthy_providers
                     ))),
                     // scaler can become unhealthy only if it was previously deployed
                     // once scaler becomes healthy again revert back to deployed state
-                    (StatusType::Unhealthy, false) => Some(StatusInfo::deployed("")),
+                    // this is a workaround to detect unhealthy status until
+                    // StatusType::Unhealthy can be used
+                    (
+                        StatusInfo {
+                            status_type: StatusType::Failed,
+                            message,
+                        },
+                        false,
+                    ) if message.starts_with("Unhealthy provider on") => {
+                        Some(StatusInfo::deployed(""))
+                    }
                     // don't update status if scaler is not deployed
                     _ => None,
                 } {
@@ -785,7 +801,7 @@ mod test {
 
         assert_eq!(
             spreadscaler.status.read().await.to_owned(),
-            StatusInfo::unhealthy("Unhealthy provider on 1 host(s)")
+            StatusInfo::failed("Unhealthy provider on 1 host(s)")
         );
         Ok(())
     }

--- a/crates/wadm/src/scaler/daemonscaler/provider.rs
+++ b/crates/wadm/src/scaler/daemonscaler/provider.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 use tracing::{instrument, trace};
+use wadm_types::api::StatusType;
 use wadm_types::{api::StatusInfo, Spread, SpreadScalerProperty, TraitProperty};
 
 use crate::commands::StopProvider;
@@ -85,12 +86,10 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
         match event {
             Event::ProviderStarted(ProviderStarted { provider_id, .. })
             | Event::ProviderStopped(ProviderStopped { provider_id, .. })
-            | Event::ProviderHealthCheckFailed(ProviderHealthCheckFailed {
-                data: ProviderHealthCheckInfo { provider_id, .. },
-            })
-            | Event::ProviderHealthCheckPassed(ProviderHealthCheckPassed {
-                data: ProviderHealthCheckInfo { provider_id, .. },
-            }) if provider_id == &self.config.provider_id => self.reconcile().await,
+                if provider_id == &self.config.provider_id =>
+            {
+                self.reconcile().await
+            }
             // If the host labels match any spread requirement, perform reconcile
             Event::HostStopped(HostStopped { labels, .. })
             | Event::HostStarted(HostStarted { labels, .. })
@@ -103,6 +102,44 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
             {
                 self.reconcile().await
             }
+            // perform status updates for health check events
+            Event::ProviderHealthCheckFailed(ProviderHealthCheckFailed {
+                data: ProviderHealthCheckInfo { provider_id, .. },
+            })
+            | Event::ProviderHealthCheckPassed(ProviderHealthCheckPassed {
+                data: ProviderHealthCheckInfo { provider_id, .. },
+            }) if provider_id == &self.config.provider_id => {
+                let provider = self
+                    .store
+                    .get::<Provider>(&self.config.lattice_id, &self.config.provider_id)
+                    .await?;
+
+                let unhealthy_providers = provider.map_or(0, |p| {
+                    p.hosts
+                        .values()
+                        .filter(|s| *s == &ProviderStatus::Failed)
+                        .count()
+                });
+                let status = self.status.read().await.to_owned();
+                // update health status of scaler
+                if let Some(status) = match (status.status_type, unhealthy_providers > 0) {
+                    // scaler is deployed but contains unhealthy providers
+                    (StatusType::Deployed, true) => Some(StatusInfo::unhealthy(&format!(
+                        "Unhealthy provider on {} host(s)",
+                        unhealthy_providers
+                    ))),
+                    // scaler can become unhealthy only if it was previously deployed
+                    // once scaler becomes healthy again revert back to deployed state
+                    (StatusType::Unhealthy, false) => Some(StatusInfo::deployed("")),
+                    // don't update status if scaler is not deployed
+                    _ => None,
+                } {
+                    *self.status.write().await = status;
+                }
+
+                // only status needs update no new commands required
+                Ok(Vec::new())
+            }
             // No other event impacts the job of this scaler so we can ignore it
             _ => Ok(Vec::new()),
         }
@@ -111,10 +148,6 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
     #[instrument(level = "trace", skip_all, fields(name = %self.config.model_name, scaler_id = %self.id))]
     async fn reconcile(&self) -> Result<Vec<Command>> {
         let hosts = self.store.list::<Host>(&self.config.lattice_id).await?;
-        let provider = self
-            .store
-            .get::<Provider>(&self.config.lattice_id, &self.config.provider_id)
-            .await?;
         let provider_id = &self.config.provider_id;
         let provider_ref = &self.config.provider_reference;
 
@@ -222,32 +255,15 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
 
         trace!(?commands, "Calculated commands for provider daemonscaler");
 
-        let unhealthy_providers = provider.map_or(0, |p| {
-            p.hosts
-                .values()
-                .filter(|s| *s == &ProviderStatus::Failed)
-                .count()
-        });
-
-        let status = match (
-            spread_status.is_empty(),
-            commands.is_empty(),
-            unhealthy_providers > 0,
-        ) {
+        let status = match (spread_status.is_empty(), commands.is_empty()) {
             // No failures, no commands, scaler satisfied
-            (true, true, false) => StatusInfo::deployed(""),
-            // scaler satisfied but contains unhealthy providers
-            (true, true, true) => StatusInfo::failed(&format!(
-                "Unhealthy provider on {} host(s)",
-                unhealthy_providers
-            )),
-
+            (true, true) => StatusInfo::deployed(""),
             // No failures, commands generated, scaler is reconciling
-            (true, false, _) => {
+            (true, false) => {
                 StatusInfo::reconciling(&format!("Scaling provider on {} host(s)", commands.len()))
             }
             // Failures occurred, scaler is in a failed state
-            (false, _, _) => StatusInfo::failed(
+            (false, _) => StatusInfo::failed(
                 &spread_status
                     .into_iter()
                     .map(|s| s.message)
@@ -635,6 +651,16 @@ mod test {
         );
 
         spreadscaler.reconcile().await?;
+        spreadscaler
+            .handle_event(&&Event::ProviderHealthCheckPassed(
+                ProviderHealthCheckPassed {
+                    data: ProviderHealthCheckInfo {
+                        provider_id: provider_id.to_string(),
+                        host_id: host_id_two.to_string(),
+                    },
+                },
+            ))
+            .await?;
 
         assert_eq!(
             spreadscaler.status.read().await.to_owned(),
@@ -746,10 +772,20 @@ mod test {
         );
 
         spreadscaler.reconcile().await?;
+        spreadscaler
+            .handle_event(&Event::ProviderHealthCheckFailed(
+                ProviderHealthCheckFailed {
+                    data: ProviderHealthCheckInfo {
+                        provider_id: provider_id.to_string(),
+                        host_id: host_id_one.to_string(),
+                    },
+                },
+            ))
+            .await?;
 
         assert_eq!(
             spreadscaler.status.read().await.to_owned(),
-            StatusInfo::failed("Unhealthy provider on 1 host(s)")
+            StatusInfo::unhealthy("Unhealthy provider on 1 host(s)")
         );
         Ok(())
     }

--- a/crates/wadm/src/scaler/daemonscaler/provider.rs
+++ b/crates/wadm/src/scaler/daemonscaler/provider.rs
@@ -635,7 +635,7 @@ mod test {
                     issuer: "issuer".to_string(),
                     reference: provider_ref.to_string(),
                     hosts: HashMap::from([
-                        (host_id_one.to_string(), ProviderStatus::Pending),
+                        (host_id_one.to_string(), ProviderStatus::Failed),
                         (host_id_two.to_string(), ProviderStatus::Running),
                     ]),
                 },
@@ -667,6 +667,34 @@ mod test {
         );
 
         spreadscaler.reconcile().await?;
+        spreadscaler
+            .handle_event(&Event::ProviderHealthCheckFailed(
+                ProviderHealthCheckFailed {
+                    data: ProviderHealthCheckInfo {
+                        provider_id: provider_id.to_string(),
+                        host_id: host_id_one.to_string(),
+                    },
+                },
+            ))
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                provider_id.to_string(),
+                Provider {
+                    id: provider_id.to_string(),
+                    name: "provider".to_string(),
+                    issuer: "issuer".to_string(),
+                    reference: provider_ref.to_string(),
+                    hosts: HashMap::from([
+                        (host_id_one.to_string(), ProviderStatus::Pending),
+                        (host_id_two.to_string(), ProviderStatus::Running),
+                    ]),
+                },
+            )
+            .await?;
+
         spreadscaler
             .handle_event(&&Event::ProviderHealthCheckPassed(
                 ProviderHealthCheckPassed {

--- a/crates/wadm/src/scaler/spreadscaler/provider.rs
+++ b/crates/wadm/src/scaler/spreadscaler/provider.rs
@@ -1369,15 +1369,15 @@ mod test {
 
         spreadscaler.reconcile().await?;
         spreadscaler
-        .handle_event(&&Event::ProviderHealthCheckPassed(
-            ProviderHealthCheckPassed {
-                data: ProviderHealthCheckInfo {
-                    provider_id: provider_id.to_string(),
-                    host_id: host_id_two.to_string(),
+            .handle_event(&&Event::ProviderHealthCheckPassed(
+                ProviderHealthCheckPassed {
+                    data: ProviderHealthCheckInfo {
+                        provider_id: provider_id.to_string(),
+                        host_id: host_id_two.to_string(),
+                    },
                 },
-            },
-        ))
-        .await?;
+            ))
+            .await?;
 
         assert_eq!(
             spreadscaler.status.read().await.to_owned(),
@@ -1490,15 +1490,15 @@ mod test {
 
         spreadscaler.reconcile().await?;
         spreadscaler
-        .handle_event(&Event::ProviderHealthCheckFailed(
-            ProviderHealthCheckFailed {
-                data: ProviderHealthCheckInfo {
-                    provider_id: provider_id.to_string(),
-                    host_id: host_id_one.to_string(),
+            .handle_event(&Event::ProviderHealthCheckFailed(
+                ProviderHealthCheckFailed {
+                    data: ProviderHealthCheckInfo {
+                        provider_id: provider_id.to_string(),
+                        host_id: host_id_one.to_string(),
+                    },
                 },
-            },
-        ))
-        .await?;
+            ))
+            .await?;
 
         assert_eq!(
             spreadscaler.status.read().await.to_owned(),

--- a/crates/wadm/src/scaler/spreadscaler/provider.rs
+++ b/crates/wadm/src/scaler/spreadscaler/provider.rs
@@ -1360,7 +1360,7 @@ mod test {
                     issuer: "issuer".to_string(),
                     reference: provider_ref.to_string(),
                     hosts: HashMap::from([
-                        (host_id_one.to_string(), ProviderStatus::Pending),
+                        (host_id_one.to_string(), ProviderStatus::Failed),
                         (host_id_two.to_string(), ProviderStatus::Running),
                     ]),
                 },
@@ -1368,6 +1368,34 @@ mod test {
             .await?;
 
         spreadscaler.reconcile().await?;
+        spreadscaler
+            .handle_event(&Event::ProviderHealthCheckFailed(
+                ProviderHealthCheckFailed {
+                    data: ProviderHealthCheckInfo {
+                        provider_id: provider_id.to_string(),
+                        host_id: host_id_one.to_string(),
+                    },
+                },
+            ))
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                provider_id.to_string(),
+                Provider {
+                    id: provider_id.to_string(),
+                    name: "provider".to_string(),
+                    issuer: "issuer".to_string(),
+                    reference: provider_ref.to_string(),
+                    hosts: HashMap::from([
+                        (host_id_one.to_string(), ProviderStatus::Pending),
+                        (host_id_two.to_string(), ProviderStatus::Running),
+                    ]),
+                },
+            )
+            .await?;
+
         spreadscaler
             .handle_event(&&Event::ProviderHealthCheckPassed(
                 ProviderHealthCheckPassed {

--- a/crates/wadm/src/scaler/spreadscaler/provider.rs
+++ b/crates/wadm/src/scaler/spreadscaler/provider.rs
@@ -1229,4 +1229,226 @@ mod test {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_healthy_providers_return_healthy_status() -> Result<()> {
+        let lattice_id = "test_healthy_providers";
+        let provider_ref = "fakecloud.azurecr.io/provider:3.2.1".to_string();
+        let provider_id = "VASDASDIAMAREALPROVIDERPROVIDER";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+
+        let store = Arc::new(TestStore::default());
+
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    components: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-noneofyourbusiness-1".to_string()),
+                    ]),
+
+                    providers: HashSet::from_iter([ProviderInfo {
+                        provider_id: provider_id.to_string(),
+                        provider_ref: provider_ref.to_string(),
+                        annotations: BTreeMap::default(),
+                    }]),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // Ensure we spread evenly with equal weights, clean division
+        let multi_spread_even = SpreadScalerProperty {
+            instances: 2,
+            spread: vec![Spread {
+                name: "SimpleOne".to_string(),
+                requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                weight: Some(100),
+            }],
+        };
+
+        let spreadscaler = ProviderSpreadScaler::new(
+            store.clone(),
+            ProviderSpreadConfig {
+                lattice_id: lattice_id.to_string(),
+                provider_reference: provider_ref.to_string(),
+                provider_id: provider_id.to_string(),
+                spread_config: multi_spread_even,
+                model_name: MODEL_NAME.to_string(),
+                provider_config: vec!["foobar".to_string()],
+            },
+            "fake_component",
+        );
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    components: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-yourhouse-1".to_string()),
+                    ]),
+
+                    providers: HashSet::from_iter([ProviderInfo {
+                        provider_id: provider_id.to_string(),
+                        provider_ref: provider_ref.to_string(),
+                        annotations: spreadscaler_annotations("SimpleOne", spreadscaler.id()),
+                    }]),
+
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                provider_id.to_string(),
+                Provider {
+                    id: provider_id.to_string(),
+                    name: "provider".to_string(),
+                    issuer: "issuer".to_string(),
+                    reference: provider_ref.to_string(),
+                    hosts: HashMap::from([
+                        (host_id_one.to_string(), ProviderStatus::Pending),
+                        (host_id_two.to_string(), ProviderStatus::Running),
+                    ]),
+                },
+            )
+            .await?;
+
+        spreadscaler.reconcile().await?;
+
+        assert_eq!(
+            spreadscaler.status.read().await.to_owned(),
+            StatusInfo::deployed("")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_unhealthy_providers_return_unhealthy_status() -> Result<()> {
+        let lattice_id = "test_unhealthy_providers";
+        let provider_ref = "fakecloud.azurecr.io/provider:3.2.1".to_string();
+        let provider_id = "VASDASDIAMAREALPROVIDERPROVIDER";
+
+        let host_id_one = "NASDASDIMAREALHOSTONE";
+        let host_id_two = "NASDASDIMAREALHOSTTWO";
+
+        let store = Arc::new(TestStore::default());
+
+        store
+            .store(
+                lattice_id,
+                host_id_one.to_string(),
+                Host {
+                    components: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-noneofyourbusiness-1".to_string()),
+                    ]),
+
+                    providers: HashSet::from_iter([ProviderInfo {
+                        provider_id: provider_id.to_string(),
+                        provider_ref: provider_ref.to_string(),
+                        annotations: BTreeMap::default(),
+                    }]),
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_one.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        // Ensure we spread evenly with equal weights, clean division
+        let multi_spread_even = SpreadScalerProperty {
+            instances: 2,
+            spread: vec![Spread {
+                name: "SimpleOne".to_string(),
+                requirements: BTreeMap::from_iter([("cloud".to_string(), "fake".to_string())]),
+                weight: Some(100),
+            }],
+        };
+
+        let spreadscaler = ProviderSpreadScaler::new(
+            store.clone(),
+            ProviderSpreadConfig {
+                lattice_id: lattice_id.to_string(),
+                provider_reference: provider_ref.to_string(),
+                provider_id: provider_id.to_string(),
+                spread_config: multi_spread_even,
+                model_name: MODEL_NAME.to_string(),
+                provider_config: vec!["foobar".to_string()],
+            },
+            "fake_component",
+        );
+
+        store
+            .store(
+                lattice_id,
+                host_id_two.to_string(),
+                Host {
+                    components: HashMap::new(),
+                    friendly_name: "hey".to_string(),
+                    labels: HashMap::from_iter([
+                        ("cloud".to_string(), "fake".to_string()),
+                        ("region".to_string(), "us-yourhouse-1".to_string()),
+                    ]),
+
+                    providers: HashSet::from_iter([ProviderInfo {
+                        provider_id: provider_id.to_string(),
+                        provider_ref: provider_ref.to_string(),
+                        annotations: spreadscaler_annotations("SimpleOne", spreadscaler.id()),
+                    }]),
+
+                    uptime_seconds: 123,
+                    version: None,
+                    id: host_id_two.to_string(),
+                    last_seen: Utc::now(),
+                },
+            )
+            .await?;
+
+        store
+            .store(
+                lattice_id,
+                provider_id.to_string(),
+                Provider {
+                    id: provider_id.to_string(),
+                    name: "provider".to_string(),
+                    issuer: "issuer".to_string(),
+                    reference: provider_ref.to_string(),
+                    hosts: HashMap::from([
+                        (host_id_one.to_string(), ProviderStatus::Failed),
+                        (host_id_two.to_string(), ProviderStatus::Running),
+                    ]),
+                },
+            )
+            .await?;
+
+        spreadscaler.reconcile().await?;
+
+        assert_eq!(
+            spreadscaler.status.read().await.to_owned(),
+            StatusInfo::failed("Unhealthy provider on 1 host(s)")
+        );
+        Ok(())
+    }
 }

--- a/crates/wadm/src/storage/state.rs
+++ b/crates/wadm/src/storage/state.rs
@@ -31,7 +31,7 @@ pub struct Provider {
     pub hosts: HashMap<String, ProviderStatus>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum ProviderStatus {
     /// The provider is starting and hasn't returned a heartbeat yet
     Pending,
@@ -40,6 +40,7 @@ pub enum ProviderStatus {
     /// The provider failed to start
     // TODO(thomastaylor312): In the future, we'll probably want to decay out a provider from state
     // if it hasn't had a heartbeat
+    // if it fails a recent health check
     Failed,
 }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Scaler status returns a `Failed` status if it contains any providers which have failed their most recent health check and are in a `Failed` state.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
- #447 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
Added 2 unit tests each for daemon and spread scalers
- test_unhealthy_providers_return_unhealthy_status
- test_healthy_providers_return_healthy_status
### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Verified the scaler status after `reconcile` is run and that all unit tests passed.
