### PR TITLE
wadm: fix 'occured' -> 'occurred' in error doc comments

### DIFF
--- a/crates/wadm/src/events/types.rs
+++ b/crates/wadm/src/events/types.rs
@@ -283,7 +283,7 @@ pub enum ConversionError {
     /// If an event of the right type was found, but no data was contained within that event
     #[error("No data found")]
     NoData,
-    /// An error occured while trying to deserialize the data
+    /// An error occurred while trying to deserialize the data
     #[error("Error when deserializing: {0}")]
     Deser(#[from] serde_json::Error),
 }

--- a/crates/wadm/src/storage/nats_kv.rs
+++ b/crates/wadm/src/storage/nats_kv.rs
@@ -31,11 +31,11 @@ use super::{ReadStore, StateKind, Store};
 /// Errors that can be encountered by NATS KV Store implemenation
 #[derive(Debug, thiserror::Error)]
 pub enum NatsStoreError {
-    /// An I/O error occured
+    /// An I/O error occurred
     #[error("I/O Error: {0}")]
     Io(#[from] IoError),
 
-    /// An error occured when performing a NATS operation
+    /// An error occurred when performing a NATS operation
     #[error("NATS error: {0:?}")]
     Nats(#[from] NatsError),
 


### PR DESCRIPTION
Doc comments in two files read `error occured`:
- `crates/wadm/src/storage/nats_kv.rs` lines 34, 38
- `crates/wadm/src/events/types.rs` line 286

Fixed to `occurred`. Comment-only change.