### PR TITLE
feat(nats): flag to change persistence of streams

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,13 +183,11 @@ struct Args {
         hide = true
     )]
     max_manifest_bucket_bytes: i64,
-    /// The storage type of nats streams, maps to [`StorageType`](async_nats::jetstream::stream::StorageType)
-    /// Possible values: "File" or "Memory", default is `File`
+    /// The storage type of nats streams, possible values: "file" or "memory", default is "file"
     #[arg(
         long = "stream-persistence",
         env = "WADM_STREAM_PERSISTENCE",
-        default_value_t = StreamPersistence::File,
-        hide = true
+        default_value_t = StreamPersistence::File
     )]
     stream_persistence: StreamPersistence,
     /// Maximum bytes to keep for the command stream

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ struct Args {
         hide = true
     )]
     max_manifest_bucket_bytes: i64,
-    /// The storage type of nats streams
+    /// Nats streams storage type
     #[arg(
         long = "stream-persistence",
         env = "WADM_STREAM_PERSISTENCE",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_nats::jetstream::{stream::Stream, Context};
 use clap::Parser;
-use nats::StreamPersistance;
+use nats::StreamPersistence;
 use tokio::sync::Semaphore;
 use tracing::log::debug;
 use wadm_types::api::DEFAULT_WADM_TOPIC_PREFIX;
@@ -183,15 +183,15 @@ struct Args {
         hide = true
     )]
     max_manifest_bucket_bytes: i64,
-    /// The storage type to use for the streams, maps to [`StorageType`](async_nats::jetstream::stream::StorageType)
-    /// Possible values: "File" or "Memory", Default is `File`
+    /// The storage type of nats streams, maps to [`StorageType`](async_nats::jetstream::stream::StorageType)
+    /// Possible values: "File" or "Memory", default is `File`
     #[arg(
         long = "stream-persistence",
         env = "WADM_STREAM_PERSISTENCE",
-        default_value_t = StreamPersistance::File,
+        default_value_t = StreamPersistence::File,
         hide = true
     )]
-    stream_persistance: StreamPersistance,
+    stream_persistance: StreamPersistence,
     /// Maximum bytes to keep for the command stream
     #[arg(
         long = "command-stream-max-bytes",
@@ -305,8 +305,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_stream_bytes,
-        // args.stream_persistance.into(),
-        async_nats::jetstream::stream::StorageType::File,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -318,8 +317,7 @@ async fn main() -> anyhow::Result<()> {
         vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
         Some("A stream that stores all commands for wadm".to_string()),
         args.max_command_stream_bytes,
-        // args.stream_persistance.into(),
-        async_nats::jetstream::stream::StorageType::File,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -328,8 +326,7 @@ async fn main() -> anyhow::Result<()> {
         internal_stream_name(STATUS_STREAM_NAME),
         vec![DEFAULT_STATUS_TOPIC.to_owned()],
         args.max_status_stream_bytes,
-        // args.stream_persistance.into(),
-        async_nats::jetstream::stream::StorageType::File,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -359,8 +356,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_wasmbus_event_stream_bytes,
-        // args.stream_persistance.into(),
-        async_nats::jetstream::stream::StorageType::File,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -371,8 +367,7 @@ async fn main() -> anyhow::Result<()> {
         NOTIFY_STREAM_NAME.to_owned(),
         vec![format!("{WADM_NOTIFY_PREFIX}.*")],
         args.max_notify_stream_bytes,
-        // args.stream_persistance.into(),
-        async_nats::jetstream::stream::StorageType::File,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -388,8 +383,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_consumer_stream_bytes,
-        // args.stream_persistance.into(),
-        async_nats::jetstream::stream::StorageType::File,
+        args.stream_persistance.into(),
     )
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ struct Args {
         default_value_t = StreamPersistence::File,
         hide = true
     )]
-    stream_persistance: StreamPersistence,
+    stream_persistence: StreamPersistence,
     /// Maximum bytes to keep for the command stream
     #[arg(
         long = "command-stream-max-bytes",
@@ -305,7 +305,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_stream_bytes,
-        args.stream_persistance.into(),
+        args.stream_persistence.into(),
     )
     .await?;
 
@@ -317,7 +317,7 @@ async fn main() -> anyhow::Result<()> {
         vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
         Some("A stream that stores all commands for wadm".to_string()),
         args.max_command_stream_bytes,
-        args.stream_persistance.into(),
+        args.stream_persistence.into(),
     )
     .await?;
 
@@ -326,7 +326,7 @@ async fn main() -> anyhow::Result<()> {
         internal_stream_name(STATUS_STREAM_NAME),
         vec![DEFAULT_STATUS_TOPIC.to_owned()],
         args.max_status_stream_bytes,
-        args.stream_persistance.into(),
+        args.stream_persistence.into(),
     )
     .await?;
 
@@ -356,7 +356,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_wasmbus_event_stream_bytes,
-        args.stream_persistance.into(),
+        args.stream_persistence.into(),
     )
     .await?;
 
@@ -367,7 +367,7 @@ async fn main() -> anyhow::Result<()> {
         NOTIFY_STREAM_NAME.to_owned(),
         vec![format!("{WADM_NOTIFY_PREFIX}.*")],
         args.max_notify_stream_bytes,
-        args.stream_persistance.into(),
+        args.stream_persistence.into(),
     )
     .await?;
 
@@ -383,7 +383,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_consumer_stream_bytes,
-        args.stream_persistance.into(),
+        args.stream_persistence.into(),
     )
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,8 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_stream_bytes,
-        args.stream_persistance.into(),
+        // args.stream_persistance.into(),
+        async_nats::jetstream::stream::StorageType::File,
     )
     .await?;
 
@@ -317,7 +318,8 @@ async fn main() -> anyhow::Result<()> {
         vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
         Some("A stream that stores all commands for wadm".to_string()),
         args.max_command_stream_bytes,
-        args.stream_persistance.into(),
+        // args.stream_persistance.into(),
+        async_nats::jetstream::stream::StorageType::File,
     )
     .await?;
 
@@ -326,7 +328,8 @@ async fn main() -> anyhow::Result<()> {
         internal_stream_name(STATUS_STREAM_NAME),
         vec![DEFAULT_STATUS_TOPIC.to_owned()],
         args.max_status_stream_bytes,
-        args.stream_persistance.into(),
+        // args.stream_persistance.into(),
+        async_nats::jetstream::stream::StorageType::File,
     )
     .await?;
 
@@ -356,7 +359,8 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_wasmbus_event_stream_bytes,
-        args.stream_persistance.into(),
+        // args.stream_persistance.into(),
+        async_nats::jetstream::stream::StorageType::File,
     )
     .await?;
 
@@ -367,7 +371,8 @@ async fn main() -> anyhow::Result<()> {
         NOTIFY_STREAM_NAME.to_owned(),
         vec![format!("{WADM_NOTIFY_PREFIX}.*")],
         args.max_notify_stream_bytes,
-        args.stream_persistance.into(),
+        // args.stream_persistance.into(),
+        async_nats::jetstream::stream::StorageType::File,
     )
     .await?;
 
@@ -383,7 +388,8 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_consumer_stream_bytes,
-        args.stream_persistance.into(),
+        // args.stream_persistance.into(),
+        async_nats::jetstream::stream::StorageType::File,
     )
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use async_nats::jetstream::{stream::Stream, Context};
 use clap::Parser;
+use nats::StreamPersistance;
 use tokio::sync::Semaphore;
 use tracing::log::debug;
 use wadm_types::api::DEFAULT_WADM_TOPIC_PREFIX;
@@ -182,6 +183,15 @@ struct Args {
         hide = true
     )]
     max_manifest_bucket_bytes: i64,
+    /// The storage type to use for the streams, maps to [`StorageType`](async_nats::jetstream::stream::StorageType)
+    /// Possible values: "File" or "Memory", Default is `File`
+    #[arg(
+        long = "stream-persistence",
+        env = "WADM_STREAM_PERSISTENCE",
+        default_value_t = StreamPersistance::File,
+        hide = true
+    )]
+    stream_persistance: StreamPersistance,
     /// Maximum bytes to keep for the command stream
     #[arg(
         long = "command-stream-max-bytes",
@@ -295,6 +305,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_stream_bytes,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -306,6 +317,7 @@ async fn main() -> anyhow::Result<()> {
         vec![DEFAULT_COMMANDS_TOPIC.to_owned()],
         Some("A stream that stores all commands for wadm".to_string()),
         args.max_command_stream_bytes,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -314,6 +326,7 @@ async fn main() -> anyhow::Result<()> {
         internal_stream_name(STATUS_STREAM_NAME),
         vec![DEFAULT_STATUS_TOPIC.to_owned()],
         args.max_status_stream_bytes,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -343,6 +356,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_wasmbus_event_stream_bytes,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -353,6 +367,7 @@ async fn main() -> anyhow::Result<()> {
         NOTIFY_STREAM_NAME.to_owned(),
         vec![format!("{WADM_NOTIFY_PREFIX}.*")],
         args.max_notify_stream_bytes,
+        args.stream_persistance.into(),
     )
     .await?;
 
@@ -368,6 +383,7 @@ async fn main() -> anyhow::Result<()> {
                 .to_string(),
         ),
         args.max_event_consumer_stream_bytes,
+        args.stream_persistance.into(),
     )
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ struct Args {
         hide = true
     )]
     max_manifest_bucket_bytes: i64,
-    /// The storage type of nats streams, possible values: "file" or "memory", default is "file"
+    /// The storage type of nats streams
     #[arg(
         long = "stream-persistence",
         env = "WADM_STREAM_PERSISTENCE",

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -14,24 +14,19 @@ use async_nats::{
 use tracing::{debug, warn};
 use wadm::DEFAULT_EXPIRY_TIME;
 
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 pub enum StreamPersistance {
+    #[default]
     File,
     Memory,
 }
 
-impl ToString for StreamPersistance {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for StreamPersistance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StreamPersistance::File => "File".to_string(),
-            StreamPersistance::Memory => "Memory".to_string(),
+            StreamPersistance::File => write!(f, "File"),
+            StreamPersistance::Memory => write!(f, "Memory"),
         }
-    }
-}
-
-impl Default for StreamPersistance {
-    fn default() -> Self {
-        StreamPersistance::File
     }
 }
 

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -156,9 +156,10 @@ pub async fn ensure_stream(
         retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
         subjects,
         max_age: DEFAULT_EXPIRY_TIME,
-        storage,
         allow_rollup: false,
         max_bytes,
+        // storage,
+        // storage: StorageType::File,
         ..Default::default()
     };
 
@@ -197,9 +198,10 @@ pub async fn ensure_limits_stream(
         retention: async_nats::jetstream::stream::RetentionPolicy::Limits,
         subjects,
         max_age: DEFAULT_EXPIRY_TIME,
-        storage,
         allow_rollup: false,
         max_bytes,
+        // storage,
+        // storage: StorageType::File,
         ..Default::default()
     };
 
@@ -270,9 +272,10 @@ pub async fn ensure_event_consumer_stream(
         subjects: vec![],
         max_age: DEFAULT_EXPIRY_TIME,
         sources: Some(sources),
-        storage,
         allow_rollup: false,
         max_bytes,
+        // storage,
+        // storage: StorageType::File,
         ..Default::default()
     };
 
@@ -311,8 +314,9 @@ pub async fn ensure_status_stream(
             max_messages_per_subject: 10,
             subjects,
             max_age: std::time::Duration::from_nanos(0),
-            storage,
             max_bytes,
+            // storage,
+            // storage: StorageType::File,
             ..Default::default()
         })
         .await
@@ -336,8 +340,9 @@ pub async fn ensure_notify_stream(
             retention: async_nats::jetstream::stream::RetentionPolicy::Interest,
             subjects,
             max_age: DEFAULT_EXPIRY_TIME,
-            storage,
             max_bytes,
+            // storage,
+            storage: StorageType::File,
             ..Default::default()
         })
         .await

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -15,7 +15,7 @@ use tracing::{debug, warn};
 use wadm::DEFAULT_EXPIRY_TIME;
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "lower")]
 pub enum StreamPersistence {
     #[default]
     File,
@@ -25,8 +25,8 @@ pub enum StreamPersistence {
 impl std::fmt::Display for StreamPersistence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StreamPersistence::File => write!(f, "File"),
-            StreamPersistence::Memory => write!(f, "Memory"),
+            StreamPersistence::File => write!(f, "file"),
+            StreamPersistence::Memory => write!(f, "memory"),
         }
     }
 }

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -15,26 +15,27 @@ use tracing::{debug, warn};
 use wadm::DEFAULT_EXPIRY_TIME;
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
-pub enum StreamPersistance {
+#[clap(rename_all = "PascalCase")]
+pub enum StreamPersistence {
     #[default]
     File,
     Memory,
 }
 
-impl std::fmt::Display for StreamPersistance {
+impl std::fmt::Display for StreamPersistence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StreamPersistance::File => write!(f, "File"),
-            StreamPersistance::Memory => write!(f, "Memory"),
+            StreamPersistence::File => write!(f, "File"),
+            StreamPersistence::Memory => write!(f, "Memory"),
         }
     }
 }
 
-impl From<StreamPersistance> for StorageType {
-    fn from(persistance: StreamPersistance) -> Self {
+impl From<StreamPersistence> for StorageType {
+    fn from(persistance: StreamPersistence) -> Self {
         match persistance {
-            StreamPersistance::File => StorageType::File,
-            StreamPersistance::Memory => StorageType::Memory,
+            StreamPersistence::File => StorageType::File,
+            StreamPersistence::Memory => StorageType::Memory,
         }
     }
 }
@@ -158,8 +159,7 @@ pub async fn ensure_stream(
         max_age: DEFAULT_EXPIRY_TIME,
         allow_rollup: false,
         max_bytes,
-        // storage,
-        // storage: StorageType::File,
+        storage,
         ..Default::default()
     };
 
@@ -200,8 +200,7 @@ pub async fn ensure_limits_stream(
         max_age: DEFAULT_EXPIRY_TIME,
         allow_rollup: false,
         max_bytes,
-        // storage,
-        // storage: StorageType::File,
+        storage,
         ..Default::default()
     };
 
@@ -274,8 +273,7 @@ pub async fn ensure_event_consumer_stream(
         sources: Some(sources),
         allow_rollup: false,
         max_bytes,
-        // storage,
-        // storage: StorageType::File,
+        storage,
         ..Default::default()
     };
 
@@ -315,8 +313,7 @@ pub async fn ensure_status_stream(
             subjects,
             max_age: std::time::Duration::from_nanos(0),
             max_bytes,
-            // storage,
-            // storage: StorageType::File,
+            storage,
             ..Default::default()
         })
         .await
@@ -341,8 +338,7 @@ pub async fn ensure_notify_stream(
             subjects,
             max_age: DEFAULT_EXPIRY_TIME,
             max_bytes,
-            // storage,
-            storage: StorageType::File,
+            storage,
             ..Default::default()
         })
         .await

--- a/tests/e2e_multiple_hosts.rs
+++ b/tests/e2e_multiple_hosts.rs
@@ -41,7 +41,7 @@ async fn run_multiple_host_tests() {
     let mut client_info = ClientInfo::new(manifest_dir, compose_file).await;
     client_info.add_ctl_client(DEFAULT_LATTICE_ID, None).await;
     client_info.add_wadm_client(DEFAULT_LATTICE_ID).await;
-    client_info.launch_wadm().await;
+    client_info.launch_wadm(None).await;
 
     // Wait for the first event on the lattice prefix before we start deploying and checking
     // statuses. Wadm can absolutely handle hosts starting before you start the wadm process, but the first event

--- a/tests/e2e_shared.rs
+++ b/tests/e2e_shared.rs
@@ -45,7 +45,7 @@ async fn run_shared_component_tests() {
     client_info.add_wadm_client(SHARED_PROVIDERS_LATTICE).await;
     client_info.add_ctl_client(INVALID_TEST_LATTICE, None).await;
     client_info.add_wadm_client(INVALID_TEST_LATTICE).await;
-    client_info.launch_wadm().await;
+    client_info.launch_wadm(None).await;
 
     // Wait for the first event on the lattice prefix before we start deploying and checking
     // statuses. Wadm can absolutely handle hosts starting before you start the wadm process, but the first event

--- a/tests/e2e_upgrades.rs
+++ b/tests/e2e_upgrades.rs
@@ -35,7 +35,9 @@ async fn run_upgrade_tests() {
     let mut client_info = ClientInfo::new(manifest_dir, compose_file).await;
     client_info.add_ctl_client("default", None).await;
     client_info.add_wadm_client("default").await;
-    client_info.launch_wadm().await;
+    client_info
+        .launch_wadm(Some(HashMap::from([("--stream-persistence", "memory")])))
+        .await;
 
     // Wait for the first event on the lattice prefix before we start deploying and checking
     // statuses. Wadm can absolutely handle hosts starting before you start the wadm process, but the first event


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

cli toggle to modify the nats stream persistence between file and memory.


I do seek some guidance regarding testing here. Since we have multiple tests which have the file - default - mode enabled, should I create another suite or how do you think should I add tests for this?

Thank you

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

#479 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
