### PR TITLE
feat(types): Added LimitsConfig field to ComponentProperties 

### DIFF
--- a/crates/wadm-types/src/bindings.rs
+++ b/crates/wadm-types/src/bindings.rs
@@ -113,6 +113,7 @@ impl From<ComponentProperties> for wadm::types::ComponentProperties {
             id: properties.id,
             config: properties.config.into_iter().map(|c| c.into()).collect(),
             secrets: properties.secrets.into_iter().map(|c| c.into()).collect(),
+            limits: properties.limits.map(Into::into),
         }
     }
 }
@@ -431,6 +432,7 @@ impl From<wadm::types::ComponentProperties> for ComponentProperties {
             id: properties.id,
             config: properties.config.into_iter().map(|c| c.into()).collect(),
             secrets: properties.secrets.into_iter().map(|c| c.into()).collect(),
+            limits: properties.limits.map(Into::into),
         }
     }
 }

--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -298,6 +298,9 @@ pub struct ComponentProperties {
     /// these values at runtime using `wasmcloud:secrets/store`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secrets: Vec<SecretProperty>,
+    /// This Config holds the componet's metadata properties like memory limits and execution time limits
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limits: Option<LimitsConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default, ToSchema, JsonSchema)]
@@ -331,6 +334,14 @@ pub struct SecretSourceProperty {
     /// The version of the secret to retrieve. If not supplied, the latest version will be used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, ToSchema, JsonSchema)]
+pub struct LimitsConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_linear_memory: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_execution_time: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema, JsonSchema)]
@@ -845,6 +856,7 @@ mod test {
                     id: None,
                     config: vec![],
                     secrets: vec![],
+                    limits: None,
                 },
             },
             traits: Some(trait_vec),


### PR DESCRIPTION
for granular per-component resource control

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
This PR aims to allow the `max_linear_memory` field to be configurable by the wadm.yaml, which will ultimately be used for setting per component resource limits.
## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
[Memory Limits Per Component](https://github.com/wasmCloud/wasmCloud/issues/4168)
## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
