### PR TITLE
fix(types): warn on unknown interface

### DIFF
--- a/crates/wadm-types/src/validation.rs
+++ b/crates/wadm-types/src/validation.rs
@@ -160,9 +160,10 @@ fn is_invalid_known_interface(
     };
     // Unknown interface inside known namespace and package is probably a bug
     if !iface_lookup.contains_key(interface) {
-        // Unknown package inside a known interface we control is probably a bug
+        // Unknown package inside a known interface we control is probably a bug, but may be
+        // a new interface we don't know about yet
         return vec![ValidationFailure::new(
-            ValidationFailureLevel::Error,
+            ValidationFailureLevel::Warning,
             format!("unrecognized interface [{namespace}:{package}/{interface}]"),
         )];
     }
@@ -702,22 +703,13 @@ pub fn validate_link_configs(manifest: &Manifest) -> Vec<ValidationFailure> {
     let mut failures = Vec::new();
     let mut link_config_names = HashSet::new();
     for link_trait in manifest.links() {
-        if let TraitProperty::Link(LinkProperty {
-            target,
-            source,
-            ..
-        }) = &link_trait.properties {
+        if let TraitProperty::Link(LinkProperty { target, source, .. }) = &link_trait.properties {
             for config in target.config.iter() {
                 // Check if config name is unique
-                if !link_config_names.insert((
-                    config.name.clone(),
-                )) {
+                if !link_config_names.insert((config.name.clone(),)) {
                     failures.push(ValidationFailure::new(
                         ValidationFailureLevel::Error,
-                        format!(
-                            "Duplicate link config name found: '{}'",
-                            config.name
-                        ),
+                        format!("Duplicate link config name found: '{}'", config.name),
                     ));
                 }
             }
@@ -725,15 +717,10 @@ pub fn validate_link_configs(manifest: &Manifest) -> Vec<ValidationFailure> {
             if let Some(source) = source {
                 for config in source.config.iter() {
                     // Check if config name is unique
-                    if !link_config_names.insert((
-                        config.name.clone(),
-                    )) {
+                    if !link_config_names.insert((config.name.clone(),)) {
                         failures.push(ValidationFailure::new(
                             ValidationFailureLevel::Error,
-                            format!(
-                                "Duplicate link config name found: '{}'",
-                                config.name
-                            ),
+                            format!("Duplicate link config name found: '{}'", config.name),
                         ));
                     }
                 }

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -44,12 +44,12 @@ async fn validate_misnamed_interface() -> Result<()> {
         !failures.is_empty()
             && failures
                 .iter()
-                .all(|f| f.level == ValidationFailureLevel::Error),
-        "failures present, all errors"
+                .all(|f| f.level == ValidationFailureLevel::Warning),
+        "failures present, all warnings"
     );
     assert!(
-        !failures.valid(),
-        "manifest should be invalid (misnamed interface w/ right namespace & package is probably a bug)"
+        failures.valid(),
+        "manifest should be valid (misnamed interface w/ right namespace & package is probably a bug but might be intentional)"
     );
     Ok(())
 }
@@ -126,8 +126,8 @@ async fn validate_link_config_names() -> Result<()> {
         validate_manifest_file("./tests/fixtures/manifests/duplicate_link_config_names.wadm.yaml")
             .await
             .context("failed to validate manifest")?;
-        let expected_errors = 3;
-        assert!(
+    let expected_errors = 3;
+    assert!(
             !failures.is_empty()
                 && failures
                     .iter()
@@ -135,10 +135,10 @@ async fn validate_link_config_names() -> Result<()> {
                 && failures.len() == expected_errors,
             "expected {} errors because manifest contains {} duplicated link config names, instead {} errors were found", expected_errors, expected_errors, failures.len().to_string()
         );
-        assert!(
-            !failures.valid(),
-            "manifest should be invalid (duplicated link config names lead to a dead loop)"
-        );
+    assert!(
+        !failures.valid(),
+        "manifest should be invalid (duplicated link config names lead to a dead loop)"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Feature or Problem
This PR downgrades the unrecognized interface error into a warning as inspired by some of the recent additions to keyvalue like `batch` and `watch`. We want to maintain a balance in validation to make sure that users don't accidentally link on, say, `wasi:keyvalue/atormics`, but we don't completely block the addition of new interfaces e.g. in wasmcloud:messaging@v0.3.0

Open to thoughts here.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
