### PR TITLE
fix(wadm): correct status topic name in WADM

### DIFF
--- a/crates/wadm-client/src/topics.rs
+++ b/crates/wadm-client/src/topics.rs
@@ -74,9 +74,8 @@ impl TopicGenerator {
 
     /// Returns the full topic for WADM status subscriptions
     pub fn wadm_status_topic(&self, app_name: &str) -> String {
-        format!(
-            "{}.{}.{}",
-            WADM_STATUS_API_PREFIX, self.topic_prefix, app_name
-        )
+        // Extract just the lattice name from topic_prefix
+        let lattice = self.topic_prefix.split('.').last().unwrap_or("default");
+        format!("{}.{}.{}", WADM_STATUS_API_PREFIX, lattice, app_name)
     }
 }


### PR DESCRIPTION
When generating the subscribe wadm topic, it does it incorrectly because it defaults to using the topic prefix of 'wadm.api.{lattice}'

however when subscribing to status we need to use wadm.status

After this fix, this should change:
wadm.status.wadm.api.default.my-app

to:
wadm.status.default.my-app

without affecting any other topic construction
