### PR TITLE
Only check configs for unique names if they declare properties

### DIFF
--- a/tests/fixtures/manifests/duplicate_link_config_names.wadm.yaml
+++ b/tests/fixtures/manifests/duplicate_link_config_names.wadm.yaml
@@ -20,6 +20,11 @@ spec:
               name: kvredis
               config:
                 - name: redis-url
+                  properties:
+                    url: "redis://127.0.0.1:6379"
+                # this config name is duplicated, but has no properties,
+                # so it references an existing config
+                - name: my_example_app-shared_redis
 
     - name: userinfo2
       type: component
@@ -35,6 +40,11 @@ spec:
               name: kvredis
               config:
                 - name: redis-url
+                  properties:
+                    url: "redis://127.0.0.1:6379"
+                # this config name is duplicated, but has no properties,
+                # so it references an existing config
+                - name: my_example_app-shared_redis
 
     - name: webcap1
       type: capability
@@ -52,8 +62,14 @@ spec:
             source:
               config:
                 - name: default-port
+                  properties:
+                    port: 0.0.0.0:8080
                 - name: alternate-port
+                  properties:
+                    address: 0.0.0.0:8081
                 - name: alternate-port
+                  properties:
+                    address: 0.0.0.0:8081
 
     - name: webcap2
       type: capability
@@ -71,6 +87,8 @@ spec:
             source:
               config:
                 - name: default-port
+                  properties:
+                    address: 0.0.0.0:8080
 
     - name: kvredis
       type: capability


### PR DESCRIPTION
## Feature or Problem
https://github.com/wasmCloud/wadm/pull/516 rejects manifests where multiple link configurations have the same name. This PR augments that functionality by only considering link configurations that declare properties. This is because (as currently implemented) configurations that don't declare properties can reference existing configs that are created either by `wash` or by `wadm` (prefixed by the application name, e.g. where application = "my-app" and config = "my-config", this can be referenced elsewhere in the manifest as "my_app-my_config").

## Related Issues
https://github.com/wasmCloud/wadm/pull/516
https://github.com/wasmCloud/wadm/issues/478
https://github.com/wasmCloud/wadm/issues/401

## Release Information
Manifests that were previously rejected may now be valid. As this widens rather than narrows, I suspect it can be released as a non-breaking minor/patch release.

## Consumer Impact
All manifests that were previously valid should remain valid. 

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
The existing test case for validation of duplicate config names has been adjusted to include properties for the duplicate configs. Additionally, duplicate configs without properties were added to show that they are now allowed through the validation stage.

### Manual Verification
None
