### PR TITLE
fix(validation): reject empty metadata.annotations in manifest

### DIFF
--- a/crates/wadm-types/src/lib.rs
+++ b/crates/wadm-types/src/lib.rs
@@ -179,7 +179,7 @@ pub struct Metadata {
     /// The name of the manifest. This must be unique per lattice
     pub name: String,
     /// Optional data for annotating this manifest see <https://github.com/oam-dev/spec/blob/master/metadata.md#annotations-format>
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<String, String>,
     /// Optional data for labeling this manifest, see <https://github.com/oam-dev/spec/blob/master/metadata.md#label-format>
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/wadm-types/src/validation.rs
+++ b/crates/wadm-types/src/validation.rs
@@ -357,8 +357,33 @@ pub fn validate_raw_yaml(content: &[u8]) -> Result<Vec<ValidationFailure>> {
     let mut failures = Vec::new();
     let raw_content: serde_yaml::Value =
         serde_yaml::from_slice(content).context("failed read raw yaml content")?;
+    failures.extend(validate_metadata_annotations(&raw_content));
     failures.extend(validate_components_configs(&raw_content));
     Ok(failures)
+}
+
+/// Validates that if the `metadata.annotations` key is present in the raw YAML,
+/// it contains valid key-value pairs rather than being null or empty.
+fn validate_metadata_annotations(raw_content: &serde_yaml::Value) -> Vec<ValidationFailure> {
+    let mut failures = Vec::new();
+    if let Some(metadata) = raw_content.get("metadata") {
+        if let Some(annotations) = metadata.get("annotations") {
+            if annotations.is_null() {
+                failures.push(ValidationFailure::new(
+                    ValidationFailureLevel::Error,
+                    "metadata.annotations is present but empty, either remove the key or provide valid annotation key-value pairs".to_string(),
+                ));
+            } else if let Some(mapping) = annotations.as_mapping() {
+                if mapping.is_empty() {
+                    failures.push(ValidationFailure::new(
+                        ValidationFailureLevel::Error,
+                        "metadata.annotations is present but empty, either remove the key or provide valid annotation key-value pairs".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+    failures
 }
 
 fn core_validation(manifest: &Manifest) -> Vec<ValidationFailure> {

--- a/tests/fixtures/manifests/empty-annotations.wadm.yaml
+++ b/tests/fixtures/manifests/empty-annotations.wadm.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: test
+  annotations:
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: ghcr.io/wasmcloud/component-http-hello-world:0.1.0
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 1

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -157,3 +157,25 @@ async fn validate_deprecated_configs_raw_yaml() -> Result<()> {
     );
     Ok(())
 }
+
+/// Ensure that empty metadata.annotations is rejected
+#[tokio::test]
+async fn validate_empty_annotations() -> Result<()> {
+    let (_manifest, failures) =
+        validate_manifest_file("./tests/fixtures/manifests/empty-annotations.wadm.yaml")
+            .await
+            .context("failed to validate manifest")?;
+    assert!(
+        !failures.is_empty(),
+        "expected failures for empty annotations"
+    );
+    assert!(
+        failures
+            .iter()
+            .any(|f| f.level == ValidationFailureLevel::Error
+                && f.msg.contains("metadata.annotations")),
+        "expected error about empty metadata.annotations"
+    );
+    assert!(!failures.valid(), "manifest should not be valid");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add `serde(default)` to `Metadata.annotations` so a null YAML value deserializes without error, allowing validation to run
- Add `validate_metadata_annotations` check in raw YAML validation to reject manifests where `metadata.annotations` is present but null or an empty mapping
- Add test case and fixture for the empty annotations scenario

Fixes #676

## Test plan
- [x] `cargo test -p wadm-types` passes
- [x] `cargo test --test validation validate_empty_annotations` passes, confirming the manifest is correctly rejected
- [x] Existing tests unaffected