### PR TITLE
fix(scaler): react to config set events for components/providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,7 +3574,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wadm"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "wadm-cli"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/wasmcloud/wadm"
 default-run = "wadm"
 
 [workspace.package]
-version = "0.20.2"
+version = "0.20.3"
 
 [features]
 default = []

--- a/crates/wadm/src/scaler/daemonscaler/mod.rs
+++ b/crates/wadm/src/scaler/daemonscaler/mod.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 use tracing::{instrument, trace};
 use wadm_types::{api::StatusInfo, Spread, SpreadScalerProperty, TraitProperty};
 
+use crate::events::ConfigSet;
 use crate::scaler::spreadscaler::{
     compute_ineligible_hosts, eligible_hosts, spreadscaler_annotations,
 };
@@ -118,6 +119,9 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ComponentDaemonScaler<S> {
                 } else {
                     Ok(Vec::new())
                 }
+            }
+            Event::ConfigSet(ConfigSet { config_name }) if self.config.contains(config_name) => {
+                self.reconcile().await
             }
             // No other event impacts the job of this scaler so we can ignore it
             _ => Ok(Vec::new()),

--- a/crates/wadm/src/scaler/daemonscaler/provider.rs
+++ b/crates/wadm/src/scaler/daemonscaler/provider.rs
@@ -9,8 +9,8 @@ use wadm_types::{api::StatusInfo, Spread, SpreadScalerProperty, TraitProperty};
 
 use crate::commands::StopProvider;
 use crate::events::{
-    HostHeartbeat, ProviderHealthCheckFailed, ProviderHealthCheckInfo, ProviderHealthCheckPassed,
-    ProviderInfo, ProviderStarted, ProviderStopped,
+    ConfigSet, HostHeartbeat, ProviderHealthCheckFailed, ProviderHealthCheckInfo,
+    ProviderHealthCheckPassed, ProviderInfo, ProviderStarted, ProviderStopped,
 };
 use crate::scaler::compute_id_sha256;
 use crate::scaler::spreadscaler::{
@@ -155,6 +155,11 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderDaemonScaler<S> {
 
                 // only status needs update no new commands required
                 Ok(Vec::new())
+            }
+            Event::ConfigSet(ConfigSet { config_name })
+                if self.config.provider_config.contains(config_name) =>
+            {
+                self.reconcile().await
             }
             // No other event impacts the job of this scaler so we can ignore it
             _ => Ok(Vec::new()),

--- a/crates/wadm/src/scaler/spreadscaler/mod.rs
+++ b/crates/wadm/src/scaler/spreadscaler/mod.rs
@@ -10,7 +10,7 @@ use wadm_types::{
     api::StatusInfo, Spread, SpreadScalerProperty, TraitProperty, DEFAULT_SPREAD_WEIGHT,
 };
 
-use crate::events::HostHeartbeat;
+use crate::events::{ConfigSet, HostHeartbeat};
 use crate::{
     commands::{Command, ScaleComponent},
     events::{Event, HostStarted, HostStopped},
@@ -113,6 +113,9 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ComponentSpreadScaler<S> {
                 } else {
                     Ok(Vec::new())
                 }
+            }
+            Event::ConfigSet(ConfigSet { config_name }) if self.config.contains(config_name) => {
+                self.reconcile().await
             }
             // No other event impacts the job of this scaler so we can ignore it
             _ => Ok(Vec::new()),

--- a/crates/wadm/src/scaler/spreadscaler/provider.rs
+++ b/crates/wadm/src/scaler/spreadscaler/provider.rs
@@ -15,7 +15,7 @@ use wadm_types::{
 use crate::{
     commands::{Command, StartProvider, StopProvider},
     events::{
-        Event, HostHeartbeat, HostStarted, HostStopped, ProviderHealthCheckFailed,
+        ConfigSet, Event, HostHeartbeat, HostStarted, HostStopped, ProviderHealthCheckFailed,
         ProviderHealthCheckInfo, ProviderHealthCheckPassed, ProviderInfo, ProviderStarted,
         ProviderStopped,
     },
@@ -172,6 +172,11 @@ impl<S: ReadStore + Send + Sync + Clone> Scaler for ProviderSpreadScaler<S> {
 
                 // only status needs update no new commands required
                 Ok(Vec::new())
+            }
+            Event::ConfigSet(ConfigSet { config_name })
+                if self.config.provider_config.contains(config_name) =>
+            {
+                self.reconcile().await
             }
             // No other event impacts the job of this scaler so we can ignore it
             _ => Ok(Vec::new()),


### PR DESCRIPTION
## Feature or Problem
This PR adds a fix to component and provider scalers to ensure they react to their respective configuration set/deleted events.

Currently, on initial reconcile, the first pass is used to create configuration that's required for the component/provider to exist in the first place. Then, the idea is that the next reconciliation pass (once config is created) we would actually start the component/provider. However, today, scalers do not react to this event, so instead we sit around waiting for a heartbeat to really start the component.

I did not address the configuration set for links because links currently get created either:
1. When their provider is healthy
2. When the respective component starts

I don't want to accidentally exacerbate a race condition by adding reacting to configuration here, so I left it out of this PR. It would be worth exploring if we also observe links not being created when their configuration is ready

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next patch wadm

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Here's a video of the difference before and after:

https://github.com/user-attachments/assets/3f160e81-236e-4810-ab49-55fd7c349bdf


